### PR TITLE
Change POSTFIELDS back to array

### DIFF
--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -279,7 +279,7 @@ class Http
             $requestDataQuery = http_build_query($this->requestData, '', $this->argumentSeparator);
 
             if (in_array($this->method, [self::METHOD_POST, self::METHOD_PATCH, self::METHOD_PUT])) {
-                curl_setopt($curl, CURLOPT_POSTFIELDS, $requestDataQuery);
+                curl_setopt($curl, CURLOPT_POSTFIELDS, $this->requestData);
             }
             elseif ($this->method == self::METHOD_GET) {
                 curl_setopt($curl, CURLOPT_URL, $this->url . '?' . $requestDataQuery);


### PR DESCRIPTION
In a previous commit, this has been changed to a string to ensure the correct argument separator to be set. However, starting from PHP 5.2.0, this disables us from uploading files, as for files an array argument is required. From the docs:
``If value is an array, the Content-Type header will be set to multipart/form-data. As of PHP 5.2.0, value must be an array if files are passed to this option with the @ prefix. As of PHP 5.5.0, the @ prefix is deprecated and files can be sent using CURLFile.
``

See: http://de2.php.net/manual/en/function.curl-setopt.php