### PR TITLE
merge dynamic properties to base attributes

### DIFF
--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -180,6 +180,7 @@ trait ExtendableTrait
 
         if (!property_exists($this, $dynamicName)) {
             $this->{$dynamicName} = $value;
+            $this->purgeable[] = $dynamicName;
         }
 
         $this->extensionData['dynamicProperties'][] = $dynamicName;

--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -180,7 +180,6 @@ trait ExtendableTrait
 
         if (!property_exists($this, $dynamicName)) {
             $this->{$dynamicName} = $value;
-            $this->purgeable[] = $dynamicName;
         }
 
         $this->extensionData['dynamicProperties'][] = $dynamicName;

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -283,6 +283,20 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
     }
 
     /**
+     * Adds an attribute to the purgeable attributes list
+     * @param  array|string|null  $attributes
+     * @return $this
+     */
+    public function addPurgeable($attributes = null)
+    {
+        $attributes = is_array($attributes) ? $attributes : func_get_args();
+
+        $this->purgeable = array_merge($this->purgeable, $attributes);
+
+        return $this;
+    }
+
+    /**
      * The settings is attribute contains everything that should
      * be saved to the settings area.
      * @return array
@@ -798,6 +812,7 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
         // merge dynamic properties to the base attributes
         if ($sync) {
             $attributes = array_merge($this->attributes, $attributes);
+            $this->addPurgeable(array_keys($this->attributes));
         }
 
         $this->attributes = $attributes;

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -796,11 +796,8 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
     public function setRawAttributes(array $attributes, $sync = false)
     {
         // merge dynamic properties to the base attributes
-        if ($sync && is_array($this->attributes)) {
-            foreach ($this->attributes as $attr => $value) {
-                $attributes[$attr] = $value;
-                $this->purgeable[] = $attr;
-            }
+        if ($sync) {
+            $attributes = array_merge($this->attributes, $attributes);
         }
 
         $this->attributes = $attributes;

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -795,6 +795,14 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
      */
     public function setRawAttributes(array $attributes, $sync = false)
     {
+        // merge dynamic properties to the base attributes
+        if ($sync && is_array($this->attributes)) {
+            foreach ($this->attributes as $attr => $value) {
+                $attributes[$attr] = $value;
+                $this->purgeable[] = $attr;
+            }
+        }
+
         $this->attributes = $attributes;
 
         if ($sync) {

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -312,9 +312,11 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
             'code'
         ];
 
+        $dynPropNames = array_keys(array_diff_key($this->getDynamicProperties(), ['purgeable' => 0]));
+
         return array_diff_key(
             $this->attributes,
-            array_flip(array_merge($defaults, $this->purgeable))
+            array_flip(array_merge($defaults, $this->purgeable, $dynPropNames))
         );
     }
 
@@ -812,7 +814,6 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
         // merge dynamic properties to the base attributes
         if ($sync) {
             $attributes = array_merge($this->attributes, $attributes);
-            $this->addPurgeable(array_keys($this->attributes));
         }
 
         $this->attributes = $attributes;

--- a/tests/Halcyon/ModelTest.php
+++ b/tests/Halcyon/ModelTest.php
@@ -332,6 +332,24 @@ ESC;
         $this->assertEquals(['about.htm', 'home.htm'], $files);
     }
 
+    public function testAddDynamicPoperty()
+    {
+        @unlink($targetFile = __DIR__.'/../fixtures/halcyon/themes/theme1/pages/dynamicproperty.htm');
+
+        $page = HalcyonTestPage::create([
+            'fileName' => 'dynamicproperty',
+            'title' => 'Add Dynamic Property',
+            'markup' => '<p>Foo bar!</p>'
+        ]);
+
+        $page->addDynamicProperty('myDynamicProperty', 'myDynamicPropertyValue');
+        $page->save();
+        $page = HalcyonTestPage::find('dynamicproperty');
+        $this->assertNotNull($page);
+        $this->assertArrayNotHasKey('myDynamicProperty', $page->attributes);
+        @unlink($targetFile);
+    }
+
     //
     // House keeping
     //

--- a/tests/Halcyon/ModelTest.php
+++ b/tests/Halcyon/ModelTest.php
@@ -343,6 +343,7 @@ ESC;
         ]);
 
         $page->addDynamicProperty('myDynamicProperty', 'myDynamicPropertyValue');
+        $page->addPurgeable('myDynamicProperty');
         $page->save();
         $page = HalcyonTestPage::find('dynamicproperty');
         $this->assertNotNull($page);

--- a/tests/Halcyon/ModelTest.php
+++ b/tests/Halcyon/ModelTest.php
@@ -343,7 +343,6 @@ ESC;
         ]);
 
         $page->addDynamicProperty('myDynamicProperty', 'myDynamicPropertyValue');
-        $page->addPurgeable('myDynamicProperty');
         $page->save();
         $page = HalcyonTestPage::find('dynamicproperty');
         $this->assertNotNull($page);


### PR DESCRIPTION
This is a fix to make dynamic properties work when extending Halcyon Model based classes (like Cms\Classes\Page).