### PR TITLE
Fix reading EXIF data for resizer

### DIFF
--- a/src/Database/Attach/Resizer.php
+++ b/src/Database/Attach/Resizer.php
@@ -176,12 +176,7 @@ class Resizer
         /*
          * Reading the exif data is prone to fail due to bad data
          */
-        try {
-            $exif = exif_read_data($filePath);
-        }
-        catch (Exception $e) {
-            return null;
-        }
+        $exif = @exif_read_data($filePath);
 
         if (!isset($exif['Orientation'])) {
             return null;


### PR DESCRIPTION
**Problem**: not every photo is correctly rotated, because of bad EXIF reliability. But even if `exif_read_data()` throws some Exception, we can still read EXIF `Orientation` property.

**Related issue**: https://github.com/octobercms/october/issues/1942

**Solution**: Mute `exif_read_data` exceptions and check if there is `Orientation` attribute we need for processing.

**Replication steps**:

1) Use this photo (not mine): [59df79725646d715843413.jpg](https://user-images.githubusercontent.com/374917/31517324-d67ca99c-af9b-11e7-9faa-332d521a77ad.jpg)

2) When put `dd($e)` in previous catch block, it throws `Illegal IFD size` exception: 

![Illegal IFD size exception](https://user-images.githubusercontent.com/374917/31517377-01b45ba0-af9c-11e7-9766-e325783d4417.png)

3) When put `dd(@exif_read_data($filePath))` we can see, there are some limited data-set we can use: 

![some data we can read](https://user-images.githubusercontent.com/374917/31517418-248cb640-af9c-11e7-98ef-e6de32e3a010.png)

Tested with October build 424 on MacOS.