### PR TITLE
Set file visibility in cloud storage

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -405,7 +405,7 @@ class File extends Model
      */
     protected function copyLocalToStorage($localPath, $storagePath)
     {
-        return Storage::put($storagePath, FileHelper::get($localPath));
+        return Storage::put($storagePath, FileHelper::get($localPath), ($this->isPublic()) ? 'public' : null);
     }
 
     /**


### PR DESCRIPTION
When uploading a file to a cloud storage, set the visibility automatically based on the model config.