### PR TITLE
Ensure db table prefix is used in raw SQL queries

### DIFF
--- a/src/Database/Dongle.php
+++ b/src/Database/Dongle.php
@@ -151,4 +151,13 @@ class Dongle
         return 'CAST('.$sql.' AS '.$asType.')';
     }
 
+    /**
+     * Get the table prefix.
+     * @return string
+     */
+    public function getTablePrefix()
+    {
+        return $this->db->getTablePrefix();
+    }
+
 }

--- a/src/Database/Relations/DeferOneOrMany.php
+++ b/src/Database/Relations/DeferOneOrMany.php
@@ -26,7 +26,7 @@ trait DeferOneOrMany
             // Bind (Add)
             $query = $query->orWhereExists(function($query) use ($sessionKey) {
                 $query->from('deferred_bindings')
-                    ->whereRaw(DbDongle::cast('slave_id', 'INTEGER').' = '.$this->related->getQualifiedKeyName())
+                    ->whereRaw(DbDongle::cast('slave_id', 'INTEGER').' = '.DbDongle::getTablePrefix().$this->related->getQualifiedKeyName())
                     ->where('master_field', $this->relationName)
                     ->where('master_type', get_class($this->parent))
                     ->where('session_key', $sessionKey)
@@ -37,13 +37,13 @@ trait DeferOneOrMany
         // Unbind (Remove)
         $newQuery->whereNotExists(function($query) use ($sessionKey) {
             $query->from('deferred_bindings')
-                ->whereRaw(DbDongle::cast('slave_id', 'INTEGER').' = '.$this->related->getQualifiedKeyName())
+                ->whereRaw(DbDongle::cast('slave_id', 'INTEGER').' = '.DbDongle::getTablePrefix().$this->related->getQualifiedKeyName())
                 ->where('master_field', $this->relationName)
                 ->where('master_type', get_class($this->parent))
                 ->where('session_key', $sessionKey)
                 ->where('is_bind', false)
-                ->whereRaw(DbDongle::parse('id > ifnull((select max(id) from deferred_bindings where
-                        '.DbDongle::cast('slave_id', 'INTEGER').' = '.$this->related->getQualifiedKeyName().' and
+                ->whereRaw(DbDongle::parse('id > ifnull((select max(id) from '.DbDongle::getTablePrefix().'deferred_bindings where
+                        '.DbDongle::cast('slave_id', 'INTEGER').' = '.DbDongle::getTablePrefix().$this->related->getQualifiedKeyName().' and
                         master_field = ? and
                         master_type = ? and
                         session_key = ? and


### PR DESCRIPTION
This fixes https://github.com/octobercms/october/issues/637 by adding the getTablePrefix() function to the Database Dongle class and ensures the new function call is added before any table names in raw SQL queries.
