### PR TITLE
Support condition inside repeater in bracket parser

### DIFF
--- a/src/Parse/Bracket.php
+++ b/src/Parse/Bracket.php
@@ -163,6 +163,7 @@ class Bracket
                 else {
                     $matchedText = $this->parseKey($key, $value, $matchedText);
                     $matchedText = $this->parseKeyFilters($key, $value, $matchedText);
+                    $matchedText = $this->parseKeyBooleans($key, $value, $matchedText);
                 }
             }
 


### PR DESCRIPTION
For more info on what I am exactly trying to do, see this issue: https://github.com/responsiv/campaign-plugin/issues/38

To summarize, I am trying to display a peice of html inside a repeater only if a given variable is set. Actually there is a `parseKeyBooleans()` method that can do what I want, but it doesn't work inside a repeater.

For example, this code works (the parser gives an empty result if the variable is not set):
```HTML
{variable name="image" type="mediafinder" mode="image" label="Image"}{/variable}
{?image}
    <img src="{image|media}" />
{/image}
```

But this one doesn't (if the variable is not set, the parser output is `{?image}<img src="http://example.com/storage/app/media/" />{/image}`):
```HTML
{repeater name="blocks" prompt="Add a block"}
    {variable name="image" type="mediafinder" mode="image" label="Image"}{/variable}
    {?image}
        <img src="{image|media}" />
    {/image}
{/repeater}
```