### PR TITLE
Made filename appear in thumb files.

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -394,13 +394,27 @@ class File extends Model
         return $thumbPublic;
     }
 
+    /*
+     * Generates a slug based upon the uploaded filename
+     * @return string
+     */
+    protected function getFilenameSlug() 
+    {
+        $extension = '.' . $this->getExtension();
+        $baseName = basename($this->file_name, $extension);
+        
+        return str_slug($baseName) . '-';    
+    }
+    
     /**
      * Generates a thumbnail filename.
      * @return string
      */
     protected function getThumbFilename($width, $height, $options)
     {
-        return 'thumb_' . $this->id . '_' . $width . 'x' . $height . '_' . $options['offset'][0] . '_' . $options['offset'][1] . '_' . $options['mode'] . '.' . $options['extension'];
+        $name = $this->getFilenameSlug();
+        
+        return 'thumb_' . $name . $this->id . '_' . $width . 'x' . $height . '_' . $options['offset'][0] . '_' . $options['offset'][1] . '_' . $options['mode'] . '.' . $options['extension'];
     }
 
     /**
@@ -512,7 +526,8 @@ class File extends Model
      */
     public function deleteThumbs()
     {
-        $pattern = 'thumb_'.$this->id.'_';
+        $name = $this->getFilenameSlug();
+        $pattern = 'thumb_' . $name . $this->id . '_';
 
         $directory = $this->getStorageDirectory() . $this->getPartitionDirectory();
         $allFiles = $this->storageCmd('files', $directory);


### PR DESCRIPTION
Files that are generated using the getThumb command will now have the original uploaded filename present in it's filename.
This makes it possible to have seo friendly images in ones pages.
I only added the custom name feature to the getThumb option since a webdeveloper should already make images to the right size instead of one size fits all because of the SEO punishments google offers for too large filesizes.