### PR TITLE
[FIX] Use getKey() instead 'id'

### DIFF
--- a/src/Database/Traits/Sortable.php
+++ b/src/Database/Traits/Sortable.php
@@ -35,7 +35,7 @@ trait Sortable
     public static function bootSortable()
     {
         static::created(function($model) {
-            $model->setSortableOrder($model->id);
+            $model->setSortableOrder($model->getKey());
         });
 
         static::addGlobalScope(new SortableScope);


### PR DESCRIPTION
Obtain model's primary key value via getKey() method instead property 'id' to ensure coherence with the actual model schema