### PR TITLE
Updated thumb filename to avoid adblockers

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -400,7 +400,7 @@ class File extends Model
      */
     protected function getThumbFilename($width, $height, $options)
     {
-        return 'thumb_' . $this->id . '_' . $width . 'x' . $height . '_' . $options['offset'][0] . '_' . $options['offset'][1] . '_' . $options['mode'] . '.' . $options['extension'];
+        return 'thumb_' . $this->id . '_' . $width . $height . '_' . $options['offset'][0] . '_' . $options['offset'][1] . '_' . $options['mode'] . '.' . $options['extension'];
     }
 
     /**


### PR DESCRIPTION
Using a filename like "thumb_101_180x300_0_0_crop.jpg" will cause some ad blockers to block the image download (see here also http://stackoverflow.com/questions/17255493/how-to-stop-adblock-plus-blocking-images-in-html-page).
Simply removing the "x" solved the problem in my case (maintains uniqueness and prevents blocking).

![blocked_image_downloads](https://cloud.githubusercontent.com/assets/7261890/23292625/d7dc12ec-fa69-11e6-90cd-13bdd0a639fa.PNG)