### PR TITLE
Use correct class property

### DIFF
--- a/src/Html/UrlGenerator.php
+++ b/src/Html/UrlGenerator.php
@@ -33,7 +33,7 @@ class UrlGenerator extends UrlGeneratorBase
             return $this->request->fullUrl();
         }
 
-        $forcingRelative = $this->forceRelative;
+        $forcingRelative = $this->forcedRelative;
         if ($forcingRelative) $this->forceRelative(false);
 
         $url = $this->to($path);


### PR DESCRIPTION
`URL::full()` is currently bugged due to a call to a property that doesn't exist.