### PR TITLE
Fix declaration incompatibility error

### DIFF
--- a/src/Database/NestedTreeScope.php
+++ b/src/Database/NestedTreeScope.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Database;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder as BuilderBase;
 use Illuminate\Database\Eloquent\ScopeInterface;
 
@@ -9,9 +10,10 @@ class NestedTreeScope implements ScopeInterface
     /**
      * Apply the scope to a given Eloquent query builder.
      * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
-    public function apply(BuilderBase $builder)
+    public function apply(BuilderBase $builder, Model $model)
     {
         $model = $builder->getModel();
         $builder->orderBy($model->getLeftColumnName());
@@ -20,9 +22,10 @@ class NestedTreeScope implements ScopeInterface
     /**
      * Remove the scope from the given Eloquent query builder.
      * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
-    public function remove(BuilderBase $builder)
+    public function remove(BuilderBase $builder, Model $model)
     {
         $column = $builder->getModel()->getLeftColumnName();
         $query = $builder->getQuery();


### PR DESCRIPTION
Using *NestedTree* trait results in the error
> Declaration of October\Rain\Database\NestedTreeScope::apply() must be compatible with Illuminate\Database\Eloquent\ScopeInterface::apply(Illuminate\Database\Eloquent\Builder $builder, Illuminate\Database\Eloquent\Model $model)

You were missing the `$model` argument on the apply/remove methods.