### PR TITLE
Get for Height and Width and Resize images on upload to default maxWidht and Heigth 

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Database\Attach;
 
+use Config;
 use Storage;
 use File as FileHelper;
 use October\Rain\Database\Model;
@@ -553,6 +554,19 @@ class File extends Model
         }
 
         $destinationPath = $this->getStorageDirectory() . $this->getPartitionDirectory();
+
+        if ($this->isImage()) {
+
+            $imageMaxWidth = Config::get('cms.storage.uploads.imageMaxWidth',0);
+            $imageMaxHeight = Config::get('cms.storage.uploads.imageMaxHeight',0);
+            $resizer = Resizer::open($sourcePath);
+
+            if (($imageMaxWidth && $resizer->getWidth() > $imageMaxWidth) || ($imageMaxHeight && $resizer->getHeight() > $imageMaxHeight)){
+
+                $resizer->resize($imageMaxWidth,$imageMaxHeight);
+                $resizer->save($sourcePath);
+            }
+        }
 
         if (!$this->isLocalStorage()) {
             return $this->copyLocalToStorage($sourcePath, $destinationPath . $destinationFileName);

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -557,14 +557,14 @@ class File extends Model
 
         if ($this->isImage()) {
 
-            $imageMaxWidth = Config::get('cms.storage.uploads.imageMaxWidth',0);
-            $imageMaxHeight = Config::get('cms.storage.uploads.imageMaxHeight',0);
+            $imageMaxWidth = Config::get('cms.storage.uploads.image.maxWidth',0);
+            $imageMaxHeight = Config::get('cms.storage.uploads.image.maxHeight',0);
             $resizer = Resizer::open($sourcePath);
 
             if (($imageMaxWidth && $resizer->getWidth() > $imageMaxWidth) || ($imageMaxHeight && $resizer->getHeight() > $imageMaxHeight)){
 
                 $resizer->resize($imageMaxWidth,$imageMaxHeight);
-                $resizer->save($sourcePath);
+                $resizer->save($sourcePath, Config::get('cms.storage.uploads.image.quality', 95));
             }
         }
 

--- a/src/Database/Attach/Resizer.php
+++ b/src/Database/Attach/Resizer.php
@@ -400,6 +400,24 @@ class Resizer
     }
 
     /**
+     * Get the image original width
+     * @return int
+     */
+    public function getWidth () {
+
+        return $this->width;
+    }
+
+    /**
+     * Get the image original height
+     * @return int
+     */
+    public function getHeight () {
+
+        return $this->height;
+    }
+
+    /**
      * Crops an image from its center
      * @param int $optimalWidth The width of the image
      * @param int $optimalHeight The height of the image


### PR DESCRIPTION
Now ... we can specify some settings for sending images to Storage in config / cms.php as follows:
    'storage' => [
        'uploads' => [
            'disk'   => 'local',
            'folder' => 'uploads',
            'path'   => '/storage/app/uploads',
            'image'  => [
                'maxWidth' => 1900,
                'maxWHeight' => 1200,
                'quality' => 85,
            ],
        ],
...
PS: this update will not change the default config file...