### PR TITLE
Force schema while using 'force' link policy

### DIFF
--- a/src/Html/UrlServiceProvider.php
+++ b/src/Html/UrlServiceProvider.php
@@ -34,7 +34,9 @@ class UrlServiceProvider extends ServiceProvider
         switch (strtolower($policy)) {
             case 'force':
                 $appUrl = $this->app['config']->get('app.url');
+                $schema = \Str::startsWith($appUrl, 'http://') ? 'http' : 'https';
                 $this->app['url']->forceRootUrl($appUrl);
+                $this->app['url']->forceSchema($schema);
                 break;
 
             case 'insecure':


### PR DESCRIPTION
This is a fix for octobercms/october#3030.

The `forceRootUrl()` method of `Illuminate\Routing\UrlGenerator` sounds like it should include schema as well, but apparently don't (see my comment in the above issue). Not sure if this is the correct way to solve this or if changes should actually be made in `Illuminate\Routing\UrlGenerator`. However I think this is a suitable fix.