### PR TITLE
Use AuthException instead of Exception

### DIFF
--- a/src/Auth/Models/Throttle.php
+++ b/src/Auth/Models/Throttle.php
@@ -1,9 +1,9 @@
 <?php namespace October\Rain\Auth\Models;
 
 use Carbon\Carbon;
-use October\Rain\Database\Model;
-use Exception;
 use DateTime;
+use October\Rain\Auth\AuthException;
+use October\Rain\Database\Model;
 
 /**
  * Throttle model
@@ -171,15 +171,16 @@ class Throttle extends Model
     /**
      * Check user throttle status.
      * @return bool
+     * @throws AuthException
      */
     public function check()
     {
         if ($this->is_banned) {
-            throw new Exception(sprintf('User [%s] has been banned.', $this->user->getLogin()));
+            throw new AuthException(sprintf('User [%s] has been banned.', $this->user->getLogin()));
         }
 
         if ($this->checkSuspended()) {
-            throw new Exception(sprintf('User [%s] has been suspended.', $this->user->getLogin()));
+            throw new AuthException(sprintf('User [%s] has been suspended.', $this->user->getLogin()));
         }
 
         return true;


### PR DESCRIPTION
Use AuthException instead of Exception. Exception is parent of AuthException, so every Exception catches in other plugins would also work with new AuthException.

AuthException is more semantic and is used (for example) in RainLab.User Account component, ResetPassword component etc.