### PR TITLE
Ensured firing of model.setAttribute event when mutator exists

### DIFF
--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -750,11 +750,15 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
         // the model, such as "json_encoding" an listing of data for storage.
         if ($this->hasSetMutator($key)) {
             $method = 'set'.Str::studly($key).'Attribute';
-
-            return $this->{$method}($value);
+            // If we return the returned value of the mutator call straight away, that will disable the firing of 
+            // 'model.setAttribute' event, and then no third party plugins will be able to implement any kind of 
+            // post processing logic when an attribute is set with explicit mutators. Returning from the mutator 
+            // call will also break method chaining as intended by returning `$this` at the end of this method.
+            $this->{$method}($value);
         }
-
-        $this->attributes[$key] = $value;
+        else {
+            $this->attributes[$key] = $value;
+        }
 
         // After Event
         $this->fireEvent('model.setAttribute', [$key, $value]);


### PR DESCRIPTION
If we return the returned value of the mutator call straight away, that will disable the firing of 
**model.setAttribute** event, and then no third party plugins will be able to implement any kind of post processing logic when an attribute is set with explicit mutators. 

Returning from the mutator call will also break method chaining as intended by returning `$this` at the end of this method.