### PR TITLE
Disable in-memory cache repository in CLI by default

### DIFF
--- a/src/Halcyon/MemoryCacheManager.php
+++ b/src/Halcyon/MemoryCacheManager.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Halcyon;
 
+use App;
 use Config;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Contracts\Cache\Store;
@@ -13,6 +14,11 @@ class MemoryCacheManager extends CacheManager
 
     public static function isEnabled()
     {
-        return !Config::get('cache.disableRequestCache', false);
+        $disabled = Config::get('cache.disableRequestCache', null);
+        if ($disabled === null) {
+            return !App::runningInConsole();
+        }
+
+        return !$disabled;
     }
 }


### PR DESCRIPTION
References octobercms/october#4057.

This implements the true/false/null setting discussed for enabling/disabling the in-memory request-level cache repository, adding the `null` setting that enables the memory cache except when running from the console.