### PR TITLE
Pass parent model to relation scopes

### DIFF
--- a/src/Database/Relations/DefinedConstraints.php
+++ b/src/Database/Relations/DefinedConstraints.php
@@ -108,7 +108,7 @@ trait DefinedConstraints
          * Scope
          */
         if ($scope = array_get($args, 'scope')) {
-            $query->$scope();
+            $query->$scope($this->parent);
         }
     }
 


### PR DESCRIPTION
This improves the extensibility of relationships by passing the parent relation model to the query scope that will be applied to relation. It allows the use of attributes of the parent relation model in the query scope applied to the relation.

This is a mirror of octobercms/october#2419 and octobercms/october#2496, except that it effects scopes applied in the relationship configuration itself instead of the recordfinder or relationcontroller widgets. If necessary, I can create a case in the test plugin, but if this is simple enough with the added reference to the prior PR to not require a case in the test plugin, that would be simpler for me :)