### PR TITLE
Make getContentType() public

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -207,7 +207,7 @@ class File extends Model
     /**
      * Returns the file content type.
      */
-    protected function getContentType()
+    public function getContentType()
     {
         if ($this->content_type !== null) {
             return $this->content_type;


### PR DESCRIPTION
When I want to send file as email attachment, it would be nice to have `->getContentType()` method available:

```php
$attachment = $record->image; // System\Models\File
Mail::send($template, $templateParameters, function($message) use ($email, $attachment) {
    $params = ['as' => $attachment->getFilename(), 'mime' => $attachment->getContentType()];
    $message->attach($attachment->getLocalPath(), $params);
    $message->to($email);
}
```