### PR TITLE
Flush entire session on logout, not just auth key

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -510,7 +510,7 @@ class Manager
 
         $this->user = null;
 
-        Session::forget($this->sessionKey);
+        Session::flush();
         Cookie::queue(Cookie::forget($this->sessionKey));
     }
 


### PR DESCRIPTION
This brings the logout logic more in line with Laravel (see https://github.com/laravel/framework/blob/9f313ce9bb5ad49a06ae78d33fbdd1c92a0e21f6/src/Illuminate/Session/Middleware/AuthenticateSession.php#L92). This also fixes an issue where if you login to a user account, change the locale, logout, login to different user, change locale to different locale, logout, then login to the original user account; the locale from the second user account will be applied.