### PR TITLE
Fix default sortable order

### DIFF
--- a/src/Database/Traits/Sortable.php
+++ b/src/Database/Traits/Sortable.php
@@ -35,7 +35,11 @@ trait Sortable
     public static function bootSortable()
     {
         static::created(function($model) {
-            $model->setSortableOrder($model->getKey());
+            $sortOrderColumn = $model->getSortOrderColumn();
+
+            if(is_null($model->$sortOrderColumn)) {
+                $model->setSortableOrder($model->getKey());
+            }
         });
 
         static::addGlobalScope(new SortableScope);


### PR DESCRIPTION
If we want to set the sort order manually when creating a new DB record, it's currently not possible. After saving, the sort order is overridden.

```php
$user = new User;
$user->name = 'John Doe';
$user->sort_order = 10;
$user->save(); // sort order should be 10, but it equals the primary key
```

With this PR I added a check to only set a default sort_order if it was not manually set before. 