### PR TITLE
Prevent NestedTree generating onSave event for children

### DIFF
--- a/src/Database/Traits/NestedTree.php
+++ b/src/Database/Traits/NestedTree.php
@@ -111,7 +111,6 @@ trait NestedTree
 
             $model->bindEvent('model.afterSave', function() use ($model) {
                 $model->moveToNewParent();
-                $model->setDepth();
             });
 
             $model->bindEvent('model.beforeDelete', function() use ($model) {
@@ -906,7 +905,7 @@ trait NestedTree
         $this->setDepth();
 
         foreach ($this->newQuery()->allChildren()->get() as $descendant) {
-            $descendant->save();
+            $descendant->setDepth();
         }
 
         $this->reload();


### PR DESCRIPTION
Reordering a NestedTree generates onSave events for child nodes but not on the node being moved which could cause performance issues or unintended consequences of the event being triggered.

This PR keeps the same functionality but doesn't generate the onSave event on child nodes.