### PR TITLE
Don't drop additional attributes in unique validation rule

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -273,6 +273,14 @@ trait Validation
                  */
                 if (starts_with($rulePart, 'unique') && $this->exists) {
                     $ruleParts[$key] = 'unique:'.$this->getTable().','.$field.','.$this->getKey();
+
+                    $parameters = explode(',', $rulePart);
+                    // If there were more than three parameters, add them
+                    // back to the rule (idColumn and where statements)
+                    if(count($parameters) > 3) {
+                        $idColumnAndWheres = array_slice($parameters, 3);
+                        $ruleParts[$key] .= ',' . implode(',', $idColumnAndWheres);
+                    }
                 }
                 /*
                  * Look for required:create and required:update rules

--- a/tests/Database/Traits/ValidationTest.php
+++ b/tests/Database/Traits/ValidationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+class ValidationTest extends TestCase
+{
+    use \October\Rain\Database\Traits\Validation;
+
+    public $exists;
+
+    public function testUnique()
+    {
+        $rules          = ['column' => 'unique:table,column,key,id,where,5'];
+        $processedRules = ['column' => ['unique:table,column,key,id,where,5']];
+
+        $this->exists = false;
+        $this->assertEquals($processedRules, $this->processValidationRules($rules));
+
+        $this->exists = true;
+        $this->assertEquals($processedRules, $this->processValidationRules($rules));
+    }
+
+    protected function getTable()
+    {
+        return 'table';
+    }
+
+    protected function getKey()
+    {
+        return 'key';
+    }
+}


### PR DESCRIPTION
Unique validation rules that have additional attributes (`idColumn` or `where`) were only working as expected when creating entries. If a entry existed, these additional attributes got dumped during processing.

```php
# Example Rule 
unique:table,column,key,id,whereCol,5

# Got truncated to
unique:table,column,key
```