### PR TITLE
Add checkbox support to parser

### DIFF
--- a/src/Parse/Syntax/FieldParser.php
+++ b/src/Parse/Syntax/FieldParser.php
@@ -49,6 +49,7 @@ class FieldParser
         'mediafinder',
         'dropdown',
         'radio',
+        'checkbox',
         'repeater',
         'variable'
     ];
@@ -231,8 +232,8 @@ class FieldParser
         $paramStrings = $result[2];
 
         foreach ($tagStrings as $key => $tagString) {
-            $params = $this->processParams($paramStrings[$key]);
             $tagName = $tagNames[$key];
+            $params = $this->processParams($paramStrings[$key], $tagName);
 
             if (isset($params['name'])) {
                 $name = $params['name'];
@@ -265,9 +266,10 @@ class FieldParser
      * Processes group 2 from the Tag regex and returns
      * an array of captured parameters.
      * @param  string $value
+     * @param  string $tagName
      * @return array
      */
-    protected function processParams($value)
+    protected function processParams($value, $tagName)
     {
         $close = Parser::CHAR_CLOSE;
         $closePos = strpos($value, $close);
@@ -287,7 +289,12 @@ class FieldParser
         $paramNames = $result[1];
         $paramValues = $result[2];
         $params = array_combine($paramNames, $paramValues);
-        $params['default'] = $defaultValue;
+
+        if($tagName == 'checkbox') {
+            $params['_content'] = $defaultValue;
+        } else {
+            $params['default'] = $defaultValue;
+        }
 
         return $params;
     }

--- a/src/Parse/Syntax/Parser.php
+++ b/src/Parse/Syntax/Parser.php
@@ -214,6 +214,9 @@ class Parser
             case 'mediafinder':
                 $result = '{{ ' . $field . '|media }}';
                 break;
+            case 'checkbox':
+                $result = '{% if ' . $field . '%}' . $params['_content'] . '{% endif %}';
+                break;
         }
 
         return $result;

--- a/src/Parse/Syntax/Parser.php
+++ b/src/Parse/Syntax/Parser.php
@@ -215,7 +215,7 @@ class Parser
                 $result = '{{ ' . $field . '|media }}';
                 break;
             case 'checkbox':
-                $result = '{% if ' . $field . '%}' . $params['_content'] . '{% endif %}';
+                $result = '{% if ' . $field . ' %}' . $params['_content'] . '{% endif %}';
                 break;
         }
 


### PR DESCRIPTION
This PR adds support for ``checkbox`` field to the October syntax parser. This can be very useful when using "Static Pages" plugin where we can allow users to toggle display of certain dynamic layout sections.

Example:
```
{checkbox name="showTitle" label="Show page title"}
    <h1>{{ page.title }}</h1>
{/checkbox}
```

Parsing to ``Twig`` is supported, but I don't think that ``Brackets`` parser currently supports conditional statements, so I didn't find a way to support it there.