### PR TITLE
Change to PHP-Markdown

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "kriswallsmith/assetic": "1.*",
         "leafo/lessphp": "dev-master",
         "linkorb/jsmin-php": "dev-master",
-        "michelf/php-markdown": "1.4.*@dev"
+        "erusev/parsedown": "~1.0",
+        "erusev/parsedown-extra": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/src/Support/Markdown.php
+++ b/src/Support/Markdown.php
@@ -1,6 +1,6 @@
 <?php namespace October\Rain\Support;
 
-use \Michelf\MarkdownExtra as MD;
+use ParsedownExtra;
 
 /**
  * Markdown content parser
@@ -12,6 +12,6 @@ class Markdown
 {
     public static function parse($text)
     {
-        return MD::defaultTransform($text);
+        return ParsedownExtra::instance()->text($text);
     }
 }


### PR DESCRIPTION
Change from Parsedown to [PHP-Markdown](http://michelf.ca/projects/php-markdown/).

The reason for this is that php-markdown seems to be a bit more popular (yay more community interaction) and also for it's ability to support [Markdown Extra](http://michelf.ca/projects/php-markdown/extra/).

I originally required this change as I wanted to easily add comments to images that were uploaded via the blog component.

The change should not break anything on the core, but some plugins using very strict matching on Markdown might be influenced. One plugin that I know will break due to this is the blog component, but I will be submitting a PR to fix it soon.
