### PR TITLE
Rewrite config files with env calls

### DIFF
--- a/tests/Config/ConfigWriterTest.php
+++ b/tests/Config/ConfigWriterTest.php
@@ -129,5 +129,17 @@ class ConfigWriterTest extends TestCase
         $this->assertArrayHasKey('database', $result['redis']['default']);
         $this->assertEquals('127.0.0.1', $result['redis']['default']['host']);
         $this->assertEquals(null, $result['redis']['default']['password']);
+
+        /*
+         * Rewrite config with values from env
+         */
+        $contents = $writer->toContent($contents, [
+            'envMethod' => 'default',
+            'nestedEnv.envMethod.envChild' => 'default',
+        ]);
+        $result = eval('?>'.$contents);
+
+        $this->assertEquals('default', $result['envMethod']);
+        $this->assertEquals('default', $result['nestedEnv']['envMethod']['envChild']);
     }
 }

--- a/tests/fixtures/config/sample-config.php
+++ b/tests/fixtures/config/sample-config.php
@@ -25,6 +25,14 @@ return [
 
     'default' => 'mysql',
 
+    'envMethod' => env('___KEY_FOR_ENV___', "unknown fallback value"),
+
+    'nestedEnv' => [
+        'envMethod' => [
+            'envChild' => env('___KEY_FOR_CHILD_ENV___', "unknown fallback child value"),
+        ],
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Application URL


### PR DESCRIPTION
After converting config files to .env files one cannot execute `october:install` anymore as it cannot rewrite config files with env-function calls. Because this leads to invalid php files.

To implement this I had to use a different replace-pattern so I had to be able to match regex and replace patterns.