### PR TITLE
Fixes an issue with static pages plugin

### DIFF
--- a/src/Parse/Syntax/Parser.php
+++ b/src/Parse/Syntax/Parser.php
@@ -89,7 +89,7 @@ class Parser
      */
     public function toEditor()
     {
-        return $this->fieldParser->getFields();
+        return is_null($this->fieldParser) ? [] : $this->fieldParser->getFields();
     }
 
     /**


### PR DESCRIPTION
When a static page layout is created without any variable fields it throws an error `Call to a member function getFields() on null". This fixes that issue.