### PR TITLE
Database memory cache

### DIFF
--- a/src/Database/MemoryCache.php
+++ b/src/Database/MemoryCache.php
@@ -1,0 +1,129 @@
+<?php namespace October\Rain\Database;
+
+use October\Rain\Support\Traits\Singleton;
+
+/**
+ * Query memory cache class.
+ *
+ * Stores query results in memory to avoid running duplicate queries
+ *
+ * @package october\database
+ * @author Alexey Bobkov, Samuel Georges
+ */
+class MemoryCache
+{
+    use Singleton;
+
+    /**
+     * Cached results.
+     *
+     * @var array
+     */
+    protected $cache = [];
+
+    /**
+     * The mapper between hashed keys and table names.
+     *
+     * @var array
+     */
+    protected $tableMap = [];
+
+    /**
+     * Check if the memory cache is enabled.
+     *
+     * @return bool
+     */
+    public function enabled()
+    {
+        return true; // TODO: Add a config option
+    }
+
+    /**
+     * Check if the given query is cached.
+     *
+     * @param  QueryBuilder  $query
+     * @return bool
+     */
+    public function has(QueryBuilder $query)
+    {
+        return isset($this->cache[$this->hash($query)]);
+    }
+
+    /**
+     * Get the cached results for the given query.
+     *
+     * @param  QueryBuilder  $query
+     * @return array|null
+     */
+    public function get(QueryBuilder $query)
+    {
+        if($this->has($query)) {
+            return $this->cache[$this->hash($query)];
+        }
+
+        return null;
+    }
+
+    /**
+     * Store the results for the given query.
+     *
+     * @param  QueryBuilder  $query
+     * @param  array  $results
+     * @return array
+     */
+    public function put(QueryBuilder $query, array $results)
+    {
+        $hash = $this->hash($query);
+
+        $this->cache[$hash] = $results;
+        $this->tableMap[$query->from][] = $hash;
+
+        return $results;
+    }
+
+    /**
+     * Delete the cache for the given table.
+     *
+     * @param $table
+     */
+    public function forget($table)
+    {
+        if(!isset($this->tableMap[$table])) {
+            return;
+        }
+
+        foreach ($this->tableMap[$table] as $hash) {
+            unset($this->cache[$hash]);
+        }
+
+        unset($this->tableMap[$table]);
+    }
+
+    /**
+     * Clear the memory cache.
+     */
+    public function flush()
+    {
+        $this->cache = [];
+        $this->tableMap = [];
+    }
+
+    /**
+     * Calculate a hash key for the given query.
+     *
+     * @param  QueryBuilder  $query
+     * @return string
+     */
+    protected function hash(QueryBuilder $query)
+    {
+        // First we will cast all bindings to string, so we can ensure the same
+        // hash format regardless of the binding type provided by the user.
+        $bindings = array_map(function($binding) {
+            return (string) $binding;
+        }, $query->getBindings());
+
+        $name = $query->getConnection()->getName();
+
+        return md5($name . $query->toSql() . serialize($bindings));
+    }
+}

--- a/src/Database/QueryBuilder.php
+++ b/src/Database/QueryBuilder.php
@@ -217,7 +217,7 @@ class QueryBuilder extends QueryBuilderBase
      */
     public function update(array $values)
     {
-        $this->clearMemoryCache($this->from);
+        $this->clearMemoryCache();
 
         return parent::update($values);
     }
@@ -230,7 +230,7 @@ class QueryBuilder extends QueryBuilderBase
      */
     public function delete($id = null)
     {
-        $this->clearMemoryCache($this->from);
+        $this->clearMemoryCache();
 
         return parent::delete($id);
     }
@@ -243,7 +243,7 @@ class QueryBuilder extends QueryBuilderBase
      */
     public function insert(array $values)
     {
-        $this->clearMemoryCache($this->from);
+        $this->clearMemoryCache();
 
         return parent::insert($values);
     }
@@ -255,13 +255,13 @@ class QueryBuilder extends QueryBuilderBase
      */
     public function truncate()
     {
-        $this->clearMemoryCache($this->from);
+        $this->clearMemoryCache();
 
         parent::truncate();
     }
 
     /**
-     * Clear the memory cache.
+     * Clear memory cache for the given table.
      *
      * @param  string|null  $table
      * @return \Illuminate\Database\Query\Builder|static
@@ -271,7 +271,23 @@ class QueryBuilder extends QueryBuilderBase
         $cache = MemoryCache::instance();
 
         if ($cache->enabled()) {
-            $table ? $cache->forget($table) : $cache->flush();
+            $cache->forget($table ?: $this->from);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Flush the memory cache.
+     *
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function flushMemoryCache()
+    {
+        $cache = MemoryCache::instance();
+
+        if ($cache->enabled()) {
+            $cache->flush();
         }
 
         return $this;


### PR DESCRIPTION
Following discussion in https://github.com/octobercms/october/issues/2640 I went ahead and implemented a simple memory caching system to prevent duplicate queries.

The results are pretty good as you can see below:

Before:
![image](https://cloud.githubusercontent.com/assets/6329543/22806100/c5223f90-ef20-11e6-8711-b5bae03b3d6a.png)

After:
![image](https://cloud.githubusercontent.com/assets/6329543/22806134/e5a4010e-ef20-11e6-9eee-75a0e502e867.png)

The implementation is quite simple - the results of every database query are saved in an array. And when performing insert/delete/update/truncate operations, the cache for the target table is cleared.

If needed, the cache can also be cleared manually by using:

```php
October\Rain\Database\MemoryCache::instance()->flush();
October\Rain\Database\MemoryCache::instance()->forget('backend_users');
```

Or during query construction:

```php
User::flushMemoryCache()->get(); // flush the cache
User::clearMemoryCache('backend_users')->get(); // forget the cache for the given table 
```

EDIT: updated the api