### PR TITLE
Added support for datepicker field

### DIFF
--- a/src/Parse/Syntax/FieldParser.php
+++ b/src/Parse/Syntax/FieldParser.php
@@ -51,6 +51,7 @@ class FieldParser
         'radio',
         'checkbox',
         'datepicker',
+        'colorpicker',
         'repeater',
         'variable'
     ];
@@ -255,7 +256,11 @@ class FieldParser
             }
 
             if (in_array($tagName, ['dropdown', 'radio']) && isset($params['options'])) {
-                $params['options'] = $this->processOptionsToArray($params['options']);
+                $params['options'] = $this->processOptionsToArray($params['options'], 'options');
+            }
+
+            if (($tagName == 'colorpicker') && isset($params['availableColors'])) {
+                $params['availableColors'] = $this->processOptionsToArray($params['availableColors'], 'availableColors');
             }
 
             $tags[$name] = $tagString;
@@ -379,7 +384,7 @@ class FieldParser
      * @param  string $optionsString
      * @return array
      */
-    protected function processOptionsToArray($optionsString)
+    protected function processOptionsToArray($optionsString, $tagName = NULL)
     {
         $options = explode('|', $optionsString);
 
@@ -391,10 +396,12 @@ class FieldParser
                 $key = trim($parts[0]);
 
                 if (strlen($key)) {
-                    if (!preg_match('/^[0-9a-z-_]+$/i', $key)) {
-                        throw new Exception(sprintf(
-                            'Invalid drop-down option key: %s. Option keys can contain only digits, Latin letters and characters _ and -', $key
-                        ));
+                    if ($tagName == 'options'){
+                        if (!preg_match('/^[0-9a-z-_]+$/i', $key)) {
+                            throw new Exception(sprintf(
+                                'Invalid drop-down option key: %s. Option keys can contain only digits, Latin letters and characters _ and -', $key
+                            ));
+                        }
                     }
 
                     $result[$key] = trim($parts[1]);
@@ -410,5 +417,43 @@ class FieldParser
 
         return $result;
     }
+
+    /**
+     * Splits an option string to an array.
+     *
+     * one|two           -> [one, two]
+     * one:One|two:Two   -> [one => 'One', two => 'Two']
+     *
+     * @param  string $optionsString
+     * @return array
+     */
+    protected function processColorOptionsToArray($optionsString)
+    {
+        $options = explode('|', $optionsString);
+
+        $result = [];
+        foreach ($options as $index => $optionStr) {
+            $parts = explode(':', $optionStr, 2);
+
+            if (count($parts) > 1 ) {
+                $key = trim($parts[0]);
+
+                if (strlen($key)) {
+
+
+                    $result[$key] = trim($parts[1]);
+                }
+                else {
+                    $result[$index] = trim($optionStr);
+                }
+            }
+            else {
+                $result[$index] = trim($optionStr);
+            }
+        }
+
+        return $result;
+    }
+
 
 }

--- a/src/Parse/Syntax/FieldParser.php
+++ b/src/Parse/Syntax/FieldParser.php
@@ -51,7 +51,6 @@ class FieldParser
         'radio',
         'checkbox',
         'datepicker',
-        'colorpicker',
         'repeater',
         'variable'
     ];
@@ -256,11 +255,7 @@ class FieldParser
             }
 
             if (in_array($tagName, ['dropdown', 'radio']) && isset($params['options'])) {
-                $params['options'] = $this->processOptionsToArray($params['options'], 'options');
-            }
-
-            if (($tagName == 'colorpicker') && isset($params['availableColors'])) {
-                $params['availableColors'] = $this->processOptionsToArray($params['availableColors'], 'availableColors');
+                $params['options'] = $this->processOptionsToArray($params['options']);
             }
 
             $tags[$name] = $tagString;
@@ -384,7 +379,7 @@ class FieldParser
      * @param  string $optionsString
      * @return array
      */
