### PR TITLE
Added badges and configuration for QA tools

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,16 @@
+checks:
+  php:
+    code_rating: true
+    duplication: true
+
+build:
+  tests:
+    override:
+      -
+    command: 'phpunit -c tests/phpunit.xml --coverage-clover=./build/logs/clover.xml'
+        coverage:
+          file: './build/logs/clover.xml'
+          format: 'php-clover'
+
+sudo: false
+language: php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: php
+sudo: false
+install: travis_retry composer install --no-interaction --prefer-source
+
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+
+before_install:
+  - mkdir -p build/logs
+  - composer self-update
+
+script:
+  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then vendor/bin/phpunit -c tests/phpunit.xml ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then vendor/bin/phpunit -c tests/phpunit.xml --coverage-clover=./build/logs/clover.xml; fi
+
+after_script:
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/coveralls ; fi
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+      env:
+        - EXECUTE_TEST_COVERALLS=true
+    - php: 7.0
+    - php: nightly
+    - php: hhvm
+
+  allow_failures:
+    - php: 7.0
+    - php: nightly

--- a/README.md
+++ b/README.md
@@ -2,3 +2,19 @@ October Rain
 =======
 
 This repository contains the core library of October CMS. If you want to build a website using October, visit the main [October repository](http://github.com/octobercms/october).
+
+Code information:
+
+[![Build Status](https://travis-ci.org/octobercms/library.png?branch=master)](https://travis-ci.org/octobercms/library)
+[![Coverage Status](https://coveralls.io/repos/octobercms/library/badge.svg?branch=master&service=github)](https://coveralls.io/github/octobercms/library?branch=master)
+[![Code Climate](https://codeclimate.com/github/octobercms/library.png)](https://codeclimate.com/github/octobercms/library)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/octobercms/library/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/octobercms/library/?branch=master)
+
+Package information:
+
+[![Latest Stable Version](https://poser.pugx.org/october/rain/v/stable.svg)](https://packagist.org/packages/october/rain)
+[![Total Downloads](https://poser.pugx.org/october/rain/downloads.svg)](https://packagist.org/packages/october/rain)
+[![Reference Status](https://www.versioneye.com/php/october:rain/reference_badge.svg)](https://www.versioneye.com/php/october:rain/references)
+[![Latest Unstable Version](https://poser.pugx.org/october/rain/v/unstable.svg)](https://packagist.org/packages/october/rain)
+[![License](https://poser.pugx.org/october/rain/license.svg)](https://packagist.org/packages/october/rain)
+[![Dependency Status](https://gemnasium.com/october/rain.png)](https://gemnasium.com/october/rain)

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "illuminate/mail": "5.0.*",
         "illuminate/events": "5.0.*",
         "illuminate/view": "5.0.*",
+        "satooshi/php-coveralls": "dev-master",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/config": "2.5.*",
         "symfony/translation": "2.5.*"


### PR DESCRIPTION
Hey guys

I forked the project to run some QA tools. It helps us to find some weaknesses in the code. Also, encourages good quality contributions.

Of course, if you accept this PR you will need to set up the services yourselves. I can help you if you want.

All tools are free for open source projects. Here are the current badges:

Code information:

[![Build Status](https://travis-ci.org/mjacobus/library.png?branch=qa-tools)](https://travis-ci.org/mjacobus/library)
[![Coverage Status](https://coveralls.io/repos/mjacobus/library/badge.svg?branch=qa-tools&service=github)](https://coveralls.io/github/mjacobus/library?branch=qa-tools)
[![Code Climate](https://codeclimate.com/github/mjacobus/library.png)](https://codeclimate.com/github/mjacobus/library)
[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/mjacobus/library/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/mjacobus/library/?branch=master)

Package information:

[![Latest Stable Version](https://poser.pugx.org/october/rain/v/stable.svg)](https://packagist.org/packages/october/rain)
[![Total Downloads](https://poser.pugx.org/october/rain/downloads.svg)](https://packagist.org/packages/october/rain)
[![Reference Status](https://www.versioneye.com/php/october:rain/reference_badge.svg)](https://www.versioneye.com/php/october:rain/references)
[![Latest Unstable Version](https://poser.pugx.org/october/rain/v/unstable.svg)](https://packagist.org/packages/october/rain)
[![License](https://poser.pugx.org/october/rain/license.svg)](https://packagist.org/packages/october/rain)
[![Dependency Status](https://gemnasium.com/october/rain.png)](https://gemnasium.com/october/rain)

Cheers!
