### PR TITLE
Add addDateAttribute method

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1122,7 +1122,7 @@ class Model extends EloquentModel
      */
     public function addDateAttribute($attribute)
     {
-        $this->dates[] = $attribute;
+        if ( !in_array($this->dates, $attribute) ) $this->dates[] = $attribute;
     }
 
     //

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1112,6 +1112,20 @@ class Model extends EloquentModel
     }
 
     //
+    // Adders
+    //
+
+    /**
+     * Adds a datetime attribute to convert to an instance of Carbon/DateTime object.
+     * @param string   $attribute
+     * @return void
+     */
+    public function addDateAttribute($attribute)
+    {
+        $this->dates[] = $attribute;
+    }
+
+    //
     // Getters
     //
 


### PR DESCRIPTION
Models currently have a `dates` property that converts date attributes to carbon objects but [it's protected](https://github.com/octobercms/library/blob/master/src/Database/Model.php#L54) so plugins can't add carbon date fields. This PR adds a simple adder method to make this possible.