### PR TITLE
Remove numeric index in array for jsonable if all the index for array  

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1266,7 +1266,7 @@ class Model extends EloquentModel
 
         // Handle jsonable
         if (in_array($key, $this->jsonable) && (!empty($value) || is_array($value))) {
-            $value = json_encode($value);
+            $value = json_encode(array_values($value));
         }
 
         // Handle direct relation setting

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -2,6 +2,7 @@
 
 use Input;
 use Closure;
+use October\Rain\Support\Arr;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Illuminate\Database\Eloquent\Collection;
 use October\Rain\Database\Relations\BelongsTo;
@@ -1266,7 +1267,7 @@ class Model extends EloquentModel
 
         // Handle jsonable
         if (in_array($key, $this->jsonable) && (!empty($value) || is_array($value))) {
-            $value = json_encode(array_values($value));
+            $value = json_encode(Arr::fixKeysNumber($value));
         }
 
         // Handle direct relation setting

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -11,27 +11,26 @@ use Illuminate\Support\Arr as ArrHelper;
 class Arr extends ArrHelper
 {
 
-	public static function fixKeysNumber($array, $recursive = false) {
-     	foreach ($array as $k => $val) {
-		    if (is_array($val) && $recursive) {
-		        $array[$k] = self::fixKeysNumber($val);
-		    } 
-	  	} 
-		return self::sortNumericKeys($array);
-	}
+    public static function fixKeysNumber($array, $recursive = false) {
+        foreach ($array as $k => $val) {
+            if (is_array($val) && $recursive) {
+                $array[$k] = self::fixKeysNumber($val);
+            } 
+        } 
+        return self::sortNumericKeys($array);
+    }
 
-	public static function sortNumericKeys($array) {
-	    $i=0;
-	    foreach($array as $k => $v) {
-	        if(is_int($k)) {
-	            $rtn[$i] = $v;
-	            $i++;
-	        } else {
-	            $rtn[$k] = $v;
-	        } //if
-	    } //foreach
-	    return $rtn;
-	}
-
+    public static function sortNumericKeys($array) {
+        $i=0;
+        foreach($array as $k => $v) {
+            if(is_int($k)) {
+                $rtn[$i] = $v;
+                $i++;
+            } else {
+                $rtn[$k] = $v;
+            } //if
+        } //foreach
+        return $rtn;
+    }
 
 }

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -11,4 +11,27 @@ use Illuminate\Support\Arr as ArrHelper;
 class Arr extends ArrHelper
 {
 
+	public static function fixKeysNumber($array, $recursive = false) {
+     	foreach ($array as $k => $val) {
+		    if (is_array($val) && $recursive) {
+		        $array[$k] = self::fixKeysNumber($val);
+		    } 
+	  	} 
+		return self::sortNumericKeys($array);
+	}
+
+	public static function sortNumericKeys($array) {
+	    $i=0;
+	    foreach($array as $k => $v) {
+	        if(is_int($k)) {
+	            $rtn[$i] = $v;
+	            $i++;
+	        } else {
+	            $rtn[$k] = $v;
+	        } //if
+	    } //foreach
+	    return $rtn;
+	}
+
+
 }


### PR DESCRIPTION
it's array:
```php
$array = ['1' => 'foo', '2' => 'bar'];
```

In database result in this json: 
```json
{"1": {"hour":"12:00"}, "2": {"hour": "13:00"}}
```
But now the result will be:
```json
[{"hour": "12:00"}, {"hour":"13:00"}]
```
in the case of associative array the number will come as the first case.