### PR TITLE
Add validation attribs for auth model

### DIFF
--- a/src/Auth/Models/User.php
+++ b/src/Auth/Models/User.php
@@ -60,6 +60,16 @@ class User extends Model implements UserInterface
     protected $purgeable = ['password_confirmation'];
 
     /**
+     * @var array The array of custom attribute names.
+     */
+    public $attributeNames = [];
+
+    /**
+     * @var array The array of custom error messages.
+     */
+    public $customMessages = [];
+
+    /**
      * @var array List of attribute names which are json encoded and decoded from the database.
      */
     protected $jsonable = ['permissions'];


### PR DESCRIPTION
Requires merging of https://github.com/octobercms/library/pull/65 first.

I want to extend backend user profile form with a plugin however I can't set custom messages or the new attribute names lists because they're not explicitly set in any of the models so I can't, for instance, do:

```php
\Backend\Models\User::extend(function($model) {
    $model->attributeNames['mfa_answer_2'] = 'Security Answer 2';
});
```