### PR TITLE
Fix escaping of multiline values in INI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,8 @@
         "illuminate/routing": "5.5.*",
         "illuminate/validation": "5.5.*",
         "illuminate/view": "5.5.*",
-        "swiftmailer/swiftmailer": "~5.1",
-        "symfony/config": "2.7.*",
+        "swiftmailer/swiftmailer": "~6.0",
+        "symfony/config": "3.3.*",
         "symfony/dom-crawler": "~3.1",
         "symfony/css-selector": "~3.1"
     },

--- a/src/Parse/Ini.php
+++ b/src/Parse/Ini.php
@@ -251,7 +251,10 @@ class Ini
         }
 
         // String (default)
-        return '"'.str_replace('"', '\"', $value).'"';
+        $value = str_replace('"', '\"', $value);
+        $value = preg_replace('~\\\"([\r\n])~', '\\\"""$1', $value);
+
+        return '"'.$value.'"';
     }
 
     /**

--- a/tests/Parse/IniTest.php
+++ b/tests/Parse/IniTest.php
@@ -242,7 +242,7 @@ class IniTest extends TestCase
         $content = $this->getContents($path);
 
         $vars = [
-            'var' => "\\\\Test\\Path\\",
+            'var' => "\\Test\\Path\\",
             'editorContent' =>
 '<p>Some
     <br>"Multi-line"
@@ -256,7 +256,7 @@ class IniTest extends TestCase
         $this->assertArrayHasKey('var', $result);
         $this->assertArrayHasKey('editorContent', $result);
         $this->assertEquals($vars, $result);
-
+		
         $result = $parser->render($vars);
         $this->assertEquals($content, $result);
     }

--- a/tests/Parse/IniTest.php
+++ b/tests/Parse/IniTest.php
@@ -255,8 +255,13 @@ class IniTest extends TestCase
         $this->assertCount(2, $result);
         $this->assertArrayHasKey('var', $result);
         $this->assertArrayHasKey('editorContent', $result);
+
+        // Ensures we do not care about EOL sequences
+        str_replace('\r\n', '\n', $result['editorContent']);
+        str_replace('\r\n', '\n', $vars['editorContent']);
+
         $this->assertEquals($vars, $result);
-		
+
         $result = $parser->render($vars);
         $this->assertEquals($content, $result);
     }

--- a/tests/Parse/IniTest.php
+++ b/tests/Parse/IniTest.php
@@ -235,6 +235,32 @@ class IniTest extends TestCase
         $this->assertEquals($content, $result);
     }
 
+    public function testMultilinesValues()
+    {
+        $path = __DIR__.'/../fixtures/parse/multilines-value.ini';
+        $this->assertFileExists($path);
+        $content = $this->getContents($path);
+
+        $vars = [
+            'var' => "\\\\Test\\Path\\",
+            'editorContent' =>
+'<p>Some
+    <br>"Multi-line"
+    <br>text
+</p>',
+        ];
+
+        $parser = new IniParser;
+        $result = $parser->parse($content);
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey('var', $result);
+        $this->assertArrayHasKey('editorContent', $result);
+        $this->assertEquals($vars, $result);
+
+        $result = $parser->render($vars);
+        $this->assertEquals($content, $result);
+    }
+
     public function testRender()
     {
         $parser = new IniParser;

--- a/tests/fixtures/parse/multilines-value.ini
+++ b/tests/fixtures/parse/multilines-value.ini
@@ -1,0 +1,5 @@
+var = "\\Test\Path\"
+editorContent = "<p>Some
+	<br>\"Multi-line\"""
+	<br>text
+</p>"

--- a/tests/fixtures/parse/multilines-value.ini
+++ b/tests/fixtures/parse/multilines-value.ini
@@ -1,5 +1,5 @@
-var = "\\Test\Path\"
+var = "\Test\Path\"
 editorContent = "<p>Some
-	<br>\"Multi-line\"""
-	<br>text
+    <br>\"Multi-line\"""
+    <br>text
 </p>"


### PR DESCRIPTION
Fixes https://github.com/rainlab/pages-plugin/issues/327

I've added a test case to demonstrate the problem but I could not install composer dependencies on php 7.0.6 (need 7.0.8) so I didn't run it to check.