### PR TITLE
Replace raw select [fixes octobercms/october#1334]

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Database;
 
+use Db;
 use Input;
 use Closure;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
@@ -657,7 +658,7 @@ class Model extends EloquentModel
                 $relation->countMode = true;
             }
 
-            $relation->selectRaw($relation->getForeignKey() . ', count(*) as count')
+            $relation->select($relation->getForeignKey(), Db::raw('count(*) as count'))
                 ->groupBy($relation->getForeignKey());
         }
 


### PR DESCRIPTION
This fixes an issue in Backend > Settings > Admin > Groups where using
a database table prefix would cause a column not found exception due
to selectRaw() not prepending the prefix to the table name.