### PR TITLE
Simplify default driver lookup in DatabaseServiceProvider.php

### DIFF
--- a/src/Database/DatabaseServiceProvider.php
+++ b/src/Database/DatabaseServiceProvider.php
@@ -36,10 +36,7 @@ class DatabaseServiceProvider extends DatabaseServiceProviderBase
     protected function getDefaultDatabaseDriver()
     {
         $defaultConnection = $this->app['db']->getDefaultConnection();
-        if (!$config = array_get($this->app['config']['database.connections'], $defaultConnection))
-            return $defaultConnection;
-
-        return array_get($config, 'driver');
+        return $this->app['config']['database.connections.' . $defaultConnection . '.driver'];
     }
 
 }


### PR DESCRIPTION
As we discussed yesterday. Just makes it a bit more clear what we're doing here.

As a side note, I'm submitting a [pull request](https://github.com/laravel/framework/pull/6153) to Laravel to add a getDefaultDatabaseDriver() function to their database manager API. If it's accepted, we won't need this protected function anymore and we can just call `return new Dongle($this->app['db]->getDefaultDatabaseDriver(), $app['db']);`
