### PR TITLE
Enable public api for ``deleteThumbs()``

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -492,7 +492,7 @@ class File extends Model
     /*
      * Delete all thumbnails for this file.
      */
-    protected function deleteThumbs()
+    public function deleteThumbs()
     {
         $pattern = 'thumb_'.$this->id.'_';
 


### PR DESCRIPTION
Delete thumbs should be a public API. In case of any modification to the image, thumbs should be regenerated. I dont see an issue to allow this from a public call.