### PR TITLE
 Use Eloquent save() method rather than newQuery() method in Sortable

### DIFF
--- a/src/Database/Traits/Sortable.php
+++ b/src/Database/Traits/Sortable.php
@@ -54,9 +54,10 @@ trait Sortable
             throw new Exception('Invalid setSortableOrder call - count of itemIds do not match count of itemOrders');
         }
 
+        $order_column = $this->getSortOrderColumn();
+
         foreach ($itemIds as $index => $id) {
             $order = $itemOrders[$index];
-            $order_column = $this->getSortOrderColumn();
             $instance = $this->find($id);
             $instance->$order_column = $order;
             $instance->save();

--- a/src/Database/Traits/Sortable.php
+++ b/src/Database/Traits/Sortable.php
@@ -56,7 +56,10 @@ trait Sortable
 
         foreach ($itemIds as $index => $id) {
             $order = $itemOrders[$index];
-            $this->newQuery()->where('id', $id)->update([$this->getSortOrderColumn() => $order]);
+            $order_column = $this->getSortOrderColumn();
+            $instance = $this->find($id);
+            $instance->$order_column = $order;
+            $instance->save();
         }
     }
 


### PR DESCRIPTION
…Trait to trigger save and update event.

I would like the save and update events to fire when sorting with the Sortable trait - this does not seem to be the case with the newQuery() update() method, so I propose to change that to the Eloquent save() model. Hope I make sense.