### PR TITLE
Small fix to prevent 'non existing fields' throwing erros on save

### DIFF
--- a/src/Database/Traits/Nullable.php
+++ b/src/Database/Traits/Nullable.php
@@ -51,7 +51,7 @@ trait Nullable
     public function nullableBeforeSave()
     {
         foreach ($this->nullable as $field) {
-            if (empty($this->{$field})) {
+            if (is_string($this->{$field}) && empty($this->{$field})) {
                 if ($this->exists) {
                     $this->attributes[$field] = null;
                 }


### PR DESCRIPTION
This fix is to prevent errors like field xyz doesn't exist in table abc if a "gost"  field is left in the nullable array.

It first checks if the given variable is a string, and then tries to check if the given variable is empty.

This error occurs in databases where fields may be removed but nullable fields not updated and something lingers. 
Another solution could be to explicitly throw a warning about an invalid field in nullable traits, but those checks would be pretty expensive for production code, even if it is developer friendlier to fix legacy code.

I'm not entirely sure if it should be included because errors like these could be cought by unit tests of course, but finding out the root cause of the error might be a hassle.
