### PR TITLE
Throw exception when migration script is missing

### DIFF
--- a/src/Database/Updater.php
+++ b/src/Database/Updater.php
@@ -23,6 +23,7 @@ class Updater
         $object = $this->resolve($file);
 
         if ($object === null) {
+            throw new Exception('File not found: ' . $file);
             return false;
         }
 
@@ -52,6 +53,7 @@ class Updater
         $object = $this->resolve($file);
 
         if ($object === null) {
+            throw new Exception('File not found: ' . $file);
             return false;
         }
 


### PR DESCRIPTION
When you make a typo in the filename of a migration script, the script will be skipped
silently. It's not clear to the developer a script is skipped, and since
the plugin version is updated anyway, there also is no easy way to go
back a single version to re-execute the script.

This update makes sure the migration stops in its tracks and the error
won't slip through.