### PR TITLE
Fixes octobercms/october#2499

### DIFF
--- a/src/Auth/Models/User.php
+++ b/src/Auth/Models/User.php
@@ -555,7 +555,7 @@ class User extends Model
      */
     public function setPermissionsAttribute($permissions)
     {
-        $permissions = json_decode($permissions, true);
+        $permissions = json_decode($permissions, true) ?: [];
         foreach ($permissions as $permission => &$value) {
             if (!in_array($value = (int) $value, $this->allowedPermissionsValues)) {
                 throw new InvalidArgumentException(sprintf(


### PR DESCRIPTION
This fixes the issue presented in octobercms/october#2499 by defaulting permissions to an empty array when the `json_encode` fails on empty data.