### PR TITLE
Validation of encrypted values fails incorrectly

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -217,7 +217,15 @@ trait Validation
              * only if they are part of the data being validated.
              */
             if (method_exists($this, 'getEncryptableAttributes')) {
-                $cleanAttributes = array_diff_key($data, array_flip($this->getEncryptableAttributes()));
+                $encryptableAttributes = $this->getEncryptableAttributes();
+                $cleanAttributes = array_diff_key($data, array_flip($encryptableAttributes));
+
+                foreach ($encryptableAttributes as $attribute) {
+                    if (isset($data[$attribute])) {
+                        $this->makeEncryptableValue($attribute, $this->getEncryptableValue($attribute));
+                    }
+                }
+
                 $encryptedAttributes = array_intersect_key($this->getOriginalEncryptableValues(), $data);
                 $data = array_merge($cleanAttributes, $encryptedAttributes);
             }


### PR DESCRIPTION
`getOriginalEncryptableValues()` called in the Validation trait will only return values that have passed through `makeEncryptableValue()` which in turn adds them to the `Encryptable::$originalEncryptableValues` array property . 

When updating an encrypted model's values, only the attributes passed in to update will run through `makeEncryptableValue` which will remove any other encrypted values on the following line:

`$encryptedAttributes = array_intersect_key($this->getOriginalEncryptableValues(), $data);`

**An example scenario illustrating the bug**

```php
// Model with encrytable & validation trait
public $rules = [
    'birthday' => 'required',
    'phone' => 'required',
];

protected $encryptable = [
    'birthday',
    'phone'
];

// Create instance
$model = new Model;
$model->birthday = '01/01/1970';
$model->phone = '0123456789';
$model->save();

// Update instance
$model->update(['phone' => '9876543210']);
// October/Rain/Database/ModelException with message 'The birthday field is required.'
```
