### PR TITLE
Travis CI config and a fix for events in Translation component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
+
+sudo: false
+
+install:
+  - composer self-update
+  - travis_retry composer install --no-interaction --prefer-source
+
+before_script: git reset --hard HEAD
+
+script: vendor/bin/phpunit ./tests

--- a/src/Foundation/Bootstrap/LoadTranslation.php
+++ b/src/Foundation/Bootstrap/LoadTranslation.php
@@ -27,7 +27,7 @@ class LoadTranslation
             $locale = $app['config']['app.locale'];
 
             $trans = new Translator($loader, $locale);
-
+            $trans->setEventDispatcher($app['events']);
             $trans->setFallback($app['config']['app.fallback_locale']);
 
             return $trans;

--- a/src/Translation/TranslationServiceProvider.php
+++ b/src/Translation/TranslationServiceProvider.php
@@ -28,7 +28,7 @@ class TranslationServiceProvider extends ServiceProvider
             $locale = $app['config']['app.locale'];
 
             $trans = new Translator($loader, $locale);
-
+            $trans->setEventDispatcher($app['events']);
             $trans->setFallback($app['config']['app.fallback_locale']);
 
             return $trans;

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -1,6 +1,6 @@
 <?php namespace October\Rain\Translation;
 
-use Event;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
 use Symfony\Component\Translation\MessageSelector;
 use Illuminate\Contracts\Translation\Translator as TranslatorContract;
@@ -44,6 +44,13 @@ class Translator implements TranslatorContract
      * @var array
      */
     protected $loaded = [];
+
+    /**
+     * The event dispatcher instance.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher|\October\Rain\Events\Dispatcher
+     */
+    protected $events;
 
     /**
      * Create a new translator instance.
@@ -93,7 +100,8 @@ class Translator implements TranslatorContract
          *     });
          *
          */
-        if ($line = Event::fire('translator.beforeResolve', [$key, $replace, $locale], true)) {
+        if (isset($this->events) &&
+            ($line = $this->events->fire('translator.beforeResolve', [$key, $replace, $locale], true))) {
             return $line;
         }
 
@@ -406,4 +414,14 @@ class Translator implements TranslatorContract
         $this->fallback = $fallback;
     }
 
+    /**
+     * Set the event dispatcher instance.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
+     * @return void
+     */
+    public function setEventDispatcher(Dispatcher $events)
+    {
+        $this->events = $events;
+    }
 }

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -1,19 +1,44 @@
 <?php
 
 use Illuminate\Filesystem\Filesystem;
+use October\Rain\Events\Dispatcher;
 use October\Rain\Translation\FileLoader;
 use October\Rain\Translation\Translator;
 
 class TranslatorTest extends TestCase
 {
-    public function testSimilarWordsParsing()
+    /**
+     * @var Translator
+     */
+    private $translator;
+
+    public function setUp()
     {
+        parent::setUp();
+
         $path       = __DIR__ . '/../fixtures/lang';
         $fileLoader = new FileLoader(new Filesystem(), $path);
         $translator = new Translator($fileLoader, 'en');
+        $this->translator = $translator;
+    }
 
+    public function testSimilarWordsParsing()
+    {
         $this->assertEquals('Displayed records: 1-100 of 10',
-            $translator->get('lang.test.pagination', ['from' => 1, 'to' => 100, 'total' => 10])
+            $this->translator->get('lang.test.pagination', ['from' => 1, 'to' => 100, 'total' => 10])
         );
+    }
+
+    public function testOverrideWithBeforeResolveEvent()
+    {
+        $eventsDispatcher = $this->createMock(Dispatcher::class);
+        $eventsDispatcher
+            ->expects($this->exactly(2))
+            ->method('fire')
+            ->will($this->onConsecutiveCalls('Hello Override!', null));
+        $this->translator->setEventDispatcher($eventsDispatcher);
+
+        $this->assertEquals('Hello Override!', $this->translator->get('lang.test.hello_override'));
+        $this->assertEquals('Hello October!', $this->translator->get('lang.test.hello_october'));
     }
 }

--- a/tests/fixtures/lang/en/lang.php
+++ b/tests/fixtures/lang/en/lang.php
@@ -2,5 +2,6 @@
 return [
     'test' => [
         'pagination' => 'Displayed records: :from-:to of :total',
+        'hello_october' => 'Hello October!'
     ],
 ];


### PR DESCRIPTION
@LukeTowers Hey, here's the Travis CI setup we talked about in PR octobercms/library#359

Before it's merged to `develop`, you (or someone with access) should activate Travis for the repo `octobercms/library` at https://travis-ci.org/octobercms/library. After merge Travis should pick up the changes and start the build automatically.

Also, tests were failing on current develop version so I've included a fix for the Translation component. Before it depended on the `Event` facade, now it gets the event dispatcher injected with `setEventDispatcher`.