### PR TITLE
Modified validator to obey connection

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -2,6 +2,7 @@
 
 use Lang;
 use Input;
+use App;
 use October\Rain\Database\ModelException;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Facades\Validator;
@@ -75,12 +76,19 @@ trait Validation
 
     /**
      * Instantiates the validator used by the validation process, depending if the class is being used inside or
-     * outside of Laravel.
+     * outside of Laravel. Optional connection string to make the validator use a different database connection
+     * than the default connection.
      * @return \Illuminate\Validation\Validator
      */
-    protected static function makeValidator($data, $rules, $customMessages, $attributeNames)
+    protected static function makeValidator($data, $rules, $customMessages, $attributeNames,$connection = null)
     {
-        return Validator::make($data, $rules, $customMessages, $attributeNames);
+        $validator = Validator::make($data, $rules, $customMessages, $attributeNames);
+        if ($connection !== null) {
+           $verifier = App::make('validation.presence');
+           $verifier->setConnection($connection);
+           $validator->setPresenceVerifier($verifier);
+        }
+        return $validator;
     }
 
     /**
@@ -216,7 +224,7 @@ trait Validation
             /*
              * Hand over to the validator
              */
-            $validator = self::makeValidator($data, $rules, $customMessages, $attributeNames);
+            $validator = self::makeValidator($data, $rules, $customMessages, $attributeNames,$this->getConnectionName());
 
             $success = $validator->passes();
 


### PR DESCRIPTION
When a model uses a different database connection via $connection the validator
would not obey this, making the validator useless for those models.
By adding an optional connection string the validator will use the database connection
provided without interfering with any other code that might directly call the validator
instantiation code.
I made an issue https://github.com/octobercms/october/issues/1580 there, this is my proposed fix basically.

    class RichIndexPage extends Model
      {

      /**
       * @var string The database table used by the model.
       */
       public $table = 'sometable';
       public $connection = 'database_two';

       use \October\Rain\Database\Traits\Validation;
       public $rules = [ 'name' => 'required|unique:sometable,name'];
       /**
        * @var array Guarded fields
        */
       protected $guarded = ['*'];
       /**
        * @var array Fillable fields
        */
       protected $fillable = [;
       /**
        * @var array Relations
        */
       public $hasOne = [];
       public $hasMany = [];
       public $belongsTo = [];
       public $belongsToMany = [];
       public $morphTo = [];
       public $morphOne = [];
       public $morphMany = [];
       public $attachOne = [];
       public $attachMany = [];
      }