### PR TITLE
Let plugins add hashable fields

### DIFF
--- a/src/Database/Traits/Hashable.php
+++ b/src/Database/Traits/Hashable.php
@@ -38,6 +38,17 @@ trait Hashable
     }
 
     /**
+     * Adds an attribute to the hashable attributes list
+     * @param string $attribute Attribute
+     * @return this
+     */
+    public function addHashableAttribute($attribute)
+    {
+        $this->hashable[] = $attribute;
+        return $this;
+    }
+
+    /**
      * Hashes an attribute value and saves it in the original locker.
      * @param  string $key   Attribute
      * @param  string $value Value to hash


### PR DESCRIPTION
I need to add a hashable attribute to the backend users model but the hashable array is protected. Figured I'd add a method to allow plugins to add hashable fields.