### PR TITLE
Order Sortable records by default

### DIFF
--- a/src/Database/Builder.php
+++ b/src/Database/Builder.php
@@ -14,6 +14,12 @@ use Illuminate\Database\Eloquent\Builder as BuilderModel;
  */
 class Builder extends BuilderModel
 {
+    /**
+     * An array of flags.
+     *
+     * @var array
+     */
+    protected $flags = [];
 
     /**
      * Get an array with the values of a given column.
@@ -170,6 +176,43 @@ class Builder extends BuilderModel
         return new Paginator($this->get($columns), $perPage, $currentPage, [
             'path' => Paginator::resolveCurrentPath()
         ]);
+    }
+
+    /**
+     * Set a flag on the current Builder instance.
+     *
+     * @param  string $name
+     * @return self
+     */
+    public function flag($name)
+    {
+        $this->flags[$name] = true;
+
+        return $this;
+    }
+
+    /**
+     * Remove a flag from the current Builder instance.
+     *
+     * @param  string $name
+     * @return self
+     */
+    public function unflag($name)
+    {
+        unset($this->flags[$name]);
+
+        return $this;
+    }
+
+    /**
+     * Check for the provided flag on the current Builder instance.
+     *
+     * @param  string $name
+     * @return self
+     */
+    public function hasFlag($name)
+    {
+        return isset($this->flags[$name]);
     }
 
     /**

--- a/src/Database/SortableScope.php
+++ b/src/Database/SortableScope.php
@@ -1,0 +1,71 @@
+<?php namespace October\Rain\Database;
+
+use Illuminate\Database\Eloquent\ScopeInterface;
+use Illuminate\Database\Eloquent\Model as ModelBase;
+use Illuminate\Database\Eloquent\Builder as BuilderBase;
+
+class SortableScope implements ScopeInterface
+{
+    protected $scopeApplied;
+
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function apply(BuilderBase $builder, ModelBase $model)
+    {
+        $this->scopeApplied = true;
+
+        $builder->getQuery()->orderBy($model->getSortOrderColumn());
+
+        $this->extend($builder);
+    }
+
+    /**
+     * Remove the scope from the given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $builder
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     *
+     * @return void
+     */
+    public function remove(BuilderBase $builder, ModelBase $model)
+    {
+        $query = $builder->getQuery();
+        $sortOrderColumn = $model->getSortOrderColumn();
+
+        foreach ((array) $query->orders as $key => $order) {
+
+            if ($order['column'] != $sortOrderColumn)
+                continue;
+
+            unset($query->orders[$key]);
+            $query->orders = array_values($query->orders) ?: null;
+
+            $this->scopeApplied = false;
+        }
+    }
+
+    /**
+     * Extend the Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
+     */
+    protected function extend(BuilderBase $builder)
+    {
+        $builder->macro('orderBy', function($builder, $column, $direction = 'asc') {
+
+            if($this->scopeApplied) {
+                $this->remove($builder, $builder->getModel());
+            }
+
+            $builder->getQuery()->orderBy($column, $direction);
+
+            return $builder;
+        });
+    }
+}

--- a/src/Database/SortableScope.php
+++ b/src/Database/SortableScope.php
@@ -6,8 +6,6 @@ use Illuminate\Database\Eloquent\Builder as BuilderBase;
 
 class SortableScope implements ScopeInterface
 {
-    protected $scopeApplied;
-
     /**
      * Apply the scope to a given Eloquent query builder.
      *
@@ -17,9 +15,9 @@ class SortableScope implements ScopeInterface
      */
     public function apply(BuilderBase $builder, ModelBase $model)
     {
-        $this->scopeApplied = true;
-
         $builder->getQuery()->orderBy($model->getSortOrderColumn());
+
+        $builder->flag('sortable_scope_applied');
 
         $this->extend($builder);
     }
@@ -45,7 +43,7 @@ class SortableScope implements ScopeInterface
             unset($query->orders[$key]);
             $query->orders = array_values($query->orders) ?: null;
 
-            $this->scopeApplied = false;
+            $builder->unflag('sortable_scope_applied');
         }
     }
 
@@ -59,7 +57,7 @@ class SortableScope implements ScopeInterface
     {
         $builder->macro('orderBy', function($builder, $column, $direction = 'asc') {
 
-            if($this->scopeApplied) {
+            if($builder->hasFlag('sortable_scope_applied')) {
                 $this->remove($builder, $builder->getModel());
             }
 

--- a/src/Database/Traits/Sortable.php
+++ b/src/Database/Traits/Sortable.php
@@ -1,6 +1,7 @@
 <?php namespace October\Rain\Database\Traits;
 
 use Exception;
+use October\Rain\Database\SortableScope;
 
 /**
  * Sortable model trait
@@ -36,6 +37,8 @@ trait Sortable
         static::created(function($model) {
             $model->setSortableOrder($model->id);
         });
+
+        static::addGlobalScope(new SortableScope);
     }
 
     /**

--- a/tests/Database/SortableTest.php
+++ b/tests/Database/SortableTest.php
@@ -1,0 +1,41 @@
+<?php
+
+class SortableTest extends TestCase
+{
+    public function setUp()
+    {
+        $capsule = new Illuminate\Database\Capsule\Manager;
+        $capsule->addConnection([
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => ''
+        ]);
+        $capsule->setAsGlobal();
+        $capsule->bootEloquent();
+    }
+
+    public function testOrderByIsAutomaticallyAdded()
+    {
+        $model = new TestModel();
+        $query = $model->newQuery()->toSql();
+
+        $this->assertEquals('select * from "test" order by "sort_order" asc', $query);
+    }
+
+    public function testOrderByCanBeOverridden()
+    {
+        $model = new TestModel();
+        $query1 = $model->newQuery()->orderBy('name')->orderBy('email', 'desc')->toSql();
+        $query2 = $model->newQuery()->orderBy('sort_order')->orderBy('name')->toSql();
+
+        $this->assertEquals('select * from "test" order by "name" asc, "email" desc', $query1);
+        $this->assertEquals('select * from "test" order by "sort_order" asc, "name" asc', $query2);
+    }
+}
+
+class TestModel extends \October\Rain\Database\Model
+{
+    use \October\Rain\Database\Traits\Sortable;
+
+    protected $table = 'test';
+}


### PR DESCRIPTION
Not sure if this is a bug or not, but when I added a ``Sortable`` trait to the model I expected the results to be ordered by default, which they were not.

So I created this PR which adds a global scope to fix that. There is also an option to easily override the default order by just calling the ``orderBy`` as per usual, which also helps to maintain backwards compatibility. I added some tests to show how this all works.

If ``Sortable`` wasn't intended to work this way feel free to close this PR.

