### PR TITLE
Regenerate slugs if missing on existing models.

### DIFF
--- a/src/Database/Traits/Sluggable.php
+++ b/src/Database/Traits/Sluggable.php
@@ -25,14 +25,10 @@ trait Sluggable
         }
 
         /*
-         * Set slugged attributes on new records
+         * Set slugged attributes on new records and existing records if slug is missing.
          */
         static::extend(function($model) {
             $model->bindEvent('model.saveInternal', function() use ($model) {
-                if ($model->exists) {
-                    return;
-                }
-
                 $model->slugAttributes();
             });
         });


### PR DESCRIPTION
This will allow slugs to be regenerated on save even if the model already exists so that if the slug attribute is missing it will be regenerated.