### PR TITLE
Add router helper function to replace parameters without a list of names

### DIFF
--- a/src/Router/Helper.php
+++ b/src/Router/Helper.php
@@ -98,6 +98,22 @@ class Helper
     }
 
     /**
+     * Replaces :column_name with object value without requiring a list of names. Example: /some/link/:id/:name -> /some/link/1/Joe
+     *
+     * @param stdObject $object Object containing the data
+     * @param string $string URL template
+     * @return string Built string
+     */
+    public static function replaceParameters($object, $string)
+    {
+        if (preg_match_all('/\:([\w]+)/', $string, $matches)) {
+            return self::parseValues($object, $matches[1], $string);
+        }
+
+        return $string;
+    }
+
+    /**
      * Checks whether an URL pattern segment is a wildcard.
      * @param string $segment The segment definition.
      * @return boolean Returns boolean true if the segment is a wildcard. Returns false otherwise.

--- a/tests/Router/RouterHelperTest.php
+++ b/tests/Router/RouterHelperTest.php
@@ -78,4 +78,19 @@ class RouterHelperTest extends TestCase
         $value = Helper::getSegmentDefaultValue(':my_param_name?default value|^[a-z]+[0-9]?$');
         $this->assertEquals('default value', $value);
     }
+
+    public function testReplaceParameters()
+    {
+        $value = Helper::replaceParameters(['param1'=>'dynamic1'], 'static1/:param1/static2');
+        $this->assertEquals('static1/dynamic1/static2', $value);
+
+        $value = Helper::replaceParameters(['param1'=>'dynamic1'], 'static1/:param1/:param2');
+        $this->assertEquals('static1/dynamic1/:param2', $value);
+
+        $value = Helper::replaceParameters(['param1'=>'dynamic1', 'param2'=>'dynamic2'], 'static1/:param1/:param2');
+        $this->assertEquals('static1/dynamic1/dynamic2', $value);
+
+        $value = Helper::replaceParameters(['longer_param'=>'replacement'], 'Non-URL string: contains :longer_param, :other_param, and non-param colon');
+        $this->assertEquals('Non-URL string: contains replacement, :other_param, and non-param colon', $value);
+    }
 }


### PR DESCRIPTION
This is my proposed functionality to leverage for octobercms/october#3358. Since there may be plugin code that makes use of `October\Rain\Router\Helper::parseValues`, I left it untouched and added a `replaceParameters` function that will match a template string for all parameter names and pass those to `parseValues` for the actual replacement.