### PR TITLE
Correcting file extension checking in Attach\File, adding the ability to upload a file by URL

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -2,6 +2,7 @@
 
 use Storage;
 use File as FileHelper;
+use October\Rain\Network\Http;
 use October\Rain\Database\Model;
 use October\Rain\Database\Attach\FileException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -146,10 +147,10 @@ class File extends Model
 
     /**
      * Creates a file object from url
-     * @param $url string Filename
+     * @param $url string URL
      * @return $this
      */
-    public function fromLink($url)
+    public function fromUrl($url)
     {
         if ($url === null) {
             return;

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -152,10 +152,6 @@ class File extends Model
      */
     public function fromUrl($url)
     {
-        if ($url === null) {
-            return;
-        }
-
         $data = Http::get($url);
 
         if ($data->code != 200) {

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -193,6 +193,41 @@ class File extends Model
     {
         $this->data = $value;
     }
+    
+    /**
+     * Helper attribute for get image width.
+     * @return string
+     */
+    public function getWidthAttribute()
+    {
+        if ($this->isImage()) {
+            $dimensions = $this->getImageDimensions();
+            
+            return $dimensions[0];
+        }
+    }
+
+    /**
+     * Helper attribute for get image height.
+     * @return string
+     */
+    public function getHeightAttribute()
+    {
+        if ($this->isImage()) {
+            $dimensions = $this->getImageDimensions();
+            
+            return $dimensions[1];
+        }
+    }
+
+    /**
+     * Helper attribute for file size in human format.
+     * @return string
+     */
+    public function getSizeAttribute()
+    {
+        return $this->sizeToString();
+    }
 
     //
     // Raw output
@@ -410,6 +445,15 @@ class File extends Model
     public function isImage()
     {
         return in_array(strtolower($this->getExtension()), static::$imageExtensions);
+    }
+
+    /**
+     * Get image dimensions
+     * @return array|bool
+     */
+    protected function getImageDimensions()
+    {
+        return getimagesize($this->getLocalPath());
     }
 
     /**

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -583,7 +583,7 @@ class File extends Model
         $ext = strtolower($this->getExtension());
         $name = str_replace('.', '', uniqid(null, true));
 
-        return $this->disk_name = $ext !== null ? $name.'.'.$ext : $name;
+        return $this->disk_name = !empty($ext) ? $name.'.'.$ext : $name;
     }
 
     /**

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -144,6 +144,28 @@ class File extends Model
         return $file;
     }
 
+    /**
+     * Creates a file object from url
+     * @param $url string Filename
+     * @return $this
+     */
+    public function fromLink($url)
+    {
+        if ($url === null) {
+            return;
+        }
+
+        $data = Http::get($url);
+
+        if ($data->code != 200) {
+            return;
+        }
+
+        $filename = FileHelper::basename($url);
+
+        return $this->fromData($data, $filename);
+    }
+
     //
     // Attribute mutators
     //

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -148,17 +148,20 @@ class File extends Model
     /**
      * Creates a file object from url
      * @param $url string URL
+     * @param $filename string Filename
      * @return $this
      */
-    public function fromUrl($url)
+    public function fromUrl($url, $filename = null)
     {
         $data = Http::get($url);
 
         if ($data->code != 200) {
-            throw new Exception(sprintf('Error getting file "%s", error code %d', $data->url, $data->code));
+            throw new Exception(sprintf('Error getting file "%s", error code: %d', $data->url, $data->code));
         }
 
-        $filename = FileHelper::basename($url);
+        if (empty($filename)) {
+            $filename = FileHelper::basename($url);
+        }
 
         return $this->fromData($data, $filename);
     }

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -159,7 +159,7 @@ class File extends Model
         $data = Http::get($url);
 
         if ($data->code != 200) {
-            return;
+            throw new Exception(sprintf('Error getting file "%s", error code %d', $data->url, $data->code));
         }
 
         $filename = FileHelper::basename($url);


### PR DESCRIPTION
`pathinfo() !== null` will always return `true`, because if no extension is specified, this method will return an empty string: `""`

This can be verified using the following code:
```php
$path_parts = pathinfo('/path/emptyextension.php', PATHINFO_EXTENSION);
var_dump($path_parts);

$path_parts = pathinfo('/path/noextension', PATHINFO_EXTENSION);
var_dump($path_parts);
```

Added the ability to upload files to the site by link.

To upload a file to a storage and attach to a model - you can use the following code:
```php
$file = new \System\Models\File;
$file->fromLink('https://..../file.jpg');
$user->avatar()->add($file);
```