### PR TITLE
File->getThumb just halt without any error returned

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -4,6 +4,7 @@ use File as FileHelper;
 use October\Rain\Database\Model;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\File\File as FileObj;
+use October\Rain\Database\Attach\FileException;
 
 /**
  * File attachment model
@@ -272,6 +273,9 @@ class File extends Model
      */
     public function getThumb($width, $height, $options = [])
     {
+        if (!$this->hasFile($this->getDiskPath()))
+            throw new FileException;
+
         if (!$this->isImage())
             return $this->getPath();
 


### PR DESCRIPTION
If the physical file doesn't exist in the disk, but the file record is still in the database, getThumb produced no error at all, but the whole PHP execution just stop.