### PR TITLE
Add relation.afterAttach, relation.afterDetach events in BelongsToMany relations

### DIFF
--- a/src/Database/Relations/BelongsToMany.php
+++ b/src/Database/Relations/BelongsToMany.php
@@ -110,6 +110,20 @@ class BelongsToMany extends BelongsToManyBase
         $insertData = $this->formatAttachRecords($this->parseIds($id), $attributes);
         $elementIDList = array_pluck($insertData, $this->relatedPivotKey);
 
+        /**
+         * @event model.relation.beforeAttach
+         * Called before creating a new relation between models (only for BelongsToMany relation)
+         *
+         * Example usage:
+         *
+         *     $model->bindEvent('model.relation.beforeAttach', function ($relationName, $elementIDList, $insertData) use (\October\Rain\Database\Model $model) {
+         *         if (!$model->isRelationValid($elementIDList)) {
+         *             throw new \Exception("Invalid relation!");
+         *             return false;
+         *         }
+         *     });
+         *
+         */
         $eventDataList = $this->parent->fireEvent('model.relation.beforeAttach', [$this->relationName, $elementIDList, $insertData]);
         if (!empty($eventDataList)) {
             foreach ($eventDataList as $eventData) {
@@ -128,6 +142,17 @@ class BelongsToMany extends BelongsToManyBase
             $this->touchIfTouching();
         }
 
+        /**
+         * @event model.relation.afterAttach
+         * Called after creating a new relation between models (only for BelongsToMany relation)
+         *
+         * Example usage:
+         *
+         *     $model->bindEvent('model.relation.afterAttach', function ($relationName, $elementIDList, $insertData) use (\October\Rain\Database\Model $model) {
+         *         \Log::info("New relation {$relationName} was created", $elementIDList);
+         *     });
+         *
+         */
         $this->parent->fireEvent('model.relation.afterAttach', [$this->relationName, $elementIDList, $insertData]);
     }
 
@@ -140,6 +165,20 @@ class BelongsToMany extends BelongsToManyBase
     {
         $elementIDList = $this->parseIds($ids);
 
+        /**
+         * @event model.relation.beforeDetach
+         * Called before removing a relation between models (only for BelongsToMany relation)
+         *
+         * Example usage:
+         *
+         *     $model->bindEvent('model.relation.beforeDetach', function ($relationName, $elementIDList) use (\October\Rain\Database\Model $model) {
+         *         if (!$model->isRelationValid($elementIDList)) {
+         *             throw new \Exception("Invalid relation!");
+         *             return false;
+         *         }
+         *     });
+         *
+         */
         $eventDataList = $this->parent->fireEvent('model.relation.beforeDetach', [$this->relationName, $elementIDList]);
         if (!empty($eventDataList)) {
             foreach ($eventDataList as $eventData) {
@@ -151,6 +190,17 @@ class BelongsToMany extends BelongsToManyBase
 
         parent::detach($ids, $touch);
 
+        /**
+         * @event model.relation.afterDetach
+         * Called after removing a relation between models (only for BelongsToMany relation)
+         *
+         * Example usage:
+         *
+         *     $model->bindEvent('model.relation.afterDetach', function ($relationName, $elementIDList) use (\October\Rain\Database\Model $model) {
+         *         \Log::info("Relation {$relationName} was removed", $elementIDList);
+         *     });
+         *
+         */
         $this->parent->fireEvent('model.relation.afterDetach', [$this->relationName, $elementIDList]);
     }
 

--- a/src/Database/Relations/BelongsToMany.php
+++ b/src/Database/Relations/BelongsToMany.php
@@ -101,6 +101,8 @@ class BelongsToMany extends BelongsToManyBase
     }
 
     /**
+     * Override attach() method of BelongToMany relation.
+     * This is necessary in order to fire 'model.relation.beforeAttach', 'model.relation.afterAttach' events
      * @param mixed $id
      * @param array $attributes
      * @param bool  $touch
@@ -124,7 +126,7 @@ class BelongsToMany extends BelongsToManyBase
          *     });
          *
          */
-        if ($this->parent->fireEvent('model.relation.beforeAttach', [$this->relationName, $attachedIDList, $insertData], true)) {
+        if ($this->parent->fireEvent('model.relation.beforeAttach', [$this->relationName, $attachedIDList, $insertData], true) === false) {
             return;
         }
 
@@ -152,6 +154,8 @@ class BelongsToMany extends BelongsToManyBase
     }
 
     /**
+     * Override detach() method of BelongToMany relation.
+     * This is necessary in order to fire 'model.relation.beforeDetach', 'model.relation.afterDetach' events
      * @param null $ids
      * @param bool $touch
      * @return int|void
@@ -174,7 +178,7 @@ class BelongsToMany extends BelongsToManyBase
          *     });
          *
          */
-        if ($this->parent->fireEvent('model.relation.beforeDetach', [$this->relationName, $attachedIDList], true)) {
+        if ($this->parent->fireEvent('model.relation.beforeDetach', [$this->relationName, $attachedIDList], true) === false) {
             return;
         }
 

--- a/src/Database/Relations/BelongsToMany.php
+++ b/src/Database/Relations/BelongsToMany.php
@@ -101,6 +101,39 @@ class BelongsToMany extends BelongsToManyBase
     }
 
     /**
+     * @param mixed $id
+     * @param array $attributes
+     * @param bool  $touch
+     */
+    public function attach($id, array $attributes = [], $touch = true)
+    {
+        $arInsertData = $this->formatAttachRecords($this->parseIds($id), $attributes);
+
+        // Here we will insert the attachment records into the pivot table. Once we have
+        // inserted the records, we will touch the relationships if necessary and the
+        // function will return. We can parse the IDs before inserting the records.
+        $this->newPivotStatement()->insert($arInsertData);
+
+        if ($touch) {
+            $this->touchIfTouching();
+        }
+
+        $this->parent->fireEvent('relation.afterAttach', [$this->relationName, array_pluck($arInsertData, $this->relatedPivotKey), $arInsertData]);
+    }
+
+    /**
+     * @param null $ids
+     * @param bool $touch
+     * @return int|void
+     */
+    public function detach($ids = null, $touch = true)
+    {
+        parent::detach($ids, $touch);
+
+        $this->parent->fireEvent('relation.afterDetach', [$this->relationName, $this->parseIds($ids)]);
+    }
+
+    /**
      * Adds a model to this relationship type.
      */
     public function add(Model $model, $sessionKey = null, $pivotData = [])

--- a/src/Database/Relations/BelongsToMany.php
+++ b/src/Database/Relations/BelongsToMany.php
@@ -116,7 +116,7 @@ class BelongsToMany extends BelongsToManyBase
          *
          * Example usage:
          *
-         *     $model->bindEvent('model.relation.beforeAttach', function ($relationName, $elementIDList, $insertData) use (\October\Rain\Database\Model $model) {
+         *     $model->bindEvent('model.relation.beforeAttach', function (string $relationName, array $elementIDList, array $insertData) use (\October\Rain\Database\Model $model) {
          *         if (!$model->isRelationValid($elementIDList)) {
          *             throw new \Exception("Invalid relation!");
          *             return false;
@@ -148,7 +148,7 @@ class BelongsToMany extends BelongsToManyBase
          *
          * Example usage:
          *
-         *     $model->bindEvent('model.relation.afterAttach', function ($relationName, $elementIDList, $insertData) use (\October\Rain\Database\Model $model) {
+         *     $model->bindEvent('model.relation.afterAttach', function (string $relationName, array $elementIDList, array $insertData) use (\October\Rain\Database\Model $model) {
          *         \Log::info("New relation {$relationName} was created", $elementIDList);
          *     });
          *
@@ -171,7 +171,7 @@ class BelongsToMany extends BelongsToManyBase
          *
          * Example usage:
          *
-         *     $model->bindEvent('model.relation.beforeDetach', function ($relationName, $elementIDList) use (\October\Rain\Database\Model $model) {
+         *     $model->bindEvent('model.relation.beforeDetach', function (string $relationName, array $elementIDList) use (\October\Rain\Database\Model $model) {
          *         if (!$model->isRelationValid($elementIDList)) {
          *             throw new \Exception("Invalid relation!");
          *             return false;
@@ -196,7 +196,7 @@ class BelongsToMany extends BelongsToManyBase
          *
          * Example usage:
          *
-         *     $model->bindEvent('model.relation.afterDetach', function ($relationName, $elementIDList) use (\October\Rain\Database\Model $model) {
+         *     $model->bindEvent('model.relation.afterDetach', function (string $relationName, array $elementIDList) use (\October\Rain\Database\Model $model) {
          *         \Log::info("Relation {$relationName} was removed", $elementIDList);
          *     });
          *

--- a/src/Database/Relations/BelongsToMany.php
+++ b/src/Database/Relations/BelongsToMany.php
@@ -108,7 +108,7 @@ class BelongsToMany extends BelongsToManyBase
     public function attach($id, array $attributes = [], $touch = true)
     {
         $insertData = $this->formatAttachRecords($this->parseIds($id), $attributes);
-        $elementIDList = array_pluck($insertData, $this->relatedPivotKey);
+        $attachedIDList = array_pluck($insertData, $this->relatedPivotKey);
 
         /**
          * @event model.relation.beforeAttach
@@ -116,21 +116,16 @@ class BelongsToMany extends BelongsToManyBase
          *
          * Example usage:
          *
-         *     $model->bindEvent('model.relation.beforeAttach', function (string $relationName, array $elementIDList, array $insertData) use (\October\Rain\Database\Model $model) {
-         *         if (!$model->isRelationValid($elementIDList)) {
+         *     $model->bindEvent('model.relation.beforeAttach', function (string $relationName, array $attachedIDList, array $insertData) use (\October\Rain\Database\Model $model) {
+         *         if (!$model->isRelationValid($attachedIDList)) {
          *             throw new \Exception("Invalid relation!");
          *             return false;
          *         }
          *     });
          *
          */
-        $eventDataList = $this->parent->fireEvent('model.relation.beforeAttach', [$this->relationName, $elementIDList, $insertData]);
-        if (!empty($eventDataList)) {
-            foreach ($eventDataList as $eventData) {
-                if ($eventData === false) {
-                    return;
-                }
-            }
+        if ($this->parent->fireEvent('model.relation.beforeAttach', [$this->relationName, $attachedIDList, $insertData], true)) {
+            return;
         }
 
         // Here we will insert the attachment records into the pivot table. Once we have
@@ -148,12 +143,12 @@ class BelongsToMany extends BelongsToManyBase
          *
          * Example usage:
          *
-         *     $model->bindEvent('model.relation.afterAttach', function (string $relationName, array $elementIDList, array $insertData) use (\October\Rain\Database\Model $model) {
-         *         \Log::info("New relation {$relationName} was created", $elementIDList);
+         *     $model->bindEvent('model.relation.afterAttach', function (string $relationName, array $attachedIDList, array $insertData) use (\October\Rain\Database\Model $model) {
+         *         \Log::info("New relation {$relationName} was created", $attachedIDList);
          *     });
          *
          */
-        $this->parent->fireEvent('model.relation.afterAttach', [$this->relationName, $elementIDList, $insertData]);
+        $this->parent->fireEvent('model.relation.afterAttach', [$this->relationName, $attachedIDList, $insertData]);
     }
 
     /**
@@ -163,7 +158,7 @@ class BelongsToMany extends BelongsToManyBase
      */
     public function detach($ids = null, $touch = true)
     {
-        $elementIDList = $this->parseIds($ids);
+        $attachedIDList = $this->parseIds($ids);
 
         /**
          * @event model.relation.beforeDetach
@@ -171,21 +166,16 @@ class BelongsToMany extends BelongsToManyBase
          *
          * Example usage:
          *
-         *     $model->bindEvent('model.relation.beforeDetach', function (string $relationName, array $elementIDList) use (\October\Rain\Database\Model $model) {
-         *         if (!$model->isRelationValid($elementIDList)) {
+         *     $model->bindEvent('model.relation.beforeDetach', function (string $relationName, array $attachedIDList) use (\October\Rain\Database\Model $model) {
+         *         if (!$model->isRelationValid($attachedIDList)) {
          *             throw new \Exception("Invalid relation!");
          *             return false;
          *         }
          *     });
          *
          */
-        $eventDataList = $this->parent->fireEvent('model.relation.beforeDetach', [$this->relationName, $elementIDList]);
-        if (!empty($eventDataList)) {
-            foreach ($eventDataList as $eventData) {
-                if ($eventData === false) {
-                    return;
-                }
-            }
+        if ($this->parent->fireEvent('model.relation.beforeDetach', [$this->relationName, $attachedIDList], true)) {
+            return;
         }
 
         parent::detach($ids, $touch);
@@ -196,12 +186,12 @@ class BelongsToMany extends BelongsToManyBase
          *
          * Example usage:
          *
-         *     $model->bindEvent('model.relation.afterDetach', function (string $relationName, array $elementIDList) use (\October\Rain\Database\Model $model) {
-         *         \Log::info("Relation {$relationName} was removed", $elementIDList);
+         *     $model->bindEvent('model.relation.afterDetach', function (string $relationName, array $attachedIDList) use (\October\Rain\Database\Model $model) {
+         *         \Log::info("Relation {$relationName} was removed", $attachedIDList);
          *     });
          *
          */
-        $this->parent->fireEvent('model.relation.afterDetach', [$this->relationName, $elementIDList]);
+        $this->parent->fireEvent('model.relation.afterDetach', [$this->relationName, $attachedIDList]);
     }
 
     /**


### PR DESCRIPTION
Related [issue](https://github.com/octobercms/october/issues/3675).
I add new events for BelongsToMany relation
  * **relation.afterAttach**
  * **relation.afterDetach**
Usage example:
```php
Product::extend(function ($obModel) {
    $obModel->bindEvent('relation.afterAttach', function ($sRelationName, $arElementIDList, $arInsertData) {
        //$sRelationName == 'category'
        //$arElementIDList == [1,3,15]
        //$arInsertData = [['product_id' => 10, 'category_id' => 1],['product_id' => 10, 'category_id' => 3],['product_id' => 10, 'category_id' => 15, 'pivot_field' => 'test']];
    });
    $obModel->bindEvent('relation.afterDetach', function ($sRelationName, $arElementIDList) {
        //$sRelationName == 'category'
        //$arElementIDList == [1,3,15]
    });
});
```
