### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Config/ConfigWriterTest.php
+++ b/tests/Config/ConfigWriterTest.php
@@ -34,7 +34,7 @@ class ConfigWriterTest extends TestCase
         $contents = $writer->toContent($contents, ['url' => 'http://octobercms.com']);
         $result = eval('?>'.$contents);
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('url', $result);
         $this->assertEquals('http://octobercms.com', $result['url']);
 

--- a/tests/Extension/ExtendableTest.php
+++ b/tests/Extension/ExtendableTest.php
@@ -30,7 +30,7 @@ class ExtendableTest extends TestCase
         $subject = new ExtendableTest_ExampleExtendableClass;
         $subject->newAttribute = 'Test';
         $this->assertNull($subject->newAttribute);
-        $this->assertFalse(property_exists($subject, 'newAttribute'));
+        $this->assertObjectNotHasAttribute('newAttribute', $subject);
     }
 
     public function testSettingDeclaredPropertyOnBehavior()
@@ -47,10 +47,10 @@ class ExtendableTest extends TestCase
     public function testDynamicPropertyOnClass()
     {
         $subject = new ExtendableTest_ExampleExtendableClass;
-        $this->assertFalse(property_exists($subject, 'newAttribute'));
+        $this->assertObjectNotHasAttribute('newAttribute', $subject);
         $subject->addDynamicProperty('dynamicAttribute', 'Test');
         $this->assertEquals('Test', $subject->dynamicAttribute);
-        $this->assertTrue(property_exists($subject, 'dynamicAttribute'));
+        $this->assertObjectHasAttribute('dynamicAttribute', $subject);
     }
 
     public function testDynamicallyExtendingClass()

--- a/tests/Halcyon/ModelTest.php
+++ b/tests/Halcyon/ModelTest.php
@@ -111,7 +111,7 @@ ESC;
 <p>Hello world!</p>
 ESC;
 
-        $this->assertEquals($content, file_get_contents($targetFile));
+        $this->assertStringEqualsFile($targetFile, $content);
 
         @unlink($targetFile);
     }

--- a/tests/Html/HtmlHelperTest.php
+++ b/tests/Html/HtmlHelperTest.php
@@ -23,27 +23,27 @@ class HtmlHelperTest extends TestCase
     {
         $result = HtmlHelper::nameToArray('field');
         $this->assertInternalType('array', $result);
-        $this->assertEquals(1, count($result));
-        $this->assertTrue(in_array('field', $result));
+        $this->assertCount(1, $result);
+        $this->assertContains('field', $result);
 
         $result = HtmlHelper::nameToArray('field[key1]');
         $this->assertInternalType('array', $result);
-        $this->assertEquals(2, count($result));
-        $this->assertTrue(in_array('field', $result));
-        $this->assertTrue(in_array('key1', $result));
+        $this->assertCount(2, $result);
+        $this->assertContains('field', $result);
+        $this->assertContains('key1', $result);
 
         $result = HtmlHelper::nameToArray('field[][key1]');
         $this->assertInternalType('array', $result);
-        $this->assertEquals(2, count($result));
-        $this->assertTrue(in_array('field', $result));
-        $this->assertTrue(in_array('key1', $result));
+        $this->assertCount(2, $result);
+        $this->assertContains('field', $result);
+        $this->assertContains('key1', $result);
 
         $result = HtmlHelper::nameToArray('field[key1][key2][key3]');
         $this->assertInternalType('array', $result);
-        $this->assertEquals(4, count($result));
-        $this->assertTrue(in_array('field', $result));
-        $this->assertTrue(in_array('key1', $result));
-        $this->assertTrue(in_array('key2', $result));
-        $this->assertTrue(in_array('key3', $result));
+        $this->assertCount(4, $result);
+        $this->assertContains('field', $result);
+        $this->assertContains('key1', $result);
+        $this->assertContains('key2', $result);
+        $this->assertContains('key3', $result);
     }
 }


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertStringEqualsFile` instead of `file_get_contents` function;
- `assertInternalType` instead of `is_*` functions;
- `assertObjectHasAttribute` and `assertObjectNotHasAttribute` instead of `property_exists`;
- `assertContains` instead of `in_array` function.