### PR TITLE
fix mailgun and mandrill

### DIFF
--- a/src/Mail/MailServiceProvider.php
+++ b/src/Mail/MailServiceProvider.php
@@ -49,4 +49,14 @@ class MailServiceProvider extends MailServiceProviderBase
         });
 
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function registerSwiftTransport()
+    {
+        $this->app['swift.transport'] = $this->app->share(function($app) {
+            return new TransportManager($app);
+        });
+    }
 }

--- a/src/Mail/Transport/MailgunTransport.php
+++ b/src/Mail/Transport/MailgunTransport.php
@@ -1,0 +1,31 @@
+<?php namespace October\Rain\Mail\Transport;
+
+use GuzzleHttp\ClientInterface;
+use Illuminate\Mail\Transport\MailgunTransport as MailgunTransportBase;
+use Swift_Mime_Message;
+use GuzzleHttp\Post\PostFile;
+
+class MailgunTransport extends MailgunTransportBase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+    {
+        $options = ['auth' => ['api', $this->key]];
+
+        if (version_compare(ClientInterface::VERSION, '6') === 1) {
+            $options['multipart'] = [
+                ['name' => 'to', 'contents' => $this->getTo($message)],
+                ['name' => 'message', 'contents' => (string) $message, 'filename' => 'message.mime'],
+            ];
+        } else {
+            $options['body'] = [
+                'to' => $this->getTo($message),
+                'message' => new PostFile('message', (string) $message),
+            ];
+        }
+
+        return $this->getHttpClient()->post($this->url, $options);
+    }
+}

--- a/src/Mail/Transport/MandrillTransport.php
+++ b/src/Mail/Transport/MandrillTransport.php
@@ -1,0 +1,29 @@
+<?php namespace October\Rain\Mail\Transport;
+
+use GuzzleHttp\ClientInterface;
+use Illuminate\Mail\Transport\MandrillTransport as MandrillTransportBase;
+use Swift_Mime_Message;
+
+class MandrillTransport extends MandrillTransportBase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+    {
+        $data = [
+            'key' => $this->key,
+            'to' => $this->getToAddresses($message),
+            'raw_message' => (string) $message,
+            'async' => false,
+        ];
+
+        if (version_compare(ClientInterface::VERSION, '6') === 1) {
+            $options = ['form_params' => $data];
+        } else {
+            $options = ['body' => $data];
+        }
+
+        return $this->getHttpClient()->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', $options);
+    }
+}

--- a/src/Mail/TransportManager.php
+++ b/src/Mail/TransportManager.php
@@ -1,0 +1,28 @@
+<?php namespace October\Rain\Mail;
+
+use Illuminate\Mail\TransportManager as TransportManagerBase;
+use October\Rain\Mail\Transport\MailgunTransport;
+use October\Rain\Mail\Transport\MandrillTransport;
+
+class TransportManager extends TransportManagerBase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createMailgunDriver()
+    {
+        $config = $this->app['config']->get('services.mailgun', array());
+
+        return new MailgunTransport($config['secret'], $config['domain']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createMandrillDriver()
+    {
+        $config = $this->app['config']->get('services.mandrill', array());
+
+        return new MandrillTransport($config['secret']);
+    }
+}


### PR DESCRIPTION
Don't need a october.driver or something else. This fix on new guzzle version. Small situation. i have laravel socialite they need new version on guzzle. but laravel 5.0 need old version.