### PR TITLE
[Fixes #22] Setting undeclared attributes doesn't work and added tests

### DIFF
--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -159,6 +159,8 @@ trait ExtendableTrait
 
             return $parent->{$name} = $value;
         }
+        
+        return $this->{$name} = $value;
     }
 
     public function extendableCall($name, $params = null)

--- a/tests/Extension/ExtendableSetTest.php
+++ b/tests/Extension/ExtendableSetTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use October\Rain\Extension\Extendable;
+
+class ExampleExtendableClass extends Extendable
+{
+    public $declaredAttribute;
+    
+    public function setDeclaredAttribute()
+    {
+        $this->declaredAttribute = "Test";
+    }
+
+    public function setAnUndeclaredAttribute()
+    {
+        $this->newAttribute = "Test";
+    }
+}
+
+class ExtendableSetTest extends TestCase
+{
+    protected $subject;
+    
+    public function setUp()
+    {
+        $this->subject = new ExampleExtendableClass();
+    }
+
+    public function testSettingDeclaredAttributeOnClass()
+    {
+        $this->subject->setDeclaredAttribute();
+        
+        $this->assertEquals("Test", $this->subject->declaredAttribute);
+    }
+
+    public function testSettingUninitilaizedAttributeOnClass()
+    {
+        $this->subject->setAnUndeclaredAttribute();
+        
+        $this->assertEquals("Test", $this->subject->newAttribute);
+    }
+}


### PR DESCRIPTION
Fix as discussed in [the issue](https://github.com/octobercms/library/issues/22).

I'm happy to make any improvements to the tests you recommend. I wasn't sure a good way to test the [extensionData foreach](https://github.com/octobercms/library/blob/master/src/Extension/ExtendableTrait.php#L148), and I had problems getting the [parent code](https://github.com/octobercms/library/blob/master/src/Extension/ExtendableTrait.php#L155) to be show as being covered.
