### PR TITLE
Use correct closure namespace in Extendable class

### DIFF
--- a/src/Extension/Extendable.php
+++ b/src/Extension/Extendable.php
@@ -42,7 +42,7 @@ class Extendable
         return $this->extendableCall($name, $params);
     }
 
-    public static function extend(Closure $callback)
+    public static function extend(\Closure $callback)
     {
         self::extendableExtendCallback($callback);
     }


### PR DESCRIPTION
This fixes the error

<blockquote>Argument 1 passed to October\Rain\Extension\Extendable::extend() must be an instance of October\Rain\Extension\Closure, instance of Closure given</blockquote>

when extending Extendables.

Example code to replicate:

``` php
BackendController::extend(function($controller) {
    $controller->addJs(__DIR__.'/foobar.js');
});
```
