### PR TITLE
Use custom attributes in validation

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -147,6 +147,15 @@ trait Validation
                 $customMessages = [];
 
             $validator = self::makeValidator($data, $rules, $customMessages);
+            
+            /*
+             * Use custom language attributes
+             */
+            $customAttributes = trans('validation.attributes');
+            if(is_array($customAttributes) && !empty($customAttributes)) {
+                $validator->setAttributeNames($customAttributes);
+            }
+            
             $success = $validator->passes();
 
             if ($success) {


### PR DESCRIPTION
Validation are not make use of language attributes. This patch solve the problem.
