### PR TITLE
Ensure that fileContent is an array

### DIFF
--- a/src/Exception/ExceptionBase.php
+++ b/src/Exception/ExceptionBase.php
@@ -160,7 +160,7 @@ class ExceptionBase extends Exception
         }
 
         if (!$this->fileContent && File::exists($this->file) && is_readable($this->file)) {
-            $this->fileContent = @file($this->file);
+            $this->fileContent = @file($this->file) ?: [];
         }
 
         $errorLine = $this->line - 1;


### PR DESCRIPTION
This fixes https://github.com/octobercms/october/issues/2274

In some cases the ``file()`` method fails and returns ``false`` which causes array_slice to fail (line 179) and only Error 500 is returned to the user.

```
array_slice() expects parameter 1 to be array, boolean given in ExceptionBase.php:179
```

With this change we ensure that ``fileContent`` property is always an array.