### PR TITLE
Add get_class_methods() equivalent for extendable classes

### DIFF
--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -276,6 +276,18 @@ trait ExtendableTrait
         );
     }
 
+    /**
+     * Get a list of class methods, extension equivalent of get_class_methods()
+     * @return array
+     */
+    public function getClassMethods()
+    {
+        return array_values(array_unique(array_merge(
+            get_class_methods($this),
+            array_keys($this->extensionData['methods']),
+            array_keys($this->extensionData['dynamicMethods'])
+        )));
+    }
 
     /**
      * Returns all dynamic properties and their values

--- a/tests/Extension/ExtendableTest.php
+++ b/tests/Extension/ExtendableTest.php
@@ -188,6 +188,38 @@ class ExtendableTest extends TestCase
         $this->assertTrue($subject->isClassExtendedWith('ExtendableTest.ExampleBehaviorClass1'));
         $this->assertTrue($subject->isClassExtendedWith('ExtendableTest.ExampleBehaviorClass2'));
     }
+
+    public function testMethodExists()
+    {
+        $subject = new ExtendableTest_ExampleExtendableClass;
+        $this->assertTrue($subject->methodExists('extend'));
+    }
+
+    public function testMethodNotExists()
+    {
+        $subject = new ExtendableTest_ExampleExtendableClass;
+        $this->assertFalse($subject->methodExists('missingFunction'));
+    }
+
+    public function testDynamicMethodExists()
+    {
+        $subject = new ExtendableTest_ExampleExtendableClass;
+        $subject->addDynamicMethod('getFooAnotherWay', 'getFoo', 'ExtendableTest_ExampleBehaviorClass1');
+
+        $this->assertTrue($subject->methodExists('getFooAnotherWay'));
+    }
+
+    public function testGetClassMethods()
+    {
+        $subject = new ExtendableTest_ExampleExtendableClass;
+        $subject->addDynamicMethod('getFooAnotherWay', 'getFoo', 'ExtendableTest_ExampleBehaviorClass1');
+        $methods =  $subject->getClassMethods();
+
+        $this->assertContains('extend', $methods);
+        $this->assertContains('getFoo', $methods);
+        $this->assertContains('getFooAnotherWay', $methods);
+        $this->assertNotContains('missingFunction', $methods);
+    }
 }
 
 //


### PR DESCRIPTION
Adds a function to list all class methods (including those provided by an extension) to a class using the Extendable trait.