### PR TITLE
Add "order by is_banned desc" to the throttle query

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -287,6 +287,7 @@ class Manager
 
         $model = $this->createThrottleModel();
         $query = $model->where('user_id', '=', $userId);
+        $query = $query->orderBy('is_banned', 'DESC')->orderBy('id', 'DESC');
 
         if ($ipAddress) {
             $query->where(function($query) use ($ipAddress) {


### PR DESCRIPTION
Hello.

There are a problem: when a banned user trying to authorize, provided that the user has already logged in before, the user is not considered banned, cause only the first sample line is taken for verification.

An example of the table:

| id | user_id | ip_address | attempts | last_attempt_at | is_suspended | suspended_at | is_banned | banned_at |
|----|---------|------------|----------|-----------------|--------------|--------------|-----------|-----------|
| 1  | 3       | 172.30.0.1 | 0        | NULL            | 0            | NULL         | 0         | NULL      |
| 2  | 3       | NULL       | 0        | NULL            | 0            | NULL         | 1         | NULL      |


Query string that is now:

```sql
SELECT * FROM backend_user_throttle WHERE user_id = 3 AND (ip_address == '172.30.0.1' OR ip_address IS NULL) LIMIT 1
```

| id | user_id | ip_address | attempts | last_attempt_at | is_suspended | suspended_at | is_banned | banned_at |
|----|---------|------------|----------|-----------------|--------------|--------------|-----------|-----------|
| 1  | 3       | 172.30.0.1 | 0        | NULL            | 0            | NULL         | 0         | NULL      |


Query string in this pull request:

```sql
SELECT * FROM backend_user_throttle WHERE user_id = 3 AND (ip_address == '172.30.0.1' OR ip_address IS NULL) ORDER BY is_banned DESC, id DESC LIMIT 1
```

| id | user_id | ip_address | attempts | last_attempt_at | is_suspended | suspended_at | is_banned | banned_at |
|----|---------|------------|----------|-----------------|--------------|--------------|-----------|-----------|
| 2  | 3       | NULL       | 0        | NULL            | 0            | NULL         | 1         | NULL      |