### PR TITLE
fix for validation of array values

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -323,6 +323,16 @@ class Model extends EloquentModel
         static::registerModelEvent('fetched', $callback);
     }
 
+    /**
+     * Get the jsonable attributes name
+     *
+     * @return array
+     */
+    public function getJsonable()
+    {
+        return $this->jsonable;
+    }
+
     //
     // Overrides
     //

--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -125,6 +125,9 @@ trait Validation
         if (!empty($rules)) {
 
             $data = $this->getAttributes();
+            foreach ($this->getJsonable() as $jsonable) {
+                $data[$jsonable] = $this->getAttribute($jsonable);
+            }
 
             /*
              * Add relation values, if specified.


### PR DESCRIPTION
This PR try to fix the validation of array values.

When defining a $rule for a model's jsonable attribute value, it was not unserializing before the validation occur.
For this I had to make Model::jsonable read public with getJsonable() method.