### PR TITLE
Correct namespace containing hyphen

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -53,6 +53,10 @@ class Str extends StrHelper
             $name = get_class($name);
 
         $name = '\\'.ltrim($name, '\\');
+        if (strpos($name, '-') !== false) {
+            // Correct plugin vendor namespaces with dashes in their name
+            $name = camel_case($name);
+        }
         return $name;
     }
 


### PR DESCRIPTION
To allow vendors with dashes in their name, such as "grrr-amsterdam".

Right now, this fails silently, the plugin just isn't recognized by the `PluginManager`.