### PR TITLE
Make timestamps() create nullable timestamps

### DIFF
--- a/src/Database/Dongle.php
+++ b/src/Database/Dongle.php
@@ -20,6 +20,11 @@ class Dongle
     protected $driver;
 
     /**
+     * @var bool Used to determine whether strict mode has been disabled.
+     */
+    protected $strictModeDisabled;
+
+    /**
      * Constructor.
      */
     public function __construct($driver = 'mysql', $db = null)
@@ -195,6 +200,20 @@ class Dongle
             Db::statement("ALTER TABLE {$table} MODIFY `{$column}` TIMESTAMP NULL DEFAULT NULL");
             Db::update("UPDATE {$table} SET {$column} = null WHERE {$column} = 0");
         }
+    }
+
+    /**
+     * Used to disable strict mode during migrations
+     */
+    public function disableStrictMode()
+    {
+        $db = $this->db->connection();
+
+        if (!$this->strictModeDisabled && !$db->getConfig('strict')) {
+            return;
+        }
+
+        $this->strictModeDisabled = $db->statement("SET @@SQL_MODE=''");
     }
 
     /**

--- a/src/Database/Migrations/2013_10_01_000001_Db_Deferred_Bindings.php
+++ b/src/Database/Migrations/2013_10_01_000001_Db_Deferred_Bindings.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Database\Schema\Blueprint;
+use October\Rain\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class DbDeferredBindings extends Migration

--- a/src/Database/Migrations/2013_10_01_000001_Db_Files.php
+++ b/src/Database/Migrations/2013_10_01_000001_Db_Files.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Database\Schema\Blueprint;
+use October\Rain\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class DbFiles extends Migration

--- a/src/Database/Migrations/2015_10_01_000001_Db_Revisions.php
+++ b/src/Database/Migrations/2015_10_01_000001_Db_Revisions.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Database\Schema\Blueprint;
+use October\Rain\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class DbRevisions extends Migration

--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -1,0 +1,40 @@
+<?php namespace October\Rain\Database\Schema;
+
+use Illuminate\Database\Schema\Blueprint as BaseBlueprint;
+
+class Blueprint extends BaseBlueprint
+{
+    /**
+     * Add nullable creation and update timestamps to the table.
+     *
+     * @return void
+     */
+    public function nullableTimestamps()
+    {
+        return $this->timestamps();
+    }
+
+    /**
+     * Add nullable creation and update timestamps to the table.
+     *
+     * @return void
+     */
+    public function timestamps()
+    {
+        $this->timestamp('created_at')->nullable();
+
+        $this->timestamp('updated_at')->nullable();
+    }
+
+    /**
+     * Add creation and update timestampTz columns to the table.
+     *
+     * @return void
+     */
+    public function timestampsTz()
+    {
+        $this->timestampTz('created_at')->nullable();
+
+        $this->timestampTz('updated_at')->nullable();
+    }
+}

--- a/src/Scaffold/Console/model/create_table.stub
+++ b/src/Scaffold/Console/model/create_table.stub
@@ -1,15 +1,14 @@
 <?php namespace {{studly_author}}\{{studly_plugin}}\Updates;
 
 use Schema;
+use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
 class Create{{studly_plural_name}}Table extends Migration
 {
-
     public function up()
     {
-        Schema::create('{{lower_author}}_{{lower_plugin}}_{{snake_plural_name}}', function($table)
-        {
+        Schema::create('{{lower_author}}_{{lower_plugin}}_{{snake_plural_name}}', function(Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->timestamps();
@@ -20,5 +19,4 @@ class Create{{studly_plural_name}}Table extends Migration
     {
         Schema::dropIfExists('{{lower_author}}_{{lower_plugin}}_{{snake_plural_name}}');
     }
-
 }

--- a/src/Support/Facades/Schema.php
+++ b/src/Support/Facades/Schema.php
@@ -1,0 +1,39 @@
+<?php namespace October\Rain\Support\Facades;
+
+use October\Rain\Support\Facade;
+use October\Rain\Database\Schema\Blueprint;
+
+class Schema extends Facade
+{
+    /**
+     * Get a schema builder instance for a connection.
+     *
+     * @param  string  $name
+     * @return \October\Rain\Database\Schema\Builder
+     */
+    public static function connection($name)
+    {
+        return static::getBuilder($name);
+    }
+
+    /**
+     * Get a schema builder instance for the default connection.
+     *
+     * @return \October\Rain\Database\Schema\Builder
+     */
+    protected static function getFacadeAccessor()
+    {
+        return static::getBuilder();
+    }
+
+    protected static function getBuilder($connection = null)
+    {
+        $builder = static::$app['db']->connection($connection)->getSchemaBuilder();
+
+        $builder->blueprintResolver(function($table, $callback) {
+            return new Blueprint($table, $callback);
+        });
+
+        return $builder;
+    }
+}


### PR DESCRIPTION
Overrides the default Illuminate Blueprint class to implement a fix
that was added in 5.2 but never backported to the LTS version we use.

More info: https://dev.mysql.com/worklog/task/?id=7467
In particular, see F-8 under the Requirements tab.

Also adds a Schema facade with blueprint injector

### Context
> The MySQL 5.7.4 change to make strict mode more strict by including `ERROR_FOR_DIVISION_BY_ZERO`, `NO_ZERO_DATE`, and `NO_ZERO_IN_DATE` caused some problems. For example, in MySQL 5.6 with strict mode but not `NO_ZERO_DATE` enabled, `TIMESTAMP` columns can be defined with `DEFAULT '0000-00-00 00:00:00'`. In MySQL 5.7.4 with the same mode settings, strict mode includes the effect of `NO_ZERO_DATE` and `TIMESTAMP` columns cannot be defined with `DEFAULT '0000-00-00 00:00:00'`.

*Source: http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-changes*