### PR TITLE
Convert array notated fields to dot notation on validation

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -348,6 +348,11 @@ trait Validation
      */
     protected function processValidationRules($rules)
     {
+        /*
+         * Run through field names and convert array notation field names to dot notation
+         */
+        $rules = $this->processRuleFieldNames($rules);
+
         foreach ($rules as $field => $ruleParts) {
             /*
              * Trim empty rules
@@ -389,6 +394,32 @@ trait Validation
         }
 
         return $rules;
+    }
+
+    /**
+     * Processes field names in a rule array.
+     *
+     * Converts any field names using array notation (ie. `field[child]`) into dot notation (ie. `field.child`)
+     *
+     * @param array $rules Rules array
+     * @return array
+     */
+    protected function processRuleFieldNames($rules)
+    {
+        $processed = [];
+
+        foreach ($rules as $field => $ruleParts) {
+            $fieldName = $field;
+
+            if (preg_match_all('/^.*?\[.*?\]/', $fieldName)) {
+                $fieldName = str_replace('[]', '.*', $fieldName);
+                $fieldName = str_replace(['[', ']'], ['.', ''], $fieldName);
+            }
+
+            $processed[$fieldName] = $ruleParts;
+        }
+
+        return $processed;
     }
 
     /**

--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -411,7 +411,7 @@ trait Validation
         foreach ($rules as $field => $ruleParts) {
             $fieldName = $field;
 
-            if (preg_match_all('/^.*?\[.*?\]/', $fieldName)) {
+            if (preg_match('/^.*?\[.*?\]/', $fieldName)) {
                 $fieldName = str_replace('[]', '.*', $fieldName);
                 $fieldName = str_replace(['[', ']'], ['.', ''], $fieldName);
             }

--- a/src/Halcyon/Traits/Validation.php
+++ b/src/Halcyon/Traits/Validation.php
@@ -237,6 +237,11 @@ trait Validation
      */
     protected function processValidationRules($rules)
     {
+        /*
+         * Run through field names and convert array notation field names to dot notation
+         */
+        $rules = $this->processRuleFieldNames($rules);
+
         foreach ($rules as $field => $ruleParts) {
             /*
              * Trim empty rules
@@ -272,6 +277,31 @@ trait Validation
         }
 
         return $rules;
+    }
+
+    /**
+     * Processes field names in a rule array.
+     *
+     * Converts any field names using array notation (ie. `field[child]`) into dot notation (ie. `field.child`)
+     *
+     * @param array $rules Rules array
+     * @return array
+     */
+    protected function processRuleFieldNames($rules)
+    {
+        $processed = [];
+
+        foreach ($rules as $field => $ruleParts) {
+            $fieldName = $field;
+
+            if (preg_match_all('/^.*?\[.*?\]/', $fieldName)) {
+                $fieldName = str_replace(['[', ']'], ['.', ''], $fieldName);
+            }
+
+            $processed[$fieldName] = $ruleParts;
+        }
+
+        return $processed;
     }
 
     /**

--- a/src/Halcyon/Traits/Validation.php
+++ b/src/Halcyon/Traits/Validation.php
@@ -294,7 +294,7 @@ trait Validation
         foreach ($rules as $field => $ruleParts) {
             $fieldName = $field;
 
-            if (preg_match_all('/^.*?\[.*?\]/', $fieldName)) {
+            if (preg_match('/^.*?\[.*?\]/', $fieldName)) {
                 $fieldName = str_replace('[]', '.*', $fieldName);
                 $fieldName = str_replace(['[', ']'], ['.', ''], $fieldName);
             }

--- a/src/Halcyon/Traits/Validation.php
+++ b/src/Halcyon/Traits/Validation.php
@@ -295,6 +295,7 @@ trait Validation
             $fieldName = $field;
 
             if (preg_match_all('/^.*?\[.*?\]/', $fieldName)) {
+                $fieldName = str_replace('[]', '.*', $fieldName);
                 $fieldName = str_replace(['[', ']'], ['.', ''], $fieldName);
             }
 

--- a/tests/Database/Traits/ValidationTest.php
+++ b/tests/Database/Traits/ValidationTest.php
@@ -85,4 +85,32 @@ class ValidationTest extends TestCase
     {
         return 'the_id';
     }
+
+    public function testArrayFieldNames()
+    {
+        $mock = $this->getMockForTrait('October\Rain\Database\Traits\Validation');
+
+        $rules = [
+            'field' => 'required',
+            'field.two' => 'required|boolean',
+            'field[three]' => 'required|date',
+            'field[three][child]' => 'required',
+            'field[four][][name]' => 'required',
+            'field[five' => 'required|string',
+            'field][six' => 'required|string',
+            'field]seven' => 'required|string',
+        ];
+        $rules = self::callProtectedMethod($mock, 'processRuleFieldNames', [$rules]);
+
+        $this->assertEquals([
+            'field' => 'required',
+            'field.two' => 'required|boolean',
+            'field.three' => 'required|date',
+            'field.three.child' => 'required',
+            'field.four.*.name' => 'required',
+            'field[five' => 'required|string',
+            'field][six' => 'required|string',
+            'field]seven' => 'required|string',
+        ], $rules);
+    }
 }

--- a/tests/Halcyon/ValidationTraitTest.php
+++ b/tests/Halcyon/ValidationTraitTest.php
@@ -10,7 +10,10 @@ class ValidationTraitTest extends TestCase
             'field.two' => 'required|boolean',
             'field[three]' => 'required|date',
             'field[three][child]' => 'required',
-            'field[four][][name]' => 'required'
+            'field[four][][name]' => 'required',
+            'field[five' => 'required|string',
+            'field][six' => 'required|string',
+            'field]seven' => 'required|string',
         ];
         $rules = self::callProtectedMethod($mock, 'processRuleFieldNames', [$rules]);
 
@@ -19,7 +22,10 @@ class ValidationTraitTest extends TestCase
             'field.two' => 'required|boolean',
             'field.three' => 'required|date',
             'field.three.child' => 'required',
-            'field.four.*.name' => 'required'
+            'field.four.*.name' => 'required',
+            'field[five' => 'required|string',
+            'field][six' => 'required|string',
+            'field]seven' => 'required|string',
         ], $rules);
     }
 }

--- a/tests/Halcyon/ValidationTraitTest.php
+++ b/tests/Halcyon/ValidationTraitTest.php
@@ -1,0 +1,23 @@
+<?php
+class ValidationTraitTest extends TestCase
+{
+    public function testArrayFieldNames()
+    {
+        $mock = $this->getMockForTrait('October\Rain\Halcyon\Traits\Validation');
+
+        $rules = [
+            'field' => 'required',
+            'field.two' => 'required|boolean',
+            'field[three]' => 'required|date',
+            'field[three][child]' => 'required'
+        ];
+        $rules = self::callProtectedMethod($mock, 'processRuleFieldNames', [$rules]);
+
+        $this->assertEquals([
+            'field' => 'required',
+            'field.two' => 'required|boolean',
+            'field.three' => 'required|date',
+            'field.three.child' => 'required'
+        ], $rules);
+    }
+}

--- a/tests/Halcyon/ValidationTraitTest.php
+++ b/tests/Halcyon/ValidationTraitTest.php
@@ -9,7 +9,8 @@ class ValidationTraitTest extends TestCase
             'field' => 'required',
             'field.two' => 'required|boolean',
             'field[three]' => 'required|date',
-            'field[three][child]' => 'required'
+            'field[three][child]' => 'required',
+            'field[four][][name]' => 'required'
         ];
         $rules = self::callProtectedMethod($mock, 'processRuleFieldNames', [$rules]);
 
@@ -17,7 +18,8 @@ class ValidationTraitTest extends TestCase
             'field' => 'required',
             'field.two' => 'required|boolean',
             'field.three' => 'required|date',
-            'field.three.child' => 'required'
+            'field.three.child' => 'required',
+            'field.four.*.name' => 'required'
         ], $rules);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-class TestCase extends PHPUnit_Framework_TestCase 
+class TestCase extends PHPUnit_Framework_TestCase
 {
     /**
      * Creates the application.
@@ -14,5 +14,14 @@ class TestCase extends PHPUnit_Framework_TestCase
     public function testNothing()
     {
         // Test nothing
+    }
+
+    protected static function callProtectedMethod($object, $name, $params = [])
+    {
+        $className = get_class($object);
+        $class = new ReflectionClass($className);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        return $method->invokeArgs($object, $params);
     }
 }


### PR DESCRIPTION
Allows for fields to be specified in array notation in a rule array. This functionality will convert the field names to dot notation at the time the validation is run, without affecting the original rules array.