### PR TITLE
Fix count if have bindings and fix for postgress

### DIFF
--- a/src/Database/DataFeed.php
+++ b/src/Database/DataFeed.php
@@ -219,7 +219,7 @@ class DataFeed
 
             $conditionalTagSelect = (Db::connection()->getDriverName() === 'pgsql') ?
                 "CAST('%s' as text) as %s" :
-                "%s as %s";
+                "'%s' as %s";
             $idSelect = sprintf("%s as id", $keyName);
             $tagSelect = sprintf($conditionalTagSelect, $tag, $this->tagVar);
             $sortSelect = sprintf("%s as %s", $sorting, $this->sortVar);

--- a/src/Database/DataFeed.php
+++ b/src/Database/DataFeed.php
@@ -217,11 +217,11 @@ class DataFeed
              * Flush the select, add ID and tag
              */
 
-            $condionalTagSelect = (Db::connection()->getDriverName() === 'pgsql') ?
+            $conditionalTagSelect = (Db::connection()->getDriverName() === 'pgsql') ?
                 "CAST('%s' as text) as %s" :
                 "%s as %s";
             $idSelect = sprintf("%s as id", $keyName);
-            $tagSelect = sprintf($condionalTagSelect, $tag, $this->tagVar);
+            $tagSelect = sprintf($conditionalTagSelect, $tag, $this->tagVar);
             $sortSelect = sprintf("%s as %s", $sorting, $this->sortVar);
 
             $cleanQuery = $cleanQuery->select(Db::raw($idSelect))

--- a/src/Database/DataFeed.php
+++ b/src/Database/DataFeed.php
@@ -218,7 +218,7 @@ class DataFeed
              * Flush the select, add ID and tag
              */
 
-            $cast = $this->getDbDialect() === 'pgsql' ? 'text' : 'binary';
+            $cast = (Db::connection()->getDriverName() === 'pgsql') ? 'text' : 'binary';
             $idSelect = sprintf("%s as id", $keyName);
             $tagSelect = sprintf("cast('%s' as %s) as %s", $tag, $cast, $this->tagVar);
             $sortSelect = sprintf("%s as %s", $sorting, $this->sortVar);

--- a/src/Database/DataFeed.php
+++ b/src/Database/DataFeed.php
@@ -95,10 +95,12 @@ class DataFeed
         $bindings = $query->bindings;
         $records = sprintf("(%s) as records", $query->toSql());
         $result = Db::table(Db::raw($records))->selectRaw("COUNT(*) as total");
-        // set bindings if have;
+
+        // Set the bindings, if present
         foreach ($bindings as $type => $params) {
             $result = $result->setBindings($params, $type);
         }
+        
         $result = $result->first();
         return $result->total;
     }
@@ -212,11 +214,8 @@ class DataFeed
 
             $sorting = $model->getTable() . '.';
             $sorting .= $orderBy ?: $this->sortField;
-
-            /*
-             * Flush the select, add ID and tag
-             */
-
+            
+            // Flush the select and add ID and tag
             $conditionalTagSelect = (Db::connection()->getDriverName() === 'pgsql') ?
                 "CAST('%s' as text) as %s" :
                 "'%s' as %s";
@@ -227,9 +226,8 @@ class DataFeed
             $cleanQuery = $cleanQuery->select(Db::raw($idSelect))
                 ->addSelect(Db::raw($tagSelect))
                 ->addSelect(Db::raw($sortSelect));
-            /*
-             * Union this query with the previous one
-             */
+            
+            // Union this query with the previous one
             if ($lastQuery) {
                 if ($this->removeDuplicates)
                     $cleanQuery = $lastQuery->union($cleanQuery);


### PR DESCRIPTION
It was impossible to get the result because there was no type cast for tagVar in postgres, and was impossible to get count() because bindings with the old query were not added to the final query.
Also, this pull request solves this issues https://github.com/octobercms/october/issues/4252 https://github.com/octobercms/october/issues/4249