### PR TITLE
Fixes storeNewParent logic

### DIFF
--- a/src/Database/Traits/NestedTree.php
+++ b/src/Database/Traits/NestedTree.php
@@ -74,7 +74,7 @@ trait NestedTree
     /**
      * @var int Indicates if the model should be aligned to new parent.
      */
-    protected $moveToNewParentId = null;
+    protected $moveToNewParentId = false;
 
     /*
      * Constructor
@@ -139,16 +139,15 @@ trait NestedTree
         $parentColumn = $this->getParentColumnName();
         $isDirty = $this->isDirty($parentColumn);
 
-        // Parent is not set or unchanged
-        if (!$isDirty) {
-            $this->moveToNewParentId = false;
-        }
-        // Created as a root node
-        elseif (!$this->exists && !$this->getParentId()) {
-            $this->moveToNewParentId = false;
-        }
-        // Parent has been set
-        else {
+        /**
+         * If the model has just been created and the parent ID is not null
+         * or if the model exists and the parent ID has changed then we
+         * need to move the model in the tree
+         */
+        if (
+            (!$this->exists && $this->getParentId() !== null) ||
+            ($this->exists && $isDirty)
+        ) {
             $this->moveToNewParentId = $this->getParentId();
         }
     }


### PR DESCRIPTION
Under some circumstances the model will think it needs to update its parent when it doesn't causing an exception. This fixes the logic to determine when the model needs to be moved in the tree.

See https://github.com/octobercms/october/issues/3740