### PR TITLE
Allow validator rule objects

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -369,6 +369,12 @@ trait Validation
              */
             foreach ($ruleParts as $key => $rulePart) {
                 /*
+                 * Allow rule objects
+                 */
+                if (is_object($rulePart)) {
+                    continue;
+                }
+                /*
                  * Remove primary key unique validation rule if the model already exists
                  */
                 if (starts_with($rulePart, 'unique') && $this->exists) {


### PR DESCRIPTION
This PR adds support for object instances in rule definitions:
https://laravel.com/docs/5.5/validation#using-rule-objects

This functionality would be useful because it provides a way of extending the validator in a non-global manner.

### Example Usage
In a model add:
```php
public function beforeValidate()
{
    $this->rules['myField'][] = new \Path\To\ClassExists;
}
```
With example class definition:
```php
<?php

namespace Path\To;

use Illuminate\Contracts\Validation\Rule;

class ClassExists implements Rule
{
    public function passes($attribute, $value)
    {
        return class_exists($value);
    }

    public function message()
    {
        return 'The :attribute class does not exist.';
    }
}
```