### PR TITLE
Add theme and plugin url helper

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -247,7 +247,7 @@ if (!function_exists('plugins_url'))
      */
     function plugins_url($path = '')
     {
-        $base = implode('/', [config('app.url'), config('cms.pluginsPath'));
+        $base = implode('/', [config('app.url'), config('cms.pluginsPath')]);
         
         return url($base . ($path ? '/'.$path : $path));
     }

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -211,8 +211,8 @@ if (!function_exists('themes_url'))
     /**
      * Get the public url to the themes folder.
      *
-     * @param  string  $path
-     * @return string
+     * @param  string  $path A relative path to a file in the themes directory
+     * @return string the full public url(http://example.com/themes/theme/file.txt) to the file in the themes directory.
      */
     function themes_url($path = '')
     {
@@ -226,8 +226,8 @@ if (!function_exists('theme_url'))
     /**
      * Get the public url to the active theme folder.
      *
-     * @param  string  $path A relative path a file in the template directory
-     * @return string url to the file in the themes folder
+     * @param  string  $path A relative path to a file in the template directory
+     * @return string the full public url(http://example.com/themes/theme/file.txt) to the file in the active theme directory.
      */
     function theme_url($path = '')
     {
@@ -241,11 +241,11 @@ if (!function_exists('plugin_url'))
 {
     /**
      * Get the public url to a plugin folder.
-     * plugin_url($this, 'assets/js/script.js');
+     * plugin_url('assets/js/script.js'); plugin_url('assets/js/scripts.js', $someComponent);
      * @param  string  $path A relative path a file in the template directory
      * @param object|string $class An object from a plugin namespace or full
      * class name with namespace. When not provided it will try to guess the calling object.
-     * @return string url to the file in the themes folder
+     * @return string the full public url(http://example.com/plugin/author/plugin/file.txt) to the file in the calling plugin folder 
      */
     function plugin_url($path = '', $class = null)
     {

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -237,45 +237,17 @@ if (!function_exists('theme_url'))
     }
 }
 
-if (!function_exists('plugin_url'))
+if (!function_exists('plugins_url'))
 {
     /**
-     * Get the public url to a plugin folder.
-     * plugin_url('assets/js/script.js'); plugin_url('assets/js/scripts.js', $someComponent);
-     * @param  string  $path A relative path a file in the template directory
-     * @param object|string $class An object from a plugin namespace or full
-     * class name with namespace. When not provided it will try to guess the calling object.
-     * @return string the full public url(http://example.com/plugin/author/plugin/file.txt) to the file in the calling plugin folder 
+     * Get the public url to the plugins folder.
+     * plugin_url('assets/js/script.js'); 
+     * @param  string  $path A relative path a file in the plugins directory
+     * @return string the full public url(http://example.com/plugin/path/to/file.txt) to the file in the plugins directory
      */
-    function plugin_url($path = '', $class = null)
+    function plugins_url($path = '')
     {
-        if(is_object($class)) {
-            $class = get_class($class);
-        }
-        
-        if(is_null($class)) {
-            $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
-            if(count($backtrace) === 2 && array_key_exists('object', $backtrace[1])) {
-                $class = get_class($backtrace[1]['object']);
-            }
-            else {
-                throw new \InvalidArgumentException('plugin_url() called without a class from plugin namespace');
-            }
-        }
-        
-        if(strpos($class,'\\') === 0) {
-            $class = substr($class, 1);
-        }
-        
-        $sliced = array_slice(explode('\\', strtolower($class)), 0, 2);
-        
-        if(count($sliced) < 2) {
-            throw new InvalidArgumentException('Class '.$class.' is not from a plugin namespace. Please provide a class or object from a plugin namespace');
-        }
-        
-        list($author, $plugin) = $sliced;
-        
-        $base = implode('/', [config('app.url'), config('cms.pluginsPath'), $author, $plugin]);
+        $base = implode('/', [config('app.url'), config('cms.pluginsPath'));
         
         return url($base . ($path ? '/'.$path : $path));
     }

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -206,6 +206,81 @@ if (!function_exists('themes_path'))
     }
 }
 
+if (!function_exists('themes_url'))
+{
+    /**
+     * Get the public url to the themes folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function themes_url($path = '')
+    {
+        $base = implode('/', [config('app.url'), config('cms.themesPath')]);
+        return url($base . ($path ? '/'.$path : $path));
+    }
+}
+
+if (!function_exists('theme_url'))
+{
+    /**
+     * Get the public url to the active theme folder.
+     *
+     * @param  string  $path A relative path a file in the template directory
+     * @return string url to the file in the themes folder
+     */
+    function theme_url($path = '')
+    {
+        $base = implode('/', [config('app.url'), config('cms.themesPath'), config('cms.activeTheme')]);
+        
+        return url($base . ($path ? '/'.$path : $path));
+    }
+}
+
+if (!function_exists('plugin_url'))
+{
+    /**
+     * Get the public url to a plugin folder.
+     * plugin_url($this, 'assets/js/script.js');
+     * @param  string  $path A relative path a file in the template directory
+     * @param object|string $class An object from a plugin namespace or full
+     * class name with namespace. When not provided it will try to guess the calling object.
+     * @return string url to the file in the themes folder
+     */
+    function plugin_url($path = '', $class = null)
+    {
+        if(is_object($class)) {
+            $class = get_class($class);
+        }
+        
+        if(is_null($class)) {
+            $backtrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
+            if(count($backtrace) === 2 && array_key_exists('object', $backtrace[1])) {
+                $class = get_class($backtrace[1]['object']);
+            }
+            else {
+                throw new \InvalidArgumentException('plugin_url() called without a class from plugin namespace');
+            }
+        }
+        
+        if(strpos($class,'\\') === 0) {
+            $class = substr($class, 1);
+        }
+        
+        $sliced = array_slice(explode('\\', strtolower($class)), 0, 2);
+        
+        if(count($sliced) < 2) {
+            throw new InvalidArgumentException('Class '.$class.' is not from a plugin namespace. Please provide a class or object from a plugin namespace');
+        }
+        
+        list($author, $plugin) = $sliced;
+        
+        $base = implode('/', [config('app.url'), config('cms.pluginsPath'), $author, $plugin]);
+        
+        return url($base . ($path ? '/'.$path : $path));
+    }
+}
+
 if (!function_exists('temp_path'))
 {
     /**


### PR DESCRIPTION
As requested by @LukeTowers on https://github.com/octobercms/october/pull/3794#issuecomment-422817893 a few new helper functions.

`themes_url()` will point to the base themes directory

`theme_url()` will point to the current active theme directory

`plugin_url()` will point to the current calling plugin directory. When called from class that's not actually part of a plugin things will go awry but let's assume people will mainly call it either in co-junction with a plugin class like a model or component or controller, or from those. But if someone wishes to use a screwdriver to hammer in a nail, they're welcome to try.

All these functions can be called with a path argument to a file.

I chose fort he debug_backtrace support in plugin_url because the cost is neglible and allows for easy use.