-    protected function processOptionsToArray($optionsString, $tagName = NULL)
+    protected function processOptionsToArray($optionsString)
     {
         $options = explode('|', $optionsString);
 
@@ -396,12 +391,10 @@ class FieldParser
                 $key = trim($parts[0]);
 
                 if (strlen($key)) {
-                    if ($tagName == 'options'){
-                        if (!preg_match('/^[0-9a-z-_]+$/i', $key)) {
-                            throw new Exception(sprintf(
-                                'Invalid drop-down option key: %s. Option keys can contain only digits, Latin letters and characters _ and -', $key
-                            ));
-                        }
+                    if (!preg_match('/^[0-9a-z-_]+$/i', $key)) {
+                        throw new Exception(sprintf(
+                            'Invalid drop-down option key: %s. Option keys can contain only digits, Latin letters and characters _ and -', $key
+                        ));
                     }
 
                     $result[$key] = trim($parts[1]);
@@ -417,43 +410,5 @@ class FieldParser
 
         return $result;
     }
-
-    /**
-     * Splits an option string to an array.
-     *
-     * one|two           -> [one, two]
-     * one:One|two:Two   -> [one => 'One', two => 'Two']
-     *
-     * @param  string $optionsString
-     * @return array
-     */
-    protected function processColorOptionsToArray($optionsString)
-    {
-        $options = explode('|', $optionsString);
-
-        $result = [];
-        foreach ($options as $index => $optionStr) {
-            $parts = explode(':', $optionStr, 2);
-
-            if (count($parts) > 1 ) {
-                $key = trim($parts[0]);
-
-                if (strlen($key)) {
-
-
-                    $result[$key] = trim($parts[1]);
-                }
-                else {
-                    $result[$index] = trim($optionStr);
-                }
-            }
-            else {
-                $result[$index] = trim($optionStr);
-            }
-        }
-
-        return $result;
-    }
-
 
 }

--- a/src/Parse/Syntax/FieldParser.php
+++ b/src/Parse/Syntax/FieldParser.php
@@ -50,6 +50,7 @@ class FieldParser
         'dropdown',
         'radio',
         'checkbox',
+        'datepicker',
         'repeater',
         'variable'
     ];

--- a/src/Parse/Syntax/Parser.php
+++ b/src/Parse/Syntax/Parser.php
@@ -219,10 +219,17 @@ class Parser
                 $result = '{% if ' . $field . ' %}' . $params['_content'] . '{% endif %}';
                 break;
             case 'datepicker':
-                if ($params['mode'] === 'date'){
-                    $result = '{{ ' . $field . '|date("Y-m-d") }}';
-                } elseif ($params['mode'] === 'time') {
-                    $result = '{{ ' . $field . '|date("H:m:s") }}';
+                switch($params['mode']) {
+                    default:
+                    case 'datetime':
+                        $result = '{{ ' . $field . '|date("Y-m-d H:i:s") }}';
+                        break;
+                    case 'date':
+                        $result = '{{ ' . $field . '|date("Y-m-d") }}';
+                        break;
+                    case 'time':
+                        $result = '{{ ' . $field . '|date("H:i:s") }}';
+                        break;
                 }
                 break;
         }

--- a/src/Parse/Syntax/Parser.php
+++ b/src/Parse/Syntax/Parser.php
@@ -218,6 +218,13 @@ class Parser
             case 'checkbox':
                 $result = '{% if ' . $field . ' %}' . $params['_content'] . '{% endif %}';
                 break;
+            case 'datepicker':
+                if ($params['mode'] === 'date'){
+                    $result = '{{ ' . $field . '|date("Y-m-d") }}';
+                } elseif ($params['mode'] === 'time') {
+                    $result = '{{ ' . $field . '|date("H:m:s") }}';
+                }
+                break;
         }
 
         return $result;


### PR DESCRIPTION
This change adds support for the Datepicker field type in the syntax parser. The available datepicker options (mode, format, minDate, maxDate, firstDay) discussed [here](https://octobercms.com/docs/backend/forms#widget-datepicker) are working correctly. 