### PR TITLE
Fix for boolean parameter values

### DIFF
--- a/src/Parse/Syntax/FieldParser.php
+++ b/src/Parse/Syntax/FieldParser.php
@@ -290,6 +290,14 @@ class FieldParser
         $result = $this->processParamsRegex($paramString);
         $paramNames = $result[1];
         $paramValues = $result[2];
+
+        // Convert all 'true' and 'false' string values to boolean values
+        foreach ($paramValues as $key => $value) {
+            if ($value === 'true' || $value === 'false') {
+                $paramValues[$key] = $value === 'true' ? true: false;
+            }
+        }
+
         $params = array_combine($paramNames, $paramValues);
 
         if ($tagName == 'checkbox') {


### PR DESCRIPTION
The parser now interprets "true" and "false" values as boolean values instead of string values.

Example:
```
{variable type="text" name="textfield" hidden="false"}{/variable}
```
Previously `hidden="false"` was converted to 
```
[..
"hidden" => "false",
..]
```
Which resulted in the field being hidden, because
`if ("false")` returns to `true`

Now it stores it as
```
[..
"hidden" => false,
..]
```
Which results in the field not being hidden. Same goes for the other boolean field options like commentHtml, readOnly, ignoreTimezone (specific to datepicker), showGutter etc.