### PR TITLE
Update MediaLibrary reference

### DIFF
--- a/src/Parse/Syntax/Parser.php
+++ b/src/Parse/Syntax/Parser.php
@@ -43,7 +43,7 @@ class Parser
 
             $textFilters = [
                 'md' => ['Markdown', 'parse'],
-                'media' => ['Cms\Classes\MediaLibrary', 'url']
+                'media' => ['System\Classes\MediaLibrary', 'url']
             ];
 
             $this->textParser = new TextParser(['filters' => $textFilters]);


### PR DESCRIPTION
My log is full of deprecation warnings:

![image](https://user-images.githubusercontent.com/6329543/46795410-6aed2300-cd4a-11e8-9f93-ea8b25bcc9e0.png)

This is the only reference to the Cms\Classes\MediaLibrary I could find, so I suspect this is the reason.