### PR TITLE
getPath() already return full url

### DIFF
--- a/src/Parse/Syntax/SyntaxModelTrait.php
+++ b/src/Parse/Syntax/SyntaxModelTrait.php
@@ -83,7 +83,7 @@ trait SyntaxModelTrait
             $path = $image->getPath();
         }
 
-        return Request::getSchemeAndHttpHost()  . $path;
+        return $path;
     }
 
     /**


### PR DESCRIPTION
We need this fix for making the campaign manager plugin to work.