### PR TITLE
A load of composer fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,27 +17,53 @@
     "require": {
         "php": ">=5.4",
         "doctrine/dbal": "~2.3",
-        "illuminate/support": "4.2.*",
+        "erusev/parsedown-extra": "~0.1",
+        "illuminate/database": "4.2.*",
         "illuminate/filesystem": "4.2.*",
-        "twig/twig": "1.*",
+        "illuminate/html": "4.2.*",
+        "illuminate/queue": "4.2.*",
+        "illuminate/support": "4.2.*",
+        "kriswallsmith/assetic": "~1.1",
+        "linkorb/jsmin-php": "~1.0",
+        "oyejorge/less.php": "~1.7",
+        "symfony/config": "2.4.*",
+        "symfony/translation": "2.4.*",
         "symfony/yaml": "2.4.*",
-        "kriswallsmith/assetic": "1.*",
-        "oyejorge/less.php": "dev-master",
-        "linkorb/jsmin-php": "dev-master",
-        "erusev/parsedown-extra": "dev-master"
+        "twig/twig": "~1.13"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "~4.0"
+    },
+    "replace": {
+        "october/auth": "self.version",
+        "october/config": "self.version",
+        "october/cron": "self.version",
+        "october/database": "self.version",
+        "october/extension": "self.version",
+        "october/filesystem": "self.version",
+        "october/html": "self.version",
+        "october/mail": "self.version",
+        "october/network": "self.version",
+        "october/router": "self.version",
+        "october/support": "self.version",
+        "october/translation": "self.version"
     },
     "autoload": {
-        "classmap": [
-            "tests/TestCase.php"
-        ],
         "files": [
             "src/Support/helpers.php"
         ],
         "psr-4": {
             "October\\Rain\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "classmap": [
+            "tests/TestCase.php"
+        ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
         }
     },
     "minimum-stability": "dev"

--- a/src/Auth/composer.json
+++ b/src/Auth/composer.json
@@ -16,13 +16,17 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "october/support": "1.*"
+        "october/support": "~1.0"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Auth": ""
+        "psr-4": {
+            "October\\Rain\\Auth\\": ""
         }
     },
-    "target-dir": "October/Rain/Auth",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Config/composer.json
+++ b/src/Config/composer.json
@@ -16,15 +16,19 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "october/support": "1.*",
-        "october/filesystem": "4.1.x",
+        "october/support": "~1.0",
+        "october/filesystem": "~1.0",
         "symfony/config": "2.4.*"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Config": ""
+        "psr-4": {
+            "October\\Rain\\Config\\": ""
         }
     },
-    "target-dir": "October/Rain/Config",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Cron/composer.json
+++ b/src/Cron/composer.json
@@ -19,10 +19,14 @@
         "illuminate/queue": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Cron": ""
+        "psr-4": {
+            "October\\Rain\\Cron\\": ""
         }
     },
-    "target-dir": "October/Rain/Cron",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -16,13 +16,18 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "october/support": "1.*"
+        "illuminate/database": "4.2.*",
+        "october/support": "~1.0"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Database": ""
+        "psr-4": {
+            "October\\Rain\\Database\\": ""
         }
     },
-    "target-dir": "October/Rain/Database",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Extension/composer.json
+++ b/src/Extension/composer.json
@@ -18,10 +18,14 @@
         "php": ">=5.4.0"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Extension": ""
+        "psr-4": {
+            "October\\Rain\\Extension\\": ""
         }
     },
-    "target-dir": "October/Rain/Extension",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Filesystem/composer.json
+++ b/src/Filesystem/composer.json
@@ -16,14 +16,18 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "october/support": "1.*",
+        "october/support": "~1.0",
         "illuminate/filesystem": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Filesystem": ""
+        "psr-4": {
+            "October\\Rain\\Filesystem\\": ""
         }
     },
-    "target-dir": "October/Rain/Filesystem",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Html/composer.json
+++ b/src/Html/composer.json
@@ -16,14 +16,18 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "october/support": "1.*",
-        "illuminate/html": "4.2.*"
+        "illuminate/html": "4.2.*",
+        "october/support": "~1.0"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Html": ""
+        "psr-4": {
+            "October\\Rain\\Html\\": ""
         }
     },
-    "target-dir": "October/Rain/Html",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Mail/composer.json
+++ b/src/Mail/composer.json
@@ -16,15 +16,19 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "october/support": "1.*",
-        "october/filesystem": "1.*",
-        "illuminate/mail": "4.2.*"
+        "illuminate/mail": "4.2.*",
+        "october/filesystem": "~1.0",
+        "october/support": "~1.0"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Mail": ""
+        "psr-4": {
+            "October\\Rain\\Mail\\": ""
         }
     },
-    "target-dir": "October/Rain/Mail",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Network/composer.json
+++ b/src/Network/composer.json
@@ -16,13 +16,17 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "october/support": "1.*"
+        "october/support": "~1.0"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Network": ""
+        "psr-4": {
+            "October\\Rain\\Network\\": ""
         }
     },
-    "target-dir": "October/Rain/Network",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Router/composer.json
+++ b/src/Router/composer.json
@@ -16,13 +16,17 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "october/support": "1.*"
+        "october/support": "~1.0"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Router": ""
+        "psr-4": {
+            "October\\Rain\\Router\\": ""
         }
     },
-    "target-dir": "October/Rain/Router",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Support/composer.json
+++ b/src/Support/composer.json
@@ -19,10 +19,14 @@
         "illuminate/support": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Support": ""
+        "psr-4": {
+            "October\\Rain\\Support\\": ""
         }
     },
-    "target-dir": "October/Rain/Support",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/src/Translation/composer.json
+++ b/src/Translation/composer.json
@@ -16,15 +16,19 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "october/support": "1.*",
-        "october/filesystem": "4.1.x",
+        "october/support": "~1.0",
+        "october/filesystem": "~1.0",
         "symfony/translation": "2.4.*"
     },
     "autoload": {
-        "psr-0": {
-            "October\\Rain\\Translation": ""
+        "psr-4": {
+            "October\\Rain\\Translation\\": ""
         }
     },
-    "target-dir": "October/Rain/Translation",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
- I've added some missing dependencies to the main composer.json file that were present in the subsplit repos, and added a couple of missing dependencies to the subsplit repos.
- I've alphabetically sorted the dependencies, and corrected their version constraints (nb. I raised twig that high to avoid a security vulnerability present in 1.0-1.12 of twig).
- I've added the correct "replace" composer attribute.
- I've updated the autoloading in the components to be the same as what I did for Laravel 4.3.
- I've added branch aliases everywhere (I aliased the master branch so the dev changes come from there rather than the master branch, thus matching the behaviour you have in the other repos).
