### PR TITLE
Fix `Fatal error: Call to a member function lists() on array` when using HasMany relationship

### DIFF
--- a/src/Database/Relations/HasMany.php
+++ b/src/Database/Relations/HasMany.php
@@ -81,7 +81,8 @@ class HasMany extends HasManyBase
         $relationName = $this->relationName;
 
         if ($this->parent->$relationName) {
-            $value = $this->parent->$relationName[$this->localKey];
+            $relation = $this->parent->$relationName;
+            $value = $relation[$this->localKey];
         }
 
         return $value;

--- a/src/Database/Relations/HasMany.php
+++ b/src/Database/Relations/HasMany.php
@@ -81,8 +81,7 @@ class HasMany extends HasManyBase
         $relationName = $this->relationName;
 
         if ($this->parent->$relationName) {
-            $key = $this->localKey;
-            $value = $this->parent->$relationName->lists($this->localKey);
+            $value = $this->parent->$relationName[$this->localKey];
         }
 
         return $value;


### PR DESCRIPTION
Using Build 335, when editing a model in the backend that has a `hasMany` relation, a fatal error is thrown.

This is beacause the `$this->parent->$relationName->lists()` call below returns an array, not a collection/relation.

![auswahl_134](https://cloud.githubusercontent.com/assets/8600029/15472210/3df5f722-20fa-11e6-9b32-0b805f7f11dc.png)
