### PR TITLE
Turn off the quoting class name with slashes, when use sqlite

### DIFF
--- a/src/Database/DataFeed.php
+++ b/src/Database/DataFeed.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Database;
 
+use Config;
 use DB;
 use Str;
 use Closure;
@@ -176,7 +177,12 @@ class DataFeed
             extract($data);
             $cleanQuery = clone $this->getQuery($item);
             $model = $this->getModel($item);
-            $class = str_replace('\\', '\\\\', get_class($model));
+            if (Config::get('database.default') == 'sqlite') {
+                $class = get_class($model);
+            }
+            else {
+                $class = str_replace('\\', '\\\\', get_class($model));
+            }
 
             $sorting = $model->getTable() . '.';
             $sorting .= $orderBy ?: $this->sortField;


### PR DESCRIPTION
We can not to quote class name with slashes, when using sqlite, because we will see an error like

     Class 'Autor\\Plugin\\Models\\Model' not found

But, when we use mysql, we need use str_replace, or we will see another error

     Class 'AutorPluginModelsModel' not found

So, I think we can check the config of connection to prevent this error.