### PR TITLE
Multiple call to `trace_sql()` cause log repetitions

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -119,6 +119,12 @@ if (!function_exists('trace_sql'))
             define('OCTOBER_NO_EVENT_LOGGING', 1);
         }
 
+        if (!defined('OCTOBER_TRACING_SQL')) {
+            define('OCTOBER_TRACING_SQL', 1);
+        } else {
+            return;
+        }
+
         Event::listen('illuminate.query', function($query, $bindings, $time, $name) {
             $data = compact('bindings', 'time', 'name');
 


### PR DESCRIPTION
When used in loop for example, cause unneeded repetitions to the log.

Problem:
```
for($i = 0; $i < 3; $i++)
{
    trace_sql();
    \Db::select(…);
}
// Generates 1+2+3 lines of SELECT
```

After fix:
```
for($i = 0; $i < 3; $i++)
{
    trace_sql();
    \Db::select(…);
}
// Generates 3 lines of SELECT
```