### PR TITLE
Add forcingRelative method

### DIFF
--- a/src/Html/UrlGenerator.php
+++ b/src/Html/UrlGenerator.php
@@ -23,6 +23,16 @@ class UrlGenerator extends UrlGeneratorBase
     }
 
     /**
+     * Get whether or not relative URLs are being forced.
+     *
+     * @return boolean
+     */
+    public function forcingRelative()
+    {
+        return $this->forcedRelative;
+    }
+
+    /**
      * Get the full URL for the current request.
      *
      * @return string
@@ -33,7 +43,7 @@ class UrlGenerator extends UrlGeneratorBase
             return $this->request->fullUrl();
         }
 
-        $forcingRelative = $this->forceRelative;
+        $forcingRelative = $this->forcingRelative();
         if ($forcingRelative) $this->forceRelative(false);
 
         $url = $this->to($path);


### PR DESCRIPTION
`URL::full()` is currently erroring out because you're using the wrong property name [here](https://github.com/Flynsarmy/library/blob/master/src/Html/UrlGenerator.php#L36) so I fixed that and added a getter method which may prove helpful in the future.