### PR TITLE
Fix following split of attribute and relation values in L5.1

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1206,13 +1206,17 @@ class Model extends EloquentModel
         if (($attr = $this->fireEvent('model.beforeGetAttribute', [$key], true)) !== null)
             return $attr;
 
-        $attr = parent::getAttributeValue($key);
+        if (array_key_exists($key, $this->attributes) || $this->hasGetMutator($key)) {
+            $attr = $this->getAttributeValue($key);
+        }
 
-        if ($attr === null &&
-            $this->hasRelation($key) &&
-            !array_key_exists($key, $this->relations)
-        ) {
-            $attr = $this->relations[$key] = $this->$key()->getResults();
+        if ($attr === null && $this->hasRelation($key)) {
+            if (isset($this->relations[$key])) {
+                $attr = $this->relations[$key];
+            }
+            else {
+                $attr = $this->relations[$key] = $this->$key()->getResults();
+            }
         }
 
         // After Event

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1206,7 +1206,7 @@ class Model extends EloquentModel
         if (($attr = $this->fireEvent('model.beforeGetAttribute', [$key], true)) !== null)
             return $attr;
 
-        $attr = parent::getAttribute($key);
+        $attr = parent::getAttributeValue($key);
 
         if ($attr === null &&
             $this->hasRelation($key) &&


### PR DESCRIPTION
See [54f984ec6e104de63e27c21cd629e353fdb00aa3](https://github.com/laravel/framework/commit/54f984ec6e104de63e27c21cd629e353fdb00aa3) for why this change is necessary.

This fixes: 
 ` [BadMethodCallException]  Call to undefined method October\Rain\Database\QueryBuilder::permissions()` and `[BadMethodCallException] Call to undefined method October\Rain\Database\QueryBuilder::send_invite()` on `artisan october:up`

It also fixes various issues where classes attempted to use `$model->someAttribute` before the model was saved.