### PR TITLE
Add ability to use array validation for attachMany

### DIFF
--- a/src/Database/Relations/AttachMany.php
+++ b/src/Database/Relations/AttachMany.php
@@ -70,6 +70,42 @@ class AttachMany extends MorphManyBase
     {
         $value = null;
 
+        $files = $this->getSimpleValueInternal();
+
+        if ($files) {
+            $value = [];
+            foreach ($value as $file) {
+                $value[] = $file->getPath();
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Helper for getting this relationship validation value.
+     */
+    public function getValidationValue()
+    {
+        if ($value = $this->getSimpleValueInternal()) {
+            $files = [];
+            foreach ($value as $file) {
+                $files[] = $this->makeValidationFile($file);
+            }
+
+            return $files;
+        }
+
+        return null;
+    }
+
+    /**
+     * Internal method used by `getSimpleValue` and `getValidationValue`
+     */
+    protected function getSimpleValueInternal()
+    {
+        $value = null;
+
         $files = ($sessionKey = $this->parent->sessionKey)
             ? $this->withDeferred($sessionKey)->get()
             : $this->parent->{$this->relationName};
@@ -77,7 +113,7 @@ class AttachMany extends MorphManyBase
         if ($files) {
             $value = [];
             $files->each(function($file) use (&$value){
-                $value[] = $file->getPath();
+                $value[] = $file;
             });
         }
 

--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -92,7 +92,7 @@ trait Validation
     {
         $relationType = $this->getRelationType($relationName);
 
-        if ($relationType == 'attachOne') {
+        if ($relationType === 'attachOne' || $relationType === 'attachMany') {
             return $this->$relationName()->getValidationValue();
         }
         else {


### PR DESCRIPTION
Fix issue from [forum](http://octobercms.com/forum/post/fileupload-validation?page=1#post-23220).

This will allow you to validate individual items from attachMany relation using [Laravel validation of arrays](https://laravel.com/docs/5.5/validation#validating-arrays).

For example
~~~php
use October\Rain\Database\Traits\Validation;
use System\Models\File;

class Gallery extends Model
{
    use Validation;

    public $attachMany = [
        'photos' => File::class
    ];

    public $rules = [
        'photos'   => 'required',
        'photos.*' => 'image|max:1000|dimensions:min_width=100,min_height=100'
    ];

    /* some other code */
}
~~~