### PR TITLE
In Mailer::queue is callback optional

### DIFF
--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -73,8 +73,10 @@ class Mailer extends MailerBase
             $this->addContent($message, $view, $plain, $raw, $data);
         }
 
-        call_user_func($callback, $message);
-
+        if ($callback !== null) {
+            call_user_func($callback, $message);
+        }
+        
         if (isset($this->to['address'])) {
             $this->setGlobalTo($message);
         }
@@ -265,7 +267,9 @@ class Mailer extends MailerBase
 
         $mailable->view($view)->withSerializedData($data);
 
-        call_user_func($callback, $mailable);
+        if ($callback !== null) {
+            call_user_func($callback, $mailable);
+        }
 
         return $mailable;
     }


### PR DESCRIPTION
In Mailer::queue is $callback optional (`public function queue($view, $data = null, $callback = null, $queue = null)...`) so `buildQueueMailable` have to reflect this. And as well `send` method.