### PR TITLE
regular expression fix for parseConcat

### DIFF
--- a/src/Database/Dongle.php
+++ b/src/Database/Dongle.php
@@ -106,7 +106,7 @@ class Dongle
      */
     public function parseConcat($sql)
     {
-        return preg_replace_callback('/(?:group_)?concat\(([^)]+)\)(?R)/i', function($matches){
+        return preg_replace_callback('/(?:group_)?concat\(([^)]+)\)(?R)?/i', function($matches){
             if (!isset($matches[1])) {
                 return $matches[0];
             }


### PR DESCRIPTION
The regular expression matcher for the concat function failed for the following statement: 

`concat(first_name, ' ', last_name)`

Throws Exception by visiting backend/backend/users with database driver other than MySQL.

And was fixed by the proposed change, tested with: https://www.regex101.com/r/mE7bX6/1