### PR TITLE
Fix in_array argument order

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1181,7 +1181,7 @@ class Model extends EloquentModel
      */
     public function addDateAttribute($attribute)
     {
-        if (in_array($this->dates, $attribute)) return;
+        if (in_array($attribute, $this->dates)) return;
 
         $this->dates[] = $attribute;
     }


### PR DESCRIPTION
You have the `in_array` arguments in `addDateAttribute` method around the wrong way resulting in the error *in_array() expects parameter 2 to be array, string given* when called.