### PR TITLE
Fixed exceptions not being out-put in case of wrong PHP syntax

### DIFF
--- a/src/Exception/ExceptionBase.php
+++ b/src/Exception/ExceptionBase.php
@@ -224,6 +224,10 @@ class ExceptionBase extends Exception
         $lastIndex = count($traceInfo) - 1;
         
         foreach ($traceInfo as $index => $event) {
+            
+            if (isset($event['function']) === false) {
+                $event['function'] = null;
+            }
 
             $functionName = (isset($event['class']) && strlen($event['class']))
                 ? $event['class'].$event['type'].$event['function']


### PR DESCRIPTION
For example, place this faulty line anywhere in Your code:
    
    echo abc;

Expected output: exception page

Current output: blank white page with no information