### PR TITLE
fixes issue with objects as model fields iteration

### DIFF
--- a/src/Router/Helper.php
+++ b/src/Router/Helper.php
@@ -77,7 +77,7 @@ class Helper
     {
         $defaultColumns = ['id'];
         foreach ($columns as $column) {
-            if (!isset($object->{$column}) || is_array($object->{$column}))
+            if (!isset($object->{$column}) || is_array($object->{$column}) || is_object($object->{$column}))
                 continue;
 
             $string = str_replace(':'.$column, urlencode((string) $object->{$column}), $string);


### PR DESCRIPTION
Objects can be model field values when using transformative traits that create objects on fetch and dismantle them to data on save, ie.: Carbon, [Financial](https://github.com/keiosweb/oc-trait-financial) or [Serializable](https://github.com/keiosweb/oc-trait-serializable). Router helper is crashing if it encounters objects that cannot be forced into a string. If this is by design, there should be information about requirement for all model fields to be convertable to strings, but as arrays are simply omitted and October doesn't use automatic Carbon instantiation on timestamp fields, there is no need to force objects into strings here.