### PR TITLE
Fix halcyon dirty logic

### DIFF
--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -879,6 +879,10 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
         $dirty = [];
 
         foreach ($this->attributes as $key => $current) {
+            if (in_array($key, $this->purgeable)) {
+                continue;
+            }
+
             $original = $this->original[$key] ?? null;
 
             // The attribute is dirty if its current value is not equivalent to the original
@@ -895,11 +899,14 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
         // Check for removed attributes and add a null entry to the dirty array
         $removed = array_diff_key(
             $this->original,
-            $this->attributes
+            $this->attributes,
+            array_flip($this->purgeable)
         );
 
         foreach ($removed as $key => $value) {
-            $dirty[$key] = null;
+            if (!empty($value) || $value === []) {
+                $dirty[$key] = null;
+            }
         }
 
         return $dirty;

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -881,19 +881,21 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
         foreach ($this->attributes as $key => $current) {
             $original = $this->original[$key] ?? null;
 
-            // The attribute is dirty if its current value is not equivalent
-            // to the original or if exactly one is an empty array
-            // to allow for adding/removing empty ini sections
+            // The attribute is dirty if its current value is not equivalent to the original
+            // or if the current value is an empty array to handle adding empty ini sections
             if (
                 !$this->isEquivalent($current, $original) ||
-                $current === [] xor $original === []
+                $current === [] && $original !== []
             ) {
                 $dirty[$key] = $current;
             }
         }
 
         // Check for removed attributes and add a null entry to the dirty array
-        $removed = array_diff_key($this->original, $this->attributes);
+        $removed = array_diff_key(
+            $this->original,
+            $this->attributes
+        );
 
         foreach ($removed as $key => $value) {
             $dirty[$key] = null;
@@ -936,7 +938,10 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
         // Arrays are equivalent only if all their elements are equivalent
         if (is_array($value1) && is_array($value2)) {
             // Get the keys of both arrays
-            $keys = array_unique(array_merge(array_keys($value1), array_keys($value2)));
+            $keys = array_unique(array_merge(
+                array_keys($value1),
+                array_keys($value2)
+            ));
 
             // Test each array element's equivalence
             foreach ($keys as $key) {

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -880,10 +880,13 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
 
         foreach ($this->attributes as $key => $value) {
             if (!array_key_exists($key, $this->original)) {
-                $dirty[$key] = $value;
+                if (!empty($value)) {
+                    $dirty[$key] = $value;
+                }
             }
             elseif (
                 $value !== $this->original[$key] &&
+                !(empty($value) && empty($this->original[$key])) &&
                 !$this->originalIsNumericallyEquivalent($key)
             ) {
                 $dirty[$key] = $value;

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -882,10 +882,11 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
             $original = $this->original[$key] ?? null;
 
             // The attribute is dirty if its current value is not equivalent to the original
-            // or if the current value is an empty array to handle adding empty ini sections
+            // or if one of current or original is an empty array to handle adding/removing empty ini sections
             if (
                 !$this->isEquivalent($current, $original) ||
-                $current === [] && $original !== []
+                $current === [] && $original !== [] ||
+                $original === [] && $current !== []
             ) {
                 $dirty[$key] = $current;
             }

--- a/tests/Halcyon/ModelTest.php
+++ b/tests/Halcyon/ModelTest.php
@@ -353,7 +353,7 @@ ESC;
         // Test adding new attributes
         $page->testString = 'This is a test';
         $page->testNumber = 12;                
-        $page->testArray = [];
+        $page->testArray = ['string' => 'Hello World!', 'number' => 22];
         $dirty = $page->getDirty();
         $this->assertCount(3, $dirty);        
         $this->assertArrayHasKey('testString', $dirty);
@@ -361,14 +361,14 @@ ESC;
         $this->assertArrayHasKey('testNumber', $dirty);
         $this->assertEquals($dirty['testNumber'], 12);
         $this->assertArrayHasKey('testArray', $dirty);
-        $this->assertEquals($dirty['testArray'], []);
+        $this->assertEquals($dirty['testArray'], ['string' => 'Hello World!', 'number' => 22]);
         $page->save();
 
         // Test setting equivalent values
         $page->testString = '    This is a test   ';
         $page->testNumber = 12.00;
         $page->testEmpty = '';
-        $page->testArray = [];
+        $page->testArray = ['string' => '   Hello World!  ', 'number' => 22.0];
         $dirty = $page->getDirty();
         $this->assertEmpty($dirty);
 

--- a/tests/Halcyon/ModelTest.php
+++ b/tests/Halcyon/ModelTest.php
@@ -332,6 +332,36 @@ ESC;
         $this->assertEquals(['about.htm', 'home.htm'], $files);
     }
 
+    public function testIsDirty()
+    {
+        // Check isDirty() == true after create
+        $page = new HalcyonTestPage([
+            'fileName' => 'dirtyTestFile.htm',
+            'title' => 'Dirty Test File',
+        ]);
+        $this->assertTrue($page->isDirty());
+        
+        // Check isDirty() == false after save
+        $page->save();
+        $this->assertFalse($page->isDirty());
+       
+        // Check isDirty() == true after update
+        $page->markup = '<p>I am dirty!</p>';
+        $this->assertTrue($page->isDirty());
+        
+        // Check isDirty() == false after save
+        $page->save();
+        $this->assertFalse($page->isDirty());
+
+        // Check isDirty() == false when setting a null value to an empty value
+        $this->assertNull($page->code);
+        $page->code = '';
+        $this->assertEquals($page->code, '');
+        $this->assertFalse($page->isDirty());
+        
+        $page->delete();
+    }
+
     //
     // House keeping
     //

--- a/tests/Halcyon/ModelTest.php
+++ b/tests/Halcyon/ModelTest.php
@@ -332,45 +332,48 @@ ESC;
         $this->assertEquals(['about.htm', 'home.htm'], $files);
     }
 
-    public function testIsDirty()
+    public function testGetDirty()
     {
-        // Check isDirty() == true after create
         $page = new HalcyonTestPage([
             'fileName' => 'dirtyTestFile.htm',
             'title' => 'Dirty Test File',
         ]);
+
+        $dirty = $page->getDirty();
+        $this->assertCount(2, $dirty);
+        $this->assertArrayHasKey('fileName', $dirty);
+        $this->assertEquals($dirty['fileName'], 'dirtyTestFile.htm');  
+        $this->assertArrayHasKey('title', $dirty);
+        $this->assertEquals($dirty['title'], 'Dirty Test File');
+
+        $page->save();
+        $dirty = $page->getDirty();
+        $this->assertEmpty($dirty);
+
+        // Test adding new attributes
         $page->testString = 'This is a test';
-        $page->testNumber = 12;
-        $this->assertTrue($page->isDirty());
-        
-        // Check isDirty() == false after save
+        $page->testNumber = 12;                
+        $page->testArray = [];
+        $dirty = $page->getDirty();
+        $this->assertCount(3, $dirty);        
+        $this->assertArrayHasKey('testString', $dirty);
+        $this->assertEquals($dirty['testString'], 'This is a test');
+        $this->assertArrayHasKey('testNumber', $dirty);
+        $this->assertEquals($dirty['testNumber'], 12);
+        $this->assertArrayHasKey('testArray', $dirty);
+        $this->assertEquals($dirty['testArray'], []);
         $page->save();
-        $this->assertFalse($page->isDirty());
-       
-        // Check isDirty() == true after update
-        $page->markup = '<p>I am dirty!</p>';
-        $this->assertTrue($page->isDirty());
-        
-        // Check isDirty() == false after save
-        $page->save();
-        $this->assertFalse($page->isDirty());
 
-        // Check isDirty() == false when setting a null value to an empty string
-        $this->assertNull($page->code);
-        $page->code = '';
-        $this->assertEquals($page->code, '');
-        $this->assertFalse($page->isDirty());
+        // Test setting equivalent values
+        $page->testString = '    This is a test   ';
+        $page->testNumber = 12.00;
+        $page->testEmpty = '';
+        $page->testArray = [
+            'empty' => ''
+        ];
+        $dirty = $page->getDirty();
+        $this->assertEmpty($dirty);
 
-        // Check isDirty() == false with leading/trailing spaces
-        $this->assertEquals($page->testString, 'This is a test');
-        $page->testString = '     This is a test      ';
-        $this->assertFalse($page->isDirty());
-
-        // Check isDirty() == false when new value is numerically equivalent
-        $this->assertEquals($page->testNumber, 12);
-        $this->testNumber = 12.0;
-        $this->assertFalse($page->isDirty());
-        
         // Clean up
         $page->delete();
     }

--- a/tests/Halcyon/ModelTest.php
+++ b/tests/Halcyon/ModelTest.php
@@ -368,11 +368,22 @@ ESC;
         $page->testString = '    This is a test   ';
         $page->testNumber = 12.00;
         $page->testEmpty = '';
-        $page->testArray = [
-            'empty' => ''
-        ];
+        $page->testArray = [];
         $dirty = $page->getDirty();
         $this->assertEmpty($dirty);
+
+        // Test removing attributes
+        unset($page->attributes['testString']);
+        unset($page->attributes['testNumber']);
+        unset($page->attributes['testArray']);
+        $dirty = $page->getDirty();
+        $this->assertCount(3, $dirty);
+        $this->assertArrayHasKey('testString', $dirty);
+        $this->assertNull($dirty['testString']);
+        $this->assertArrayHasKey('testNumber', $dirty);
+        $this->assertNull($dirty['testNumber']);
+        $this->assertArrayHasKey('testArray', $dirty);
+        $this->assertNull($dirty['testArray']);
 
         // Clean up
         $page->delete();

--- a/tests/Halcyon/ModelTest.php
+++ b/tests/Halcyon/ModelTest.php
@@ -339,6 +339,8 @@ ESC;
             'fileName' => 'dirtyTestFile.htm',
             'title' => 'Dirty Test File',
         ]);
+        $page->testString = 'This is a test';
+        $page->testNumber = 12;
         $this->assertTrue($page->isDirty());
         
         // Check isDirty() == false after save
@@ -353,12 +355,23 @@ ESC;
         $page->save();
         $this->assertFalse($page->isDirty());
 
-        // Check isDirty() == false when setting a null value to an empty value
+        // Check isDirty() == false when setting a null value to an empty string
         $this->assertNull($page->code);
         $page->code = '';
         $this->assertEquals($page->code, '');
         $this->assertFalse($page->isDirty());
+
+        // Check isDirty() == false with leading/trailing spaces
+        $this->assertEquals($page->testString, 'This is a test');
+        $page->testString = '     This is a test      ';
+        $this->assertFalse($page->isDirty());
+
+        // Check isDirty() == false when new value is numerically equivalent
+        $this->assertEquals($page->testNumber, 12);
+        $this->testNumber = 12.0;
+        $this->assertFalse($page->isDirty());
         
+        // Clean up
         $page->delete();
     }
 


### PR DESCRIPTION
Fix for issue https://github.com/octobercms/october/issues/3611

Takes into account empty values and leading/trailing whitespace in strings when determining if a Halcyon model is dirty and needs saving.