### PR TITLE
Add settable attributeNames array for use in validation trait

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -15,6 +15,12 @@ trait Validation
      */
 
     /**
+     * @var array The array of custom attribute names.
+     *
+     * public $attributeNames = [];
+     */
+
+    /**
      * @var array The array of custom error messages.
      *
      * public $customMessages = [];
@@ -79,9 +85,9 @@ trait Validation
      * outside of Laravel.
      * @return \Illuminate\Validation\Validator
      */
-    protected static function makeValidator($data, $rules, $customMessages)
+    protected static function makeValidator($data, $rules, $customMessages, $attributeNames)
     {
-        return Validator::make($data, $rules, $customMessages);
+        return Validator::make($data, $rules, $customMessages, $attributeNames);
     }
 
     /**
@@ -98,7 +104,7 @@ trait Validation
      * Validate the model instance
      * @return bool
      */
-    public function validate($rules = null, $customMessages = null)
+    public function validate($rules = null, $customMessages = null, $attributeNames = null)
     {
         if ($this->validationErrors === null)
             $this->validationErrors = new MessageBag;
@@ -134,7 +140,7 @@ trait Validation
 
             /*
              * Compatability with Hashable trait:
-             * Remove all hashable values regardless, add the original values back 
+             * Remove all hashable values regardless, add the original values back
              * only if they are part of the data being validated.
              */
             if (method_exists($this, 'getHashableAttributes')) {
@@ -149,15 +155,21 @@ trait Validation
             if (is_null($customMessages))
                 $customMessages = [];
 
-            $validator = self::makeValidator($data, $rules, $customMessages);
+            if (is_null($attributeNames))
+                $attributeNames = [];
+
+            if (property_exists($this, 'attributeNames'))
+                $attributeNames = array_merge($this->attributeNames, $attributeNames);
 
             /*
              * Use custom language attributes
              */
-            $customAttributes = trans('validation.attributes');
-            if (is_array($customAttributes) && !empty($customAttributes)) {
-                $validator->setAttributeNames($customAttributes);
-            }
+            $translations = trans('validation.attributes');
+            if (is_array($translations))
+                $attributeNames = array_merge($translations, $attributeNames);
+
+
+            $validator = self::makeValidator($data, $rules, $customMessages, $attributeNames);
 
             $success = $validator->passes();
 


### PR DESCRIPTION
This PR adds support for an `attributeNames` model property which the *Validation* trait uses to display better attribute names in error messages.

## Usage

In your model:
```php
public $attributeNames = ['my_attrib' => 'My Attrib Name'];
```

Based on [this Ardent PR](https://github.com/laravelbook/ardent/pull/213/files). Keeps support for localization that was already present. Order of priority is explicitly passed, model property, localization file.