### PR TITLE
Removed spaces from stubs so str_replace will place correct values

### DIFF
--- a/src/Scaffold/Console/formwidget/javascript.stub
+++ b/src/Scaffold/Console/formwidget/javascript.stub
@@ -1,5 +1,5 @@
 /*
- * This is a sample JavaScript file used by {{ name }}
+ * This is a sample JavaScript file used by {{name}}
  *
  * You can delete this file if you want
  */

--- a/src/Scaffold/Console/formwidget/stylesheet.stub
+++ b/src/Scaffold/Console/formwidget/stylesheet.stub
@@ -1,5 +1,5 @@
 /*
- * This is a sample StyleSheet file used by {{ name }}
+ * This is a sample StyleSheet file used by {{name}}
  *
  * You can delete this file if you want
  */


### PR DESCRIPTION
When creating a formwidget with artisan the generated javascript and stylesheet file will show the line 
`This is a sample JavaScript file used by {{ name }}` 
instead of the actual given name i.e.
`This is a sample JavaScript file used by MyFormWidget`
These changes fix this problem