### PR TITLE
Add missing svg mimetype

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -67,7 +67,8 @@ class File extends Model
         'jpg'  => 'image/jpeg',
         'jpeg' => 'image/jpeg',
         'webp' => 'image/webp',
-        'pdf'  => 'application/pdf'
+        'pdf'  => 'application/pdf',
+        'svg'  => 'image/svg+xml',
     ];
 
     //


### PR DESCRIPTION
Sometimes some system parse `image/svg` as file and start to download it, using `image/svg+xml` should work as image and it should prevent running js in it.