### PR TITLE
Change Exception to AuthException

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -272,7 +272,7 @@ class Manager
         try {
             $user = $this->findUserByCredentials($credentials);
         }
-        catch (Exception $ex) {
+        catch (AuthException $ex) {
             if ($this->useThrottle)
                 $throttle->addLoginAttempt();
 


### PR DESCRIPTION
The translation doesn't work because the use of `Exception` instead of `AuthException` in `Auth::authenticate`