### PR TITLE
Validator obey changed primary key name

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -272,7 +272,7 @@ trait Validation
                  * Remove primary key unique validation rule if the model already exists
                  */
                 if (starts_with($rulePart, 'unique') && $this->exists) {
-                    $ruleParts[$key] = 'unique:'.$this->getTable().','.$field.','.$this->getKey();
+                    $ruleParts[$key] = 'unique:'.$this->getTable().','.$field.','.$this->getKey().','.$this->getKeyName();
                 }
                 /*
                  * Look for required:create and required:update rules


### PR DESCRIPTION
If the validator doesn't get supplied the primary key name it won't
obey the unique filter on update if the primary key name is different
from `id`.
This way if for some reason primary key is changed via `$primaryKey`
the unique filter will still work by doing `AND WHERE "otherkey" <> 2`
instead of `AND WHERE "id" <> 2`