### PR TITLE
enabled CSRF protection via middleware

### DIFF
--- a/src/Foundation/Http/Kernel.php
+++ b/src/Foundation/Http/Kernel.php
@@ -34,7 +34,7 @@ class Kernel extends HttpKernel
         'Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse',
         'Illuminate\Session\Middleware\StartSession',
         'Illuminate\View\Middleware\ShareErrorsFromSession',
-        // 'App\Http\Middleware\VerifyCsrfToken',
+        'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken'
     ];
 
     /**


### PR DESCRIPTION
Fixes: #105, enabled Laravel's CSRF middleware for all requests. Twin PR: https://github.com/octobercms/october/pull/1216 for framework.js