### PR TITLE
Enable use of unencrypted cookies

### DIFF
--- a/src/Cookie/Middleware/EncryptCookies.php
+++ b/src/Cookie/Middleware/EncryptCookies.php
@@ -8,7 +8,7 @@ class EncryptCookies extends \Illuminate\Cookie\Middleware\EncryptCookies
     public function __construct(EncrypterContract $encrypter)
     {
         parent::__construct($encrypter);
-        $except = Config::get('cookie.unencryptedCookies');
+        $except = Config::get('cookie.unencryptedCookies', []);
         $this->disableFor($except);
     }
 }

--- a/src/Cookie/Middleware/EncryptCookies.php
+++ b/src/Cookie/Middleware/EncryptCookies.php
@@ -8,7 +8,7 @@ class EncryptCookies extends \Illuminate\Cookie\Middleware\EncryptCookies
     public function __construct(EncrypterContract $encrypter)
     {
         parent::__construct($encrypter);
-        $except = Config::get('cookie.unencrypted_cookies');
+        $except = Config::get('cookie.unecryptedCookies');
         $this->disableFor($except);
     }
 }

--- a/src/Cookie/Middleware/EncryptCookies.php
+++ b/src/Cookie/Middleware/EncryptCookies.php
@@ -8,7 +8,7 @@ class EncryptCookies extends \Illuminate\Cookie\Middleware\EncryptCookies
     public function __construct(EncrypterContract $encrypter)
     {
         parent::__construct($encrypter);
-        $except = Config::get('cookie.unecryptedCookies');
+        $except = Config::get('cookie.unencryptedCookies');
         $this->disableFor($except);
     }
 }

--- a/src/Cookie/Middleware/EncryptCookies.php
+++ b/src/Cookie/Middleware/EncryptCookies.php
@@ -1,0 +1,14 @@
+<?php namespace October\Rain\Cookie\Middleware;
+
+use Config;
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+
+class EncryptCookies extends \Illuminate\Cookie\Middleware\EncryptCookies
+{
+    public function __construct(EncrypterContract $encrypter)
+    {
+        parent::__construct($encrypter);
+        $except = Config::get('cookie.unencrypted_cookies');
+        $this->disableFor($except);
+    }
+}

--- a/src/Foundation/Http/Kernel.php
+++ b/src/Foundation/Http/Kernel.php
@@ -51,7 +51,7 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \Illuminate\Cookie\Middleware\EncryptCookies::class,
+            \October\Rain\Cookie\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,


### PR DESCRIPTION
Currently OctoberCMS encrypts all cookies, and thus it always tries to decrypt them on read.
This PR gives developers a chance to specify cookies that should not be decrypted.

Even though `\Illuminate\Cookie\Middleware\EncryptCookies` provides `$except` field and `disableFor` method to specify a list of cookies that shouldn't be decrypted, current implementation of october lib does not make use of them.

With this modification, developer will be able to specify unencrypted cookies in `config/cookie.php` like below.
```
<?php
return [
    "unencryptedCookies" => [
        "my_cookie",
    ],
];
```

This is useful when a developer wants to create cookies in frontend to pass data to backend.