### PR TITLE
Remove unwanted / suffix from single wildcard segments

### DIFF
--- a/src/Router/Rule.php
+++ b/src/Router/Rule.php
@@ -195,7 +195,7 @@ class Rule
                 /*
                  * Determine if wildcard and add stored paramters as a suffix
                  */
-                if (Helper::segmentIsWildcard($patternSegment)) {
+                if (Helper::segmentIsWildcard($patternSegment) && count($wildSegments)) {
                     $parameters[$paramName] .= Helper::rebuildUrl($wildSegments);
                 }
 

--- a/tests/Router/RouterTest.php
+++ b/tests/Router/RouterTest.php
@@ -135,6 +135,15 @@ class RouteTest extends TestCase
         $this->assertEquals('brown', $params['color']);
         $this->assertEquals('code/with/slashes', $params['largecode']);
 
+        $rule = $router->reset()->route('testRuleId', '/color/:color/largecode/:largecode*/edit');
+        $result = $rule->resolveUrl('color/brown/largecode/code/edit', $params);
+        $this->assertTrue($result);
+        $this->assertEquals(2, count($params));
+        $this->assertArrayHasKey('color', $params);
+        $this->assertArrayHasKey('largecode', $params);
+        $this->assertEquals('brown', $params['color']);
+        $this->assertEquals('code', $params['largecode']);
+
         $rule = $router->reset()->route('testRuleId', '/color/:color/largecode/:largecode*/create');
         $result = $rule->resolveUrl('color/brown/largecode/code/with/slashes/edit', $params);
         $this->assertFalse($result);
@@ -207,7 +216,7 @@ class RouteTest extends TestCase
 
         $result = $router->url('productPage', array('id' => '7'));
         $this->assertEquals('/product/default/7', $result);
-        
+
         $result = $router->url('productPage', array('id' => '7', 'category' => 'helmets'));
         $this->assertEquals('/product/helmets/7', $result);
     }


### PR DESCRIPTION
## Issue
* I have a CMS Page with slug `blog/:slug*` 
* I hit the URL `/blog/foo` in my browser
* I call `$this->param('slug')` in my component `onRun` method and get *foo/*

## Expected Result
I should be getting *foo*. No other param wildcard or otherwise has a */* suffix.

## Additional Info
This issue only occurs when you hit a wildcard segment with a single URL segment. For example if I hit the URL `/blog/foo/bar` then `$this->param('slug')` will correctly return *foo/bar*.

My PR includes new tests to cover this.