### PR TITLE
Try to make a valid object before json encode

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1303,6 +1303,11 @@ class Model extends EloquentModel
         if (($_value = $this->fireEvent('model.beforeSetAttribute', [$key, $value], true)) !== null)
             $value = $_value;
 
+        // Check if Jsonable attribute is String and try to json decode it
+        if ($this->isJsonable($key) && is_string($value)) {
+            $value = json_decode($value);
+        }
+        
         // Handle jsonable
         if ($this->isJsonable($key) && (!empty($value) || is_array($value))) {
             $value = json_encode($value);


### PR DESCRIPTION
Check if provided `$value` is a string and try to convert it into a object, so that the `json_encode` will have a valid object to encode.

PS: This problem was related to a [form-builder post in the forum](https://octobercms.com/plugin/support/renatio-formbuilder/problem-with-validationinvalid-argument-applied-to-foreach). Anyway after this "first try to decode" and then "encode" flow, it worked.
