### PR TITLE
Bugfix when Model's relation is not a Collection

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1097,7 +1097,11 @@ class Model extends EloquentModel
             if (!$this->isRelationPushable($name))
                 continue;
 
-            foreach (Collection::make($models) as $model) {
+            if (!$models instanceof Collection) {
+                $models = Collection::make([$models]);
+            }
+
+            foreach ($models as $model) {
                 if (!$model->push($sessionKey))
                     return false;
             }


### PR DESCRIPTION
I'm not sure if this is the best solution. However, it fixes the problem of pushing a Model with hasOne relation.