### PR TITLE
Fixes incorrect order on listsNested()

### DIFF
--- a/src/Database/Traits/NestedTree.php
+++ b/src/Database/Traits/NestedTree.php
@@ -511,7 +511,7 @@ trait NestedTree
             $columns[] = $key;
         }
 
-        $results = new Collection($query->getQuery()->get($columns));
+        $results = new Collection($query->getQuery()->orderBy($this->getLeftColumnName())->get($columns));
         $values = $results->pluck($columns[1])->all();
         $indentation = $results->pluck($columns[0])->all();
 

--- a/src/Database/Traits/NestedTree.php
+++ b/src/Database/Traits/NestedTree.php
@@ -511,7 +511,7 @@ trait NestedTree
             $columns[] = $key;
         }
 
-        $results = new Collection($query->getQuery()->orderBy($this->getLeftColumnName())->get($columns));
+        $results = new Collection($query->toBase()->get($columns));
         $values = $results->pluck($columns[1])->all();
         $indentation = $results->pluck($columns[0])->all();
 


### PR DESCRIPTION
listsNested should return an indented array of nodes in the correct order to represent the tree but it actually returns the array in index order. This PR adds an order by clause to the query to fix this.