### PR TITLE
Override runningInConsole() method

### DIFF
--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -173,6 +173,15 @@ class Application extends ApplicationBase
     {
         return $this->executionContext == 'back-end';
     }
+    
+    /**
+     * Determine if we are running in the console.
+     *
+     * @return bool
+     */
+    public function runningInConsole() {
+        return (!isset($_SERVER['SERVER_SOFTWARE']) && (php_sapi_name() == 'cli' || (is_numeric($_SERVER['argc']) && $_SERVER['argc'] > 0)));
+    }
 
     /**
      * Sets the execution context


### PR DESCRIPTION
In some cases `php_sapi_name()` returns `cgi-fcgi` in both CLI and Web.
Source: [Drupal 7 - drupal_is_cli](https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_is_cli/7.x)
