### PR TITLE
Default extension must be "auto"

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -395,7 +395,7 @@ class File extends Model
             'mode'      => 'auto',
             'offset'    => [0, 0],
             'quality'   => 95,
-            'extension' => 'jpg',
+            'extension' => 'auto',
         ];
 
         if (!is_array($overrideOptions)) {


### PR DESCRIPTION
getDefaultThumbOptions must have `$defaultOptions['extension'] = 'auto' ` instead of `jpg`.
This way work fine with 'png' files that have alpha channel.