### PR TITLE
add support for mail interception for queueing

### DIFF
--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -17,13 +17,19 @@ class Mailer extends MailerBase
     /**
      * Send a new message using a view.
      *
-     * @param  string|array  $view
-     * @param  array  $data
-     * @param  Closure|string  $callback
+     * @param  string|array $view
+     * @param  array $data
+     * @param  Closure|string $callback
      * @return void
      */
     public function send($view, array $data, $callback)
     {
+        /*
+         * Allow for mail interception for queuing
+         */
+        if (Event::fire('mailer.prepareSend', [$view, $data, $callback], true) === false) return;
+        if ($this->fireEvent('mailer.prepareSend', [$view, $data, $callback], true) === false) return;
+
         /*
          * Inherit logic from Illuminate\Mail\Mailer
          */
@@ -58,10 +64,10 @@ class Mailer extends MailerBase
     /**
      * Add the content to a given message.
      *
-     * @param  \Illuminate\Mail\Message  $message
-     * @param  string  $view
-     * @param  string  $plain
-     * @param  array   $data
+     * @param  \Illuminate\Mail\Message $message
+     * @param  string $view
+     * @param  string $plain
+     * @param  array $data
      * @return void
      */
     protected function addContent($message, $view, $plain, $data)


### PR DESCRIPTION
In current state there is no sane way to hook into all Mail::send calls to queue them. Event mailer.prepareSend allows for such functionality by passing original data and closure to another Mail::queue call.
