### PR TITLE
Add slugsSeparator option

### DIFF
--- a/src/Database/Traits/Sluggable.php
+++ b/src/Database/Traits/Sluggable.php
@@ -40,7 +40,7 @@ trait Sluggable
      */
     public function slugAttributes()
     {
-        if ( !isset($this->slugsSeparator) ) $this->slugsSeparator = '-';
+        if (!isset($this->slugsSeparator)) $this->slugsSeparator = '-';
 
         foreach ($this->slugs as $slugAttribute => $sourceAttributes)
             $this->setSluggedValue($slugAttribute, $sourceAttributes);


### PR DESCRIPTION
This PR adds an option to set the separator used in the Sluggable trait. Defaults to `-`
## Usage

``` php
class Category extends Model
{
    use \October\Rain\Database\Traits\Sluggable;

    public $slugs = ['slug' => 'title'];
    public $slugsSeparator = '_';
    ...
}
```
