### PR TITLE
Fix failing SectionParserTest::testParse

### DIFF
--- a/tests/Halcyon/SectionParserTest.php
+++ b/tests/Halcyon/SectionParserTest.php
@@ -84,7 +84,7 @@ class SectionParserTest extends TestCase
         $this->assertArrayHasKey("code", $result);
         $this->assertArrayHasKey("markup", $result);
         $this->assertNotNull($result["settings"]);
-        $this->assertArrayHasKey("url", $result["settings"]["url"]);
+        $this->assertArrayHasKey("url", $result["settings"]);
         $this->assertEquals($result["settings"]["url"], "/blog/post");
         $this->assertNull($result["code"]);
         $this->assertNotNull($result["markup"]);
@@ -97,7 +97,7 @@ class SectionParserTest extends TestCase
         $this->assertArrayHasKey("code", $result);
         $this->assertArrayHasKey("markup", $result);
         $this->assertNotNull($result["settings"]);
-        $this->assertArrayHasKey("url", $result["settings"]["url"]);
+        $this->assertArrayHasKey("url", $result["settings"]);
         $this->assertEquals($result["settings"]["url"], "/blog/post");
         $this->assertNotNull($result["code"]);
         $this->assertContains("\$var = 23;", $result["code"]);

--- a/tests/Halcyon/SectionParserTest.php
+++ b/tests/Halcyon/SectionParserTest.php
@@ -75,7 +75,7 @@ class SectionParserTest extends TestCase
         $this->assertEmpty($result["settings"]);
         $this->assertNull($result["code"]);
         $this->assertNotNull($result["markup"]);
-        $this->assertEquals($result["markup"], "This is a header\n================\n\nThis is a paragraph");
+        $this->assertEquals("This is a header\n================\n\nThis is a paragraph", $result["markup"]);
 
         // Test doesn't break Markdown two sections
         $result = SectionParser::parse("url = \"/blog/post\"\n==\nThis is a header\n================\n\nThis is a paragraph");
@@ -85,11 +85,11 @@ class SectionParserTest extends TestCase
         $this->assertArrayHasKey("markup", $result);
         $this->assertNotNull($result["settings"]);
         $this->assertArrayHasKey("url", $result["settings"]);
-        $this->assertEquals($result["settings"]["url"], "/blog/post");
+        $this->assertEquals("/blog/post", $result["settings"]["url"]);
         $this->assertNull($result["code"]);
         $this->assertNotNull($result["markup"]);
-        $this->assertEquals($result["markup"], "This is a header\n================\n\nThis is a paragraph");
-        
+        $this->assertEquals("This is a header\n================\n\nThis is a paragraph", $result["markup"]);
+
         // Test doesn't break Markdown three sections
         $result = SectionParser::parse("url = \"/blog/post\"\n==\n\$var = 23; \n phpinfo();\n==\nThis is a header\n================\n\nThis is a paragraph");
         $this->assertCount(3, $result);
@@ -98,12 +98,12 @@ class SectionParserTest extends TestCase
         $this->assertArrayHasKey("markup", $result);
         $this->assertNotNull($result["settings"]);
         $this->assertArrayHasKey("url", $result["settings"]);
-        $this->assertEquals($result["settings"]["url"], "/blog/post");
+        $this->assertEquals("/blog/post", $result["settings"]["url"]);
         $this->assertNotNull($result["code"]);
         $this->assertContains("\$var = 23;", $result["code"]);
         $this->assertContains("phpinfo();", $result["code"]);
         $this->assertNotNull($result["markup"]);
-        $this->assertEquals($result["markup"], "This is a header\n================\n\nThis is a paragraph");
+        $this->assertEquals("This is a header\n================\n\nThis is a paragraph", $result["markup"]);
     }
 
     public function testParseOffset()


### PR DESCRIPTION
This PR fixes issues with the unit tests introduced here: https://github.com/octobercms/library/commit/0b6c7c63d7128d06ec38a4a31e38f634619952e3