### PR TITLE
Allow optional wildcard parameters

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -510,7 +510,7 @@ class Manager
 
         $this->user = null;
 
-        Session::forget($this->sessionKey);
+        Session::flush();
         Cookie::queue(Cookie::forget($this->sessionKey));
     }
 

--- a/src/Database/Builder.php
+++ b/src/Database/Builder.php
@@ -126,7 +126,7 @@ class Builder extends BuilderModel
         $total = $this->toBase()->getCountForPagination();
         $this->forPage((int) $currentPage, (int) $perPage);
 
-        return new LengthAwarePaginator($this->get($columns), $total, $perPage, $currentPage, [
+        return $this->paginator($this->get($columns), $total, $perPage, $currentPage, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName
         ]);
@@ -157,7 +157,7 @@ class Builder extends BuilderModel
 
         $this->skip(($currentPage - 1) * $perPage)->take($perPage + 1);
 
-        return new Paginator($this->get($columns), $perPage, $currentPage, [
+        return $this->simplePaginator($this->get($columns), $perPage, $currentPage, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName
         ]);

--- a/src/Events/Dispatcher.php
+++ b/src/Events/Dispatcher.php
@@ -416,7 +416,7 @@ class Dispatcher implements DispatcherContract
             if (method_exists($class, 'queue')) {
                 $this->callQueueMethodOnHandler($class, $method, $arguments);
             } else {
-                $this->resolveQueue()->push('Illuminate\Events\CallQueuedHandler@call', [
+                $this->resolveQueue()->push('October\Rain\Events\CallQueuedHandler@call', [
                     'class' => $class, 'method' => $method, 'data' => serialize($arguments),
                 ]);
             }
@@ -448,7 +448,7 @@ class Dispatcher implements DispatcherContract
     {
         $handler = (new ReflectionClass($class))->newInstanceWithoutConstructor();
 
-        $handler->queue($this->resolveQueue(), 'Illuminate\Events\CallQueuedHandler@call', [
+        $handler->queue($this->resolveQueue(), 'October\Rain\Events\CallQueuedHandler@call', [
             'class' => $class, 'method' => $method, 'data' => serialize($arguments),
         ]);
     }

--- a/src/Halcyon/Datasource/DatasourceInterface.php
+++ b/src/Halcyon/Datasource/DatasourceInterface.php
@@ -40,9 +40,11 @@ interface DatasourceInterface
      * @param  string  $fileName
      * @param  string  $extension
      * @param  array   $content
+     * @param  string  $oldFileName Defaults to null
+     * @param  string  $oldExtension Defaults to null
      * @return int
      */
-    public function update($dirName, $fileName, $extension, $content);
+    public function update($dirName, $fileName, $extension, $content, $oldFileName = null, $oldExtension = null);
 
     /**
      * Run a delete statement against the datasource.

--- a/src/Halcyon/Datasource/FileDatasource.php
+++ b/src/Halcyon/Datasource/FileDatasource.php
@@ -32,8 +32,8 @@ class FileDatasource extends Datasource implements DatasourceInterface
     /**
      * Create a new datasource instance.
      *
-     * @param  string   $container
-     * @param  array    $config
+     * @param string $container
+     * @param Filesystem $files
      * @return void
      */
     public function __construct($basePath, Filesystem $files)
@@ -71,7 +71,15 @@ class FileDatasource extends Datasource implements DatasourceInterface
     /**
      * Returns all templates.
      *
-     * @param  string  $dirName
+     * @param string $dirName
+     * @param array $options Array of options, [
+     *                          'columns'    => ['fileName', 'mtime', 'content'], // Only return specific columns
+     *                          'extensions' => ['htm', 'md', 'twig'],            // Extensions to search for
+     *                          'fileMatch'  => '*gr[ae]y',                       // Shell matching pattern to match the filename against using the fnmatch function
+     *                          'orders'     => false                             // Not implemented
+     *                          'limit'      => false                             // Not implemented
+     *                          'offset'     => false                             // Not implemented
+     *                      ];
      * @return array
      */
     public function select($dirName, array $options = [])
@@ -126,7 +134,7 @@ class FileDatasource extends Datasource implements DatasourceInterface
             /*
              * Filter by file name match
              */
-            if ($fileMatch !== null && !fnmatch($fileName, $fileMatch)) {
+            if ($fileMatch !== null && !fnmatch($fileMatch, $fileName)) {
                 $it->next();
                 continue;
             }

--- a/src/Halcyon/Datasource/FileDatasource.php
+++ b/src/Halcyon/Datasource/FileDatasource.php
@@ -32,7 +32,7 @@ class FileDatasource extends Datasource implements DatasourceInterface
     /**
      * Create a new datasource instance.
      *
-     * @param string $container
+     * @param string $basePath
      * @param Filesystem $files
      * @return void
      */
@@ -166,7 +166,7 @@ class FileDatasource extends Datasource implements DatasourceInterface
      *
      * @param  string  $dirName
      * @param  string  $fileName
-     * @param  array   $content
+     * @param  string   $content
      * @return bool
      */
     public function insert($dirName, $fileName, $extension, $content)
@@ -192,7 +192,9 @@ class FileDatasource extends Datasource implements DatasourceInterface
      *
      * @param  string  $dirName
      * @param  string  $fileName
-     * @param  array   $content
+     * @param  string  $content
+     * @param  string  $oldFileName Defaults to null
+     * @param  string  $oldExtension Defaults to null
      * @return int
      */
     public function update($dirName, $fileName, $extension, $content, $oldFileName = null, $oldExtension = null)

--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -73,8 +73,10 @@ class Mailer extends MailerBase
             $this->addContent($message, $view, $plain, $raw, $data);
         }
 
-        call_user_func($callback, $message);
-
+        if ($callback !== null) {
+            call_user_func($callback, $message);
+        }
+        
         if (isset($this->to['address'])) {
             $this->setGlobalTo($message);
         }
@@ -265,7 +267,9 @@ class Mailer extends MailerBase
 
         $mailable->view($view)->withSerializedData($data);
 
-        call_user_func($callback, $mailable);
+        if ($callback !== null) {
+            call_user_func($callback, $mailable);
+        }
 
         return $mailable;
     }

--- a/src/Parse/Syntax/Parser.php
+++ b/src/Parse/Syntax/Parser.php
@@ -43,7 +43,7 @@ class Parser
 
             $textFilters = [
                 'md' => ['Markdown', 'parse'],
-                'media' => ['Cms\Classes\MediaLibrary', 'url']
+                'media' => ['System\Classes\MediaLibrary', 'url']
             ];
 
             $this->textParser = new TextParser(['filters' => $textFilters]);

--- a/src/Router/Helper.php
+++ b/src/Router/Helper.php
@@ -147,6 +147,10 @@ class Helper
         $regexMarkerPos = mb_strpos($name, '|');
 
         if ($wildMarkerPos !== false) {
+            if ($optMarkerPos !== false) {
+                return mb_substr($name, 0, $optMarkerPos);
+            }
+
             return mb_substr($name, 0, $wildMarkerPos);
         }
 
@@ -201,10 +205,14 @@ class Helper
         }
 
         $regexMarkerPos = mb_strpos($segment, '|');
+        $wildMarkerPos = mb_strpos($segment, '*');
         $value = false;
 
         if ($regexMarkerPos !== false) {
             $value = mb_substr($segment, $optMarkerPos+1, $regexMarkerPos-$optMarkerPos-1);
+        }
+        elseif ($wildMarkerPos !== false) {
+            $value = mb_substr($segment, $optMarkerPos+1, $wildMarkerPos-$optMarkerPos-1);
         }
         else {
             $value = mb_substr($segment, $optMarkerPos+1);

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -70,6 +70,27 @@ class Translator implements TranslatorContract
     }
 
     /**
+     * Dynamically set the translation for the given key.
+     *
+     * @param  string $key
+     * @param  string $value
+     * @param  string $locale
+     */
+    public function set($key, $value, $locale = null) {
+        // Ensure that the loaded property is initialized
+        $this->get($key, [], $locale);
+
+        // Parse the key & locale
+        list($namespace, $group, $item) = $this->parseKey($key);
+        $locale = $this->parseLocale($locale)[0];
+
+        // Override the specified key with the provided value
+        $loaded = $this->loaded;
+        array_set($loaded, "$namespace.$group.$locale.$item", $value);
+        $this->loaded = $loaded;
+    }
+
+    /**
      * Get the translation for the given key.
      *
      * @param  string  $key

--- a/tests/Events/DispatcherTest.php
+++ b/tests/Events/DispatcherTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use October\Rain\Events\Dispatcher;
+
+class DispatcherTest extends TestCase
+{
+    /**
+     * @var Dispatcher
+     */
+    private $dispatcher;
+
+    public function setUp()
+    {
+        $this->dispatcher = new Dispatcher();
+    }
+
+    private function buildQueueResolverMock(callable $pushCallback)
+    {
+        $queueResolver = function () use ($pushCallback) {
+            $queue = $this->createMock(Queue::class);
+            $queue->method('push')->will($this->returnCallback($pushCallback));
+            return $queue;
+        };
+        return $queueResolver;
+    }
+
+    public function testCreateClassListener()
+    {
+        $this->dispatcher->setQueueResolver($this->buildQueueResolverMock(function ($job, $data = '', $queue = null) {
+            list($class, $method) = explode('@', $job);
+            $this->assertTrue(class_exists($class), sprintf('Job class %s does not exist', $class));
+        }));
+        $this->dispatcher->createClassListener('MockEventListenerCallable@handle')();
+        $this->dispatcher->createClassListener('MockEventListenerQueueMethod@handle')();
+    }
+}
+
+class MockEventListenerCallable implements ShouldQueue
+{
+    public function handle($event)
+    {
+    }
+}
+
+class MockEventListenerQueueMethod implements ShouldQueue
+{
+    public function handle($event)
+    {
+    }
+
+    public function queue($queue, $job, $data)
+    {
+        $queue->push($job, $data);
+    }
+}


### PR DESCRIPTION
A wildcard parameter can be made optional using the syntax `url = "/blog/:slug?*"`

So this would work:

url/blog
url/blog/category
url/blog/category/subcategory

For using a default value the syntax is `url="/blog/:slug?all*"`

Note: this was already the behaviour when passing a param with ?*, but the parameter was parsed like this:

param name: slug?
value: *

(the optional character wasn't stripped from the parameter name, and the wildcard character was returned as the parameter value)

