### PR TITLE
Fixed sorting of replacements in Translator / Created tests

### DIFF
--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -184,8 +184,8 @@ class Translator implements TranslatorInterface
      */
     protected function sortReplacements(array $replace)
     {
-        return (new Collection($replace))->sortBy(function($r) {
-            return mb_strlen($r) * -1;
+        return (new Collection($replace))->sortBy(function($r, $k) {
+            return mb_strlen($k) * -1;
         });
     }
 

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -184,8 +184,8 @@ class Translator implements TranslatorInterface
      */
     protected function sortReplacements(array $replace)
     {
-        return (new Collection($replace))->sortBy(function($r, $k) {
-            return mb_strlen($k) * -1;
+        return (new Collection($replace))->sortBy(function ($value, $key) {
+            return mb_strlen($key) * -1;
         });
     }
 

--- a/tests/Translate/TranslateTest.php
+++ b/tests/Translate/TranslateTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use October\Rain\Translation\FileLoader;
+use October\Rain\Translation\Translator;
+
+class TranslateTest extends TestCase
+{
+    public function testSimilarWordsParsing()
+    {
+        $path       = __DIR__ . '/../fixtures/lang';
+        $fileLoader = new FileLoader(new Filesystem(), $path);
+        $translator = new Translator($fileLoader, 'en');
+
+        $this->assertEquals('Displayed records: 1-100 of 10',
+            $translator->get('lang.test.pagination', ['from' => 1, 'to' => 100, 'total' => 10])
+        );
+    }
+}

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -4,7 +4,7 @@ use Illuminate\Filesystem\Filesystem;
 use October\Rain\Translation\FileLoader;
 use October\Rain\Translation\Translator;
 
-class TranslateTest extends TestCase
+class TranslatorTest extends TestCase
 {
     public function testSimilarWordsParsing()
     {

--- a/tests/fixtures/lang/en/lang.php
+++ b/tests/fixtures/lang/en/lang.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'test' => [
+        'pagination' => 'Displayed records: :from-:to of :total',
+    ],
+];


### PR DESCRIPTION
The replacements in Translation/Translator were ordered by value instead of by key. This caused some errors when replacing variables like `to` and `total` that begin with the same letters.

https://github.com/octobercms/library/blob/master/src/Translation/Translator.php#L187
```
// Needs to be sorted by key, not value

dump($replace);

#items: array:3 [
    "from" => 1
    "to" => 0
    "total" => 0
]
```

See also https://github.com/octobercms/october/issues/793