### PR TITLE
Fix cancelDeferredActions query

### DIFF
--- a/src/Database/Models/DeferredBinding.php
+++ b/src/Database/Models/DeferredBinding.php
@@ -63,8 +63,8 @@ class DeferredBinding extends Model
      */
     public static function cancelDeferredActions($masterType, $sessionKey)
     {
-        $records = self::where('master_type=?', $masterType)
-            ->where('session_key=?', $sessionKey)
+        $records = self::where('master_type', $masterType)
+            ->where('session_key', $sessionKey)
             ->get();
 
         foreach ($records as $record) {


### PR DESCRIPTION
The where clauses where firing SQL Exceptions because of bad syntax.