### PR TITLE
Add a new event - backend.auth.afterLogin

### DIFF
--- a/src/Auth/Models/User.php
+++ b/src/Auth/Models/User.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 use RuntimeException;
 use Exception;
 use DateTime;
+use Event;
 
 /**
  * User model
@@ -143,6 +144,7 @@ class User extends Model
 
     public function afterLogin()
     {
+        Event::fire('backend.auth.afterLogin', [$this]);
         $this->last_login = $this->freshTimestamp();
         $this->forceSave();
     }


### PR DESCRIPTION
I wanted to listen to an event when a users logs-in and I realised that October does not yet have that. It would be great to support this out of the box to avoid users make changes to core files or listen to hack-ish events to do something after login.