### PR TITLE
Implement DataFeed pagination

### DIFF
--- a/src/Database/DataFeed.php
+++ b/src/Database/DataFeed.php
@@ -172,7 +172,9 @@ class DataFeed
 
         $query->orderBy($this->sortVar, $this->sortDirection);
 
-        return new LengthAwarePaginator($this->createCollection($query->get()), $total, $perPage, $page);
+        return new LengthAwarePaginator($this->createCollection($query->get()), $total, $perPage, $page, [
+            'path' => Paginator::resolveCurrentPath()
+        ]);
     }
 
     /**

--- a/src/Database/DataFeed.php
+++ b/src/Database/DataFeed.php
@@ -92,7 +92,7 @@ class DataFeed
     public function count()
     {
         $query = $this->processCollection();
-        $result = Db::table(Db::raw("(".$query->toSql().") as records"))->select(Db::raw("COUNT(*) as total"))->first();
+        $result = Db::table(Db::raw("(".$query->toSql().") as records"))->select(Db::raw("COUNT(*) as total"))->mergeBindings($query)->first();
         return $result->total;
     }
 

--- a/src/Database/DataFeed.php
+++ b/src/Database/DataFeed.php
@@ -116,6 +116,13 @@ class DataFeed
 
         $records = $query->get();
 
+        return $this->createCollection($records);
+    }
+
+    /**
+     * Gets the actual data from an array of records and returns a Collection
+     */
+    protected function createCollection($records = []){
         /*
          * Build a collection of class names and IDs needed
          */

--- a/src/Database/DataFeed.php
+++ b/src/Database/DataFeed.php
@@ -1,6 +1,8 @@
 <?php namespace October\Rain\Database;
 
 use Db;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Str;
 use Closure;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
@@ -156,6 +158,21 @@ class DataFeed
         }
 
         return new Collection($dataArray);
+    }
+
+    public function paginate($perPage = 10){
+        $total = $this->count();
+
+        $query = $this->processCollection();
+
+        $query->forPage(
+            $page = Paginator::resolveCurrentPage(),
+            $perPage
+        );
+
+        $query->orderBy($this->sortVar, $this->sortDirection);
+
+        return new LengthAwarePaginator($this->createCollection($query->get()), $total, $perPage, $page);
     }
 
     /**


### PR DESCRIPTION
DataFeed pagination is listed in the documentation but not implemented (Issue octobercms/october#2415), this pull request fix that. While I worked on it I also discovered that the DataFeed->count() function did not work when the query had bindings, so I fixed that as well.

The implementation is based on the implementation from the Eloquent Builder.

Please note that I have only tested this for on a site that I'm working on and some more tests might be necessary.