### PR TITLE
Activate users on successful password reset

### DIFF
--- a/src/Auth/Models/User.php
+++ b/src/Auth/Models/User.php
@@ -223,14 +223,8 @@ class User extends Model
      */
     public function attemptActivation($activationCode)
     {
-        if ($this->is_activated) {
-            throw new Exception('User is already active!');
-        }
-
         if ($activationCode == $this->activation_code) {
-            $this->activation_code = null;
-            $this->is_activated = true;
-            $this->activated_at = $this->freshTimestamp();
+            $this->setActive();
             $this->forceSave();
             return true;
         }
@@ -288,6 +282,9 @@ class User extends Model
         if ($this->checkResetPasswordCode($resetCode)) {
             $this->password = $newPassword;
             $this->reset_password_code = null;
+            if (!$this->is_activated) { // Receiving the password reset code also verifies email address
+                $this->setActive();
+            }
             return $this->forceSave();
         }
 
@@ -664,5 +661,19 @@ class User extends Model
         $pool = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
         return substr(str_shuffle(str_repeat($pool, 5)), 0, $length);
+    }
+
+    /**
+     * Activate user
+     */
+    public function setActive()
+    {
+        if ($this->is_activated) {
+            throw new Exception('User is already active!');
+        }
+
+        $this->activation_code = null;
+        $this->is_activated = true;
+        $this->activated_at = $this->freshTimestamp();
     }
 }


### PR DESCRIPTION
I found https://github.com/rainlab/user-plugin/issues/141 that describes the root issue this is attempting to help smooth over. As described there, I think this is a fairly rare situation, but in our case:

1. On a client project, we imported accounts from another system and sent everyone an activation email to verify the email address and set a password on the newly-created October user accounts.
2. A lot of people ignored the activation emails, as you do.
3. Those users eventually end up at the site, try to sign in with the account they know they have, fail, reset their password, and fail again, as now the password works, but they're still inactive and they have no way to resend the activation email.
4. Those users complain to the client.

Of course the easy thing to do was to change the setting to allow inactive accounts to log in, which I've done. However, it's not really ideal that now users will reset their password but still be prompted to verify their email after they log in. Since the password reset requires the receipt of a code via email just like activation does, it makes sense to me that a successful password reset should also activate the account, as the email address has now been verified. So that's what this PR does.