### PR TITLE
added open_basedir detection for circumventing CURLOPT_FOLLOWLOCATION

### DIFF
--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -242,7 +242,7 @@ class Http
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
-        if (defined('CURLOPT_FOLLOWLOCATION')) {
+        if (defined('CURLOPT_FOLLOWLOCATION') && !ini_get(‘open_basedir’)) {
             curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($curl, CURLOPT_MAXREDIRS, $this->maxRedirects);
         }
@@ -320,7 +320,7 @@ class Http
         /*
          * Emulate FOLLOW LOCATION behavior
          */
-        if (!defined('CURLOPT_FOLLOWLOCATION')) {
+        if (!defined('CURLOPT_FOLLOWLOCATION') || ini_get(‘open_basedir’)) {
             if ($this->redirectCount === null) {
                 $this->redirectCount = $this->maxRedirects;
             }


### PR DESCRIPTION
resolves octobercms/october issue #1034