### PR TITLE
Add global events for model attribute getters

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1015,6 +1015,8 @@ class Model extends EloquentModel
             return $this->getAttributeDotted($key);
 
         // Before Event
+        if ($attr = Event::fire('model.beforeGetAttribute', [$key], true))
+            return $attr;
         if ($attr = $this->fireEvent('model.beforeGetAttribute', [$key], true))
             return $attr;
 
@@ -1028,6 +1030,8 @@ class Model extends EloquentModel
         }
 
         // After Event
+        if ($attr = Event::fire('model.getAttribute', [$key, $attr], true))
+            return $attr;
         if ($_attr = $this->fireEvent('model.getAttribute', [$key, $attr], true))
             return $_attr;
 


### PR DESCRIPTION
Models currently support emitter events but not global events for attribute getters. I want to add a getter for `$user->rewardspoints_points` that can be used anywhere but this currently isn' tpossible. The below commit adds Event hooks in the `getAttribute` methods.

Two notes:
- I'd also love for the getter events to pass $this - as the value of the getter may be dependant on other aspects of the model. As a very quick example, if the user's state is QLD, we know his country is Australia.
- There are many other emitter events in this class that don't have global event equivalents. These should also be fixed up.
