### PR TITLE
Updated Mailer so that it returns the response

### DIFF
--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -60,13 +60,15 @@ class Mailer extends MailerBase
          * Send the message
          */
         $_message = $message->getSwiftMessage();
-        $this->sendSwiftMessage($_message);
+        $response = $this->sendSwiftMessage($_message);
 
         /*
          * Extensbility
          */
         $this->fireEvent('mailer.send', [$view, $message]);
         Event::fire('mailer.send', [$this, $view, $message]);
+        
+        return $response;
     }
 
     /**


### PR DESCRIPTION
In Laravel 5, the Mailer's send method returns the response, which can be useful when using services like Mandrill.

https://github.com/laravel/framework/blob/5.0/src/Illuminate/Mail/Mailer.php#L166