### PR TITLE
Change hasManyThrough to HasManyThrough

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -13,7 +13,7 @@ use October\Rain\Database\Relations\MorphToMany;
 use October\Rain\Database\Relations\MorphOne;
 use October\Rain\Database\Relations\AttachMany;
 use October\Rain\Database\Relations\AttachOne;
-use October\Rain\Database\Relations\hasManyThrough;
+use October\Rain\Database\Relations\HasManyThrough;
 use October\Rain\Database\ModelException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use InvalidArgumentException;


### PR DESCRIPTION
This fixes 'Class 'October\Rain\Database\Relations\hasManyThrough' not
found' error on case-sensitive file systems such as Linux.
