### PR TITLE
Allow optional wildcard parameteres

### DIFF
--- a/src/Router/Helper.php
+++ b/src/Router/Helper.php
@@ -147,6 +147,10 @@ class Helper
         $regexMarkerPos = mb_strpos($name, '|');
 
         if ($wildMarkerPos !== false) {
+            if ($optMarkerPos !== false) {
+                return mb_substr($name, 0, $optMarkerPos);
+            }
+
             return mb_substr($name, 0, $wildMarkerPos);
         }
 
@@ -201,10 +205,14 @@ class Helper
         }
 
         $regexMarkerPos = mb_strpos($segment, '|');
+        $wildMarkerPos = mb_strpos($segment, '*');
         $value = false;
 
         if ($regexMarkerPos !== false) {
             $value = mb_substr($segment, $optMarkerPos+1, $regexMarkerPos-$optMarkerPos-1);
+        }
+        elseif ($wildMarkerPos !== false) {
+            $value = mb_substr($segment, $optMarkerPos+1, $wildMarkerPos-$optMarkerPos-1);
         }
         else {
             $value = mb_substr($segment, $optMarkerPos+1);


### PR DESCRIPTION
A wildcard parameter can be made optional using the syntax `url = "/blog/:slug?*"`

So this would work:

url/blog
url/blog/category
url/blog/category/subcategory

For using a default value the syntax is `url="/blog/:slug?all*"`

Note: this was already the behaviour when passing a param with ?*, but the parameter was parsed like this:

param name: slug?
value: *

(the optional character wasn't stripped from the parameter name, and the wildcard character was returned as the parameter value)

