### PR TITLE
add October specific implementation of ->saveMany(), references #103

### DIFF
--- a/src/Database/Relations/HasOneOrMany.php
+++ b/src/Database/Relations/HasOneOrMany.php
@@ -22,6 +22,21 @@ trait HasOneOrMany
     }
 
     /**
+     * Attach an array of models to the parent instance with deferred binding support.
+     *
+     * @param  array  $models
+     * @return array
+     */
+    public function saveMany(array $models, $sessionKey = null)
+    {
+        foreach ($models as $model) {
+            $this->save($model,$sessionKey);
+        }
+
+        return $models;
+    }
+
+    /**
      * Create a new instance of this related model with deferred binding support.
      */
     public function create(array $attributes, $sessionKey = null)


### PR DESCRIPTION
As per issue #103 , adds saveMany implementation to align with other October specific persistance methods.

Not sure if the deferred binding will work if a $sessionKey is passed, as the $models you pass in saveMany tend to not have been saved yet, meaning the call to bindDeferred wouldn't have an ID to write to the table, but I guess that's a separate issue. 

One possible solution to this could be in the save method of the HasOneOrMany trait, to save the $model before calling $this->add() maybe? 