### PR TITLE
StylesheetMinify.php Fix

### DIFF
--- a/src/Parse/Assetic/StylesheetMinify.php
+++ b/src/Parse/Assetic/StylesheetMinify.php
@@ -26,8 +26,8 @@ class StylesheetMinify implements FilterInterface
      */
     protected function minify($css)
     {
-        // Normalize whitespace - Disabled to improve readability of diffs for compiled assets
-        // $css = preg_replace('/\s+/', ' ', $css);
+        // Normalize whitespace in a smart way
+        $css = preg_replace('/\s{2,}/', ' ', $css);
 
         // Remove spaces before and after comment
         $css = preg_replace('/(\s+)(\/\*(.*?)\*\/)(\s+)/', '$2', $css);
@@ -43,13 +43,16 @@ class StylesheetMinify implements FilterInterface
 
         // Remove space before , ; { } >
         $css = preg_replace('/(,|;|\{|}|>)/', '$1', $css);
+        
+        // Remove newline before } >
+        $css = preg_replace('/(\r\n|\r|\n)(})/', '$2', $css);
 
         // Remove trailing zeros from float numbers preceded by : or a white-space
         // -6.0100em to -6.01em, .0100 to .01, 1.200px to 1.2px
         $css = preg_replace('/((?<!\\\\)\:|\s)(\-?)(\d?\.\d+?)0+([^\d])/S', '$1$2$3$4', $css);
 
         // Strips units if value is 0 (converts 0px to 0)
-        $css = preg_replace('/(:| )(\.?)0(%|em|ex|px|in|cm|mm|pt|pc)/i', '${1}0', $css);
+        $css = preg_replace('/(:| )(\.?)0(em|ex|px|in|cm|mm|pt|pc)/i', '${1}0', $css);
 
         // Shortern 6-character hex color codes to 3-character where possible
         $css = preg_replace('/#([a-f0-9])\\1([a-f0-9])\\2([a-f0-9])\\3/i', '#\1\2\3', $css);


### PR DESCRIPTION
While dealing with the `Tabs issue`, found out that there was a css space issue.

Changes:
- Normalize spaces by removing 2 or more space
- Remove newline character before closing bracket to make it cleaner
- Remove `%` - it bugs for keyframes
 
## Before with the latest changes:
**storm.css**
![old_storm](https://user-images.githubusercontent.com/1053320/51175817-00f19600-18c4-11e9-8283-983c7c9e62c7.png)
**october.css**
![old_october](https://user-images.githubusercontent.com/1053320/51175916-41e9aa80-18c4-11e9-89aa-f05796ff0a5f.png)


## After:
**storm.css**
![new_storm](https://user-images.githubusercontent.com/1053320/51175890-35655200-18c4-11e9-9e06-1e141440607c.png)
**october.css**
![new_october](https://user-images.githubusercontent.com/1053320/51175886-339b8e80-18c4-11e9-9783-744ea53f2e0a.png)

@LukeTowers, could you test this out?

