### PR TITLE
Removes default on $args in __call

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -406,7 +406,7 @@ class Model extends EloquentModel
         return $this->extendableSet($name, $value);
     }
 
-    public function __call($name, $params = null)
+    public function __call($name, $params)
     {
         /*
          * Never call handleRelation() anywhere else as it could


### PR DESCRIPTION
# Issue

The __call method's second parameter, here called `$params`, is required and will always be present as an array (http://www.php.net/manual/en/language.oop5.overloading.php#object.call), adding a default value (like `$params = null`) is not needed and even causes problems, as described in padraic/mockery#263.

# Fix
Removing this default allows us to manipulate the object as expected (especially in Mockery tests).