### PR TITLE
Add scaffolding command for a console command

### DIFF
--- a/src/Scaffold/Console/CreateCommand.php
+++ b/src/Scaffold/Console/CreateCommand.php
@@ -1,0 +1,85 @@
+<?php namespace October\Rain\Scaffold\Console;
+
+use October\Rain\Scaffold\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class CreateCommand extends GeneratorCommand
+{
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'create:command';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new console command.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Command';
+
+    /**
+     * A mapping of stub to generated file.
+     *
+     * @var array
+     */
+    protected $stubs = [
+        'command/command.stub' => 'console/{{studly_name}}.php',
+    ];
+
+    /**
+     * Prepare variables for stubs.
+     *
+     * return @array
+     */
+    protected function prepareVars()
+    {
+        $pluginCode = $this->argument('plugin');
+
+        $parts = explode('.', $pluginCode);
+        $plugin = array_pop($parts);
+        $author = array_pop($parts);
+        $command = $this->argument('command-name');
+
+        return [
+            'name' => $command,
+            'author' => $author,
+            'plugin' => $plugin
+        ];
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['plugin', InputArgument::REQUIRED, 'The name of the plugin. Eg: RainLab.Blog'],
+            ['command-name', InputArgument::REQUIRED, 'The name of the command. Eg: MyCommand'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', null, InputOption::VALUE_NONE, 'Overwrite existing files with generated ones.']
+        ];
+    }
+}

--- a/src/Scaffold/Console/command/command.stub
+++ b/src/Scaffold/Console/command/command.stub
@@ -1,0 +1,46 @@
+<?php namespace {{studly_author}}\{{studly_plugin}}\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class {{studly_name}} extends Command
+{
+    /**
+     * @var string The console command name.
+     */
+    protected $name = '{{lower_plugin}}:{{lower_name}}';
+
+    /**
+     * @var string The console command description.
+     */
+    protected $description = 'No description provided yet...';
+
+    /**
+     * Execute the console command.
+     * @return void
+     */
+    public function fire()
+    {
+        $this->output->writeln('Hello world!');
+    }
+
+    /**
+     * Get the console command arguments.
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [];
+    }
+
+    /**
+     * Get the console command options.
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+
+}

--- a/src/Scaffold/ScaffoldServiceProvider.php
+++ b/src/Scaffold/ScaffoldServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace October\Rain\Scaffold;
 
 use Illuminate\Support\ServiceProvider;
+use October\Rain\Scaffold\Console\CreateCommand;
 use October\Rain\Scaffold\Console\CreatePlugin;
 use October\Rain\Scaffold\Console\CreateModel;
 use October\Rain\Scaffold\Console\CreateController;
@@ -35,11 +36,16 @@ class ScaffoldServiceProvider extends ServiceProvider
             return new CreateFormWidget;
         });
 
+        $this->app->singleton('command.create.command', function() {
+            return new CreateCommand;
+        });
+
         $this->commands('command.create.plugin');
         $this->commands('command.create.model');
         $this->commands('command.create.controller');
         $this->commands('command.create.component');
         $this->commands('command.create.formwidget');
+        $this->commands('command.create.command');
     }
 
     /**
@@ -54,6 +60,7 @@ class ScaffoldServiceProvider extends ServiceProvider
             'command.create.controller',
             'command.create.component',
             'command.create.formwidget',
+            'command.create.command'
         ];
     }
 }


### PR DESCRIPTION
Note: The argument name cannot be named just "command". This name throws
a LogixException saying, the name is already in use. Thus it is named
"command-name" now.