### PR TITLE
Black border on some cropped thumbnails

### DIFF
--- a/src/Database/Attach/Resizer.php
+++ b/src/Database/Attach/Resizer.php
@@ -612,8 +612,8 @@ class Resizer
             $optimalRatio = $widthRatio;
         }
 
-        $optimalHeight = $this->height / $optimalRatio;
-        $optimalWidth  = $this->width  / $optimalRatio;
+        $optimalHeight = round($this->height / $optimalRatio);
+        $optimalWidth  = round($this->width  / $optimalRatio);
 
         return [$optimalWidth, $optimalHeight];
     }


### PR DESCRIPTION
## Environment
October build: 428
Php version: 7.0 64bits (tested on Windows and Linux)

## Reproduce steps
- Get an image with a non-black background (I used an uniform gray background of 1200x1600 px)
- Add this image using a `System\Models\File` relation (I used Rainlab Blog plugin)
- Create a cropped thumbnail to a smaller size (I did from twig `myImage.thumb(204, 272, 'crop')`)
- Note that in this particular case, the ratio of the original image and the thumbnail are same, but I suspect that other sizes could be problematic too.

## Actual result
The generated thumbnail get a black border of 1px width on the right side, like this:
![thumb_1_204_272_0_0_crop](https://user-images.githubusercontent.com/16371551/33011977-da2e55f6-cddf-11e7-8bc4-331dba6a6119.jpg)

## Expected result
The thumbnail should be an uniform gray background without the black border, just like the source image.

## Proposed fix
By looking at the `October\Rain\Database\Attach\Resizer` class with a debugger, I found this funny situation at the end of the `resize()` method (I wrote the values coming from the debugger in red):
![resizer php - october - visual studio code 2017-11-20 09 10 37](https://user-images.githubusercontent.com/16371551/33013034-e4a8ba3c-cde2-11e7-9e7b-ac3c43256b99.png)

As you can see, `$cropStartX` should be 0 but get an unexpected value. Then, the `crop()` method will call the `imagecopyresampled()` function, which takes integers as parameters, so the value of `$cropStartX` will be cast to `-1` instead of 0.

The problem comes from the `$optimalWidth` variable which is not exactly `204`: in `getOptimalCrop()`, it's set to `1200 / (1200 / 204)`, so it gets a precision loss when computing the intermediate value.

My suggestion is to make a `round()` on the values returned by `getOptimalCrop()`, so width and height will both be clean integers. As all functions using these values takes integers as parameters, it should not be a big problem.
But one case that could theorically be problematic is when the other returned variable (`$optimalHeight` in my case) is between xx.5 and xx.999... : previously, it was floored, now it will be rounded to the upper integer.
In practice, I was not able to find image sizes where this has an influence.