### PR TITLE
Wrap single model in array in push(), fixes #1067 in octobercms/october

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1114,7 +1114,7 @@ class Model extends EloquentModel
 
             $models = $models instanceof Collection
                 ? $models->all()
-                : (array) $models;
+                : array($models);
 
             foreach (array_filter($models) as $model) {
                 if (!$model->push($sessionKey))


### PR DESCRIPTION
Wrap single model in array instead of casting which creates array of all model fields, meaning push will fail.