### PR TITLE
Validate original values before encryption

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -143,6 +143,17 @@ trait Validation
                 $data = array_merge($cleanAttributes, $hashedAttributes);
             }
 
+            /*
+             * Compatability with Encryptable trait:
+             * Remove all encryptable values regardless, add the original values back
+             * only if they are part of the data being validated.
+             */
+            if (method_exists($this, 'getEncryptableAttributes')) {
+                $cleanAttributes = array_diff_key($data, array_flip($this->getEncryptableAttributes()));
+                $encryptedAttributes = array_intersect_key($this->getOriginalEncryptableValues(), $data);
+                $data = array_merge($cleanAttributes, $encryptedAttributes);
+            }
+
             if (property_exists($this, 'customMessages') && is_null($customMessages))
                 $customMessages = $this->customMessages;
 


### PR DESCRIPTION
Validation doesn't work with Encryptable trait. It validate every field after encryption. For example I have field name with rule 'between:3,35', but after encryption name is something like that:

'eyJpdiI6IlRZeUZWQ25JU3JCelZEUjVuXC9rV3RRPT0iLCJ2YWx1ZSI6Ik9iK24rajFvZUh6QVhLZ1RLRWpGeFE9PSIsIm1hYyI6ImE5ODhmY2E3YTA1NGZjNDNhN2VlYjA5YmQxNGQxMjY1NzUzMzYxZGUwZjg0NDQ5YjljYzUzYjJjNjkzOTk2MGQifQ=='

That's for sure longer then 35 chars.