### PR TITLE
Implement "http_build_url" polyfill / wrapper into core

### DIFF
--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -5,6 +5,7 @@ use Illuminate\Foundation\Application as ApplicationBase;
 use Symfony\Component\Debug\Exception\FatalErrorException;
 use October\Rain\Events\EventServiceProvider;
 use October\Rain\Router\RoutingServiceProvider;
+use October\Rain\Router\UrlServiceProvider;
 use October\Rain\Foundation\Providers\LogServiceProvider;
 use October\Rain\Foundation\Providers\MakerServiceProvider;
 use October\Rain\Foundation\Providers\ExecutionContextProvider;
@@ -281,7 +282,7 @@ class Application extends ApplicationBase
             'router'               => [\Illuminate\Routing\Router::class, \Illuminate\Contracts\Routing\Registrar::class, \Illuminate\Contracts\Routing\BindingRegistrar::class],
             'session'              => [\Illuminate\Session\SessionManager::class],
             'session.store'        => [\Illuminate\Session\Store::class, \Illuminate\Contracts\Session\Session::class],
-            'url'                  => [\Illuminate\Routing\UrlGenerator::class, \Illuminate\Contracts\Routing\UrlGenerator::class],
+            'url'                  => [\October\Rain\Router\UrlGenerator::class, \Illuminate\Contracts\Routing\UrlGenerator::class],
             'validator'            => [\Illuminate\Validation\Factory::class, \Illuminate\Contracts\Validation\Factory::class],
             'view'                 => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
         ];

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -5,7 +5,6 @@ use Illuminate\Foundation\Application as ApplicationBase;
 use Symfony\Component\Debug\Exception\FatalErrorException;
 use October\Rain\Events\EventServiceProvider;
 use October\Rain\Router\RoutingServiceProvider;
-use October\Rain\Router\UrlServiceProvider;
 use October\Rain\Foundation\Providers\LogServiceProvider;
 use October\Rain\Foundation\Providers\MakerServiceProvider;
 use October\Rain\Foundation\Providers\ExecutionContextProvider;

--- a/src/Router/RoutingServiceProvider.php
+++ b/src/Router/RoutingServiceProvider.php
@@ -15,4 +15,40 @@ class RoutingServiceProvider extends RoutingServiceProviderBase
             return new CoreRouter($app['events'], $app);
         });
     }
+
+    /**
+     * Register the URL generator service.
+     *
+     * @return void
+     */
+    protected function registerUrlGenerator()
+    {
+        $this->app->singleton('url', function ($app) {
+            $routes = $app['router']->getRoutes();
+
+            // The URL generator needs the route collection that exists on the router.
+            // Keep in mind this is an object, so we're passing by references here
+            // and all the registered routes will be available to the generator.
+            $app->instance('routes', $routes);
+
+            $url = new UrlGenerator(
+                $routes, $app->rebinding(
+                    'request', $this->requestRebinder()
+                )
+            );
+
+            $url->setSessionResolver(function () {
+                return $this->app['session'];
+            });
+
+            // If the route collection is "rebound", for example, when the routes stay
+            // cached for the application, we will need to rebind the routes on the
+            // URL generator instance so it has the latest version of the routes.
+            $app->rebinding('routes', function ($app, $routes) {
+                $app['url']->setRoutes($routes);
+            });
+
+            return $url;
+        });
+    }
 }

--- a/src/Router/UrlGenerator.php
+++ b/src/Router/UrlGenerator.php
@@ -1,0 +1,69 @@
+<?php
+namespace October\Rain\Router;
+
+use Illuminate\Routing\UrlGenerator as UrlGeneratorBase;
+
+// PECL HTTP constant definitions
+if (!defined('HTTP_URL_REPLACE')) {
+    define('HTTP_URL_REPLACE', 1);
+}
+if (!defined('HTTP_URL_JOIN_PATH')) {
+    define('HTTP_URL_JOIN_PATH', 2);
+}
+if (!defined('HTTP_URL_JOIN_QUERY')) {
+    define('HTTP_URL_JOIN_QUERY', 4);
+}
+if (!defined('HTTP_URL_STRIP_USER')) {
+    define('HTTP_URL_STRIP_USER', 8);
+}
+if (!defined('HTTP_URL_STRIP_PASS')) {
+    define('HTTP_URL_STRIP_PASS', 16);
+}
+if (!defined('HTTP_URL_STRIP_AUTH')) {
+    define('HTTP_URL_STRIP_AUTH', 32);
+}
+if (!defined('HTTP_URL_STRIP_PORT')) {
+    define('HTTP_URL_STRIP_PORT', 64);
+}
+if (!defined('HTTP_URL_STRIP_PATH')) {
+    define('HTTP_URL_STRIP_PATH', 128);
+}
+if (!defined('HTTP_URL_STRIP_QUERY')) {
+    define('HTTP_URL_STRIP_QUERY', 256);
+}
+if (!defined('HTTP_URL_STRIP_FRAGMENT')) {
+    define('HTTP_URL_STRIP_FRAGMENT', 512);
+}
+if (!defined('HTTP_URL_STRIP_ALL')) {
+    define('HTTP_URL_STRIP_ALL', 1024);
+}
+
+class UrlGenerator extends UrlGeneratorBase
+{
+    /**
+     * Build a URL from an array.
+     *
+     * This function serves as a counterpart to the `parse_url` method available in PHP, and a userland implementation
+     * of the `http_build_query` method provided by the PECL HTTP module. This allows a developer to parse a URL to an
+     * array and make adjustments to the URL parts before combining them into a valid URL reference string.
+     *
+     * If PECL HTTP is installed, it will use the native method instead.
+     *
+     * @param array $url The URL parts, as an array. Must match the structure returned from a `parse_url` call.
+     * @param array $parts The URL replacement parts. Allows a developer to replace certain sections of the URL with
+     *                     a different value.
+     * @param mixed $flags A bitmask of binary or'ed HTTP_URL constants. By default, this is set to HTTP_URL_REPLACE.
+     * @param array $newUrl If set, this will be filled with the array parts of the composed URL, similar to the return
+     *                      value of `parse_url`.
+     *
+     * @return string
+     */
+    public function buildUrl(array $url, array $parts = [], $flags = HTTP_URL_REPLACE, &$newUrl = []): string
+    {
+        if (function_exists('http_build_url')) {
+            return http_build_url($url, $parts, $flags, $newUrl);
+        }
+
+
+    }
+}

--- a/src/Router/UrlGenerator.php
+++ b/src/Router/UrlGenerator.php
@@ -3,67 +3,124 @@ namespace October\Rain\Router;
 
 use Illuminate\Routing\UrlGenerator as UrlGeneratorBase;
 
-// PECL HTTP constant definitions
-if (!defined('HTTP_URL_REPLACE')) {
-    define('HTTP_URL_REPLACE', 1);
-}
-if (!defined('HTTP_URL_JOIN_PATH')) {
-    define('HTTP_URL_JOIN_PATH', 2);
-}
-if (!defined('HTTP_URL_JOIN_QUERY')) {
-    define('HTTP_URL_JOIN_QUERY', 4);
-}
-if (!defined('HTTP_URL_STRIP_USER')) {
-    define('HTTP_URL_STRIP_USER', 8);
-}
-if (!defined('HTTP_URL_STRIP_PASS')) {
-    define('HTTP_URL_STRIP_PASS', 16);
-}
-if (!defined('HTTP_URL_STRIP_AUTH')) {
-    define('HTTP_URL_STRIP_AUTH', 32);
-}
-if (!defined('HTTP_URL_STRIP_PORT')) {
-    define('HTTP_URL_STRIP_PORT', 64);
-}
-if (!defined('HTTP_URL_STRIP_PATH')) {
-    define('HTTP_URL_STRIP_PATH', 128);
-}
-if (!defined('HTTP_URL_STRIP_QUERY')) {
-    define('HTTP_URL_STRIP_QUERY', 256);
-}
-if (!defined('HTTP_URL_STRIP_FRAGMENT')) {
-    define('HTTP_URL_STRIP_FRAGMENT', 512);
-}
-if (!defined('HTTP_URL_STRIP_ALL')) {
-    define('HTTP_URL_STRIP_ALL', 1024);
-}
-
 class UrlGenerator extends UrlGeneratorBase
 {
     /**
-     * Build a URL from an array.
+     * Build a URL from an array returned from a `parse_url` call.
      *
      * This function serves as a counterpart to the `parse_url` method available in PHP, and a userland implementation
      * of the `http_build_query` method provided by the PECL HTTP module. This allows a developer to parse a URL to an
      * array and make adjustments to the URL parts before combining them into a valid URL reference string.
      *
-     * If PECL HTTP is installed, it will use the native method instead.
+     * Based off of the implentation at https://github.com/jakeasmith/http_build_url/blob/master/src/http_build_url.php.
      *
      * @param array $url The URL parts, as an array. Must match the structure returned from a `parse_url` call.
-     * @param array $parts The URL replacement parts. Allows a developer to replace certain sections of the URL with
-     *                     a different value.
+     * @param array $replace The URL replacement parts. Allows a developer to replace certain sections of the URL with
+     *                       a different value.
      * @param mixed $flags A bitmask of binary or'ed HTTP_URL constants. By default, this is set to HTTP_URL_REPLACE.
      * @param array $newUrl If set, this will be filled with the array parts of the composed URL, similar to the return
      *                      value of `parse_url`.
      *
-     * @return string
+     * @return string The generated URL as a string
      */
-    public function buildUrl(array $url, array $parts = [], $flags = HTTP_URL_REPLACE, &$newUrl = []): string
+    public function buildUrl(array $url, array $replace = [], $flags = HTTP_URL_REPLACE, &$newUrl = []): string
     {
-        if (function_exists('http_build_url')) {
-            return http_build_url($url, $parts, $flags, $newUrl);
+        $urlSegments = ['scheme', 'host', 'user', 'pass', 'port', 'path', 'query', 'fragment'];
+
+        // Set flags - HTTP_URL_STRIP_ALL and HTTP_URL_STRIP_AUTH cover several other flags.
+        if ($flags & HTTP_URL_STRIP_ALL) {
+            $flags |= HTTP_URL_STRIP_USER
+                   | HTTP_URL_STRIP_PASS
+                   | HTTP_URL_STRIP_PORT
+                   | HTTP_URL_STRIP_PATH
+                   | HTTP_URL_STRIP_QUERY
+                   | HTTP_URL_STRIP_FRAGMENT;
+        } elseif ($flags & HTTP_URL_STRIP_AUTH) {
+            $flags |= HTTP_URL_STRIP_USER
+                   | HTTP_URL_STRIP_PASS;
         }
 
+        // Filter $url and $replace arrays to strip out unknown segments
+        array_change_key_case($url, CASE_LOWER);
+        array_change_key_case($replace, CASE_LOWER);
 
+        $url = array_filter($url, function ($value, $key) use ($urlSegments) {
+            return (in_array($key, $urlSegments) && isset($value));
+        }, ARRAY_FILTER_USE_BOTH);
+        $replace = array_filter($replace, function ($value, $key) use ($urlSegments) {
+            return (in_array($key, $urlSegments) && isset($value));
+        }, ARRAY_FILTER_USE_BOTH);
+
+        // Replace URL parts if required
+        if ($flags & HTTP_URL_REPLACE) {
+            $url = array_replace($url, $replace);
+        } else {
+            // Process joined paths
+            if (($flags & HTTP_URL_JOIN_PATH) && isset($replace['path'])) {
+                $urlPath = (isset($url['path'])) ? explode('/', trim($url['path'], '/')) : [];
+                $joinedPath = explode('/', trim($replace['path'], '/'));
+
+                $url['path'] = '/' . implode('/', array_merge($urlPath, $joinedPath));
+            }
+
+            // Process joined query string
+            if (($flags & HTTP_URL_JOIN_QUERY) && isset($replace['query'])) {
+                $urlQuery = $joinedQuery = [];
+
+                parse_str($url['query'] ?? '', $urlQuery);
+                parse_str($replace['query'] ?? '', $joinedQuery);
+
+                $url['query'] = http_build_query(array_replace_recursive($urlQuery, $joinedQuery));
+            }
+        }
+
+        // Strip segments as necessary
+        foreach ($urlSegments as $segment) {
+            $strip = 'HTTP_URL_STRIP_' . strtoupper($segment);
+
+            if (!defined($strip)) {
+                continue;
+            }
+
+            if ($flags & constant($strip)) {
+                unset($url[$segment]);
+            }
+        }
+
+        // Make new URL available
+        $newUrl = $url;
+
+        // Generate URL string
+        $urlString = '';
+
+        if (!empty($url['scheme'])) {
+            $urlString .= $url['scheme'] . '://';
+        }
+        if (!empty($url['user'])) {
+            $urlString .= $url['user'];
+
+            if (!empty($url['pass'])) {
+                $urlString .= ':' . $url['pass'];
+            }
+
+            $urlString .= '@';
+        }
+        if (!empty($url['host'])) {
+            $urlString .= $url['host'];
+        }
+        if (!empty($url['port'])) {
+            $urlString .= ':' . $url['port'];
+        }
+        if (!empty($url['path'])) {
+            $urlString .= ((substr($url['path'], 0, 1) !== '/') ? '/' : '') . $url['path'];
+        }
+        if (!empty($url['query'])) {
+            $urlString .= '?' . $url['query'];
+        }
+        if (!empty($url['fragment'])) {
+            $urlString .= '#' . $url['fragment'];
+        }
+
+        return $urlString;
     }
 }

--- a/src/Router/UrlGenerator.php
+++ b/src/Router/UrlGenerator.php
@@ -23,7 +23,7 @@ class UrlGenerator extends UrlGeneratorBase
      *
      * @return string The generated URL as a string
      */
-    public function buildUrl(array $url, array $replace = [], $flags = HTTP_URL_REPLACE, &$newUrl = []): string
+    public static function buildUrl(array $url, array $replace = [], $flags = HTTP_URL_REPLACE, &$newUrl = []): string
     {
         $urlSegments = ['scheme', 'host', 'user', 'pass', 'port', 'path', 'query', 'fragment'];
 

--- a/src/Support/Facades/Url.php
+++ b/src/Support/Facades/Url.php
@@ -1,0 +1,19 @@
+<?php namespace October\Rain\Support\Facades;
+
+use October\Rain\Support\Facade;
+
+class Url extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * Resolves to:
+     * - October\Rain\Router\UrlGenerator
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'url';
+    }
+}

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -265,3 +265,55 @@ if (! function_exists('collect')) {
         return new \October\Rain\Support\Collection($value);
     }
 }
+
+// PECL HTTP constant definitions
+if (!defined('HTTP_URL_REPLACE')) {
+    define('HTTP_URL_REPLACE', 1);
+}
+if (!defined('HTTP_URL_JOIN_PATH')) {
+    define('HTTP_URL_JOIN_PATH', 2);
+}
+if (!defined('HTTP_URL_JOIN_QUERY')) {
+    define('HTTP_URL_JOIN_QUERY', 4);
+}
+if (!defined('HTTP_URL_STRIP_USER')) {
+    define('HTTP_URL_STRIP_USER', 8);
+}
+if (!defined('HTTP_URL_STRIP_PASS')) {
+    define('HTTP_URL_STRIP_PASS', 16);
+}
+if (!defined('HTTP_URL_STRIP_AUTH')) {
+    define('HTTP_URL_STRIP_AUTH', 32);
+}
+if (!defined('HTTP_URL_STRIP_PORT')) {
+    define('HTTP_URL_STRIP_PORT', 64);
+}
+if (!defined('HTTP_URL_STRIP_PATH')) {
+    define('HTTP_URL_STRIP_PATH', 128);
+}
+if (!defined('HTTP_URL_STRIP_QUERY')) {
+    define('HTTP_URL_STRIP_QUERY', 256);
+}
+if (!defined('HTTP_URL_STRIP_FRAGMENT')) {
+    define('HTTP_URL_STRIP_FRAGMENT', 512);
+}
+if (!defined('HTTP_URL_STRIP_ALL')) {
+    define('HTTP_URL_STRIP_ALL', 1024);
+}
+
+if (!function_exists('http_build_url')) {
+    /**
+     * Polyfill for `http_build_url` method provided by PECL HTTP extension.
+     *
+     * @see \October\Rain\Router\UrlGenerator::buildUrl()
+     * @param array $url
+     * @param array $replace
+     * @param mixed $flags
+     * @param array $newUrl
+     * @return string
+     */
+    function http_build_url(array $url, array $replace = [], $flags = HTTP_URL_REPLACE, array &$newUrl = []): string
+    {
+        return Url::buildUrl($url, $replace, $flags, $newUrl);
+    }
+}

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -314,6 +314,6 @@ if (!function_exists('http_build_url')) {
      */
     function http_build_url(array $url, array $replace = [], $flags = HTTP_URL_REPLACE, array &$newUrl = []): string
     {
-        return Url::buildUrl($url, $replace, $flags, $newUrl);
+        return \October\Rain\Router\UrlGenerator::buildUrl($url, $replace, $flags, $newUrl);
     }
 }

--- a/tests/Support/UrlGeneratorTest.php
+++ b/tests/Support/UrlGeneratorTest.php
@@ -1,11 +1,11 @@
 <?php
-use October\Rain\Support\Facades\Url;
+use October\Rain\Router\UrlGenerator;
 
 class UrlGeneratorTest extends TestCase
 {
     public function testSimpleUrl()
     {
-        $this->assertEquals('https://octobercms.com/', Url::buildUrl([
+        $this->assertEquals('https://octobercms.com/', UrlGenerator::buildUrl([
             'scheme' => 'https',
             'host' => 'octobercms.com',
             'path' => '/'
@@ -20,7 +20,7 @@ class UrlGeneratorTest extends TestCase
 
     public function testComplexUrl()
     {
-        $this->assertEquals('https://user:pass@github.com:80/octobercms/october?test=1&test=2#comment1', Url::buildUrl([
+        $this->assertEquals('https://user:pass@github.com:80/octobercms/october?test=1&test=2#comment1', UrlGenerator::buildUrl([
             'scheme' => 'https',
             'user' => 'user',
             'pass' => 'pass',
@@ -45,7 +45,7 @@ class UrlGeneratorTest extends TestCase
 
     public function testReplacements()
     {
-        $this->assertEquals('https://octobercms.com', Url::buildUrl([
+        $this->assertEquals('https://octobercms.com', UrlGenerator::buildUrl([
             'scheme' => 'https',
             'host' => 'wordpress.org'
         ], [
@@ -53,7 +53,7 @@ class UrlGeneratorTest extends TestCase
             'host' => 'octobercms.com'
         ]));
 
-        $this->assertEquals('https://octobercms.com:80/changelog', Url::buildUrl([
+        $this->assertEquals('https://octobercms.com:80/changelog', UrlGenerator::buildUrl([
             'scheme' => 'https',
             'host' => 'octobercms.com'
         ], [
@@ -61,7 +61,7 @@ class UrlGeneratorTest extends TestCase
             'path' => '/changelog'
         ]));
 
-        $this->assertEquals('ftp://username:password@ftp.test.com.au:21/newfolder', Url::buildUrl([
+        $this->assertEquals('ftp://username:password@ftp.test.com.au:21/newfolder', UrlGenerator::buildUrl([
             'scheme' => 'https',
             'user' => 'user',
             'pass' => 'pass',
@@ -84,7 +84,7 @@ class UrlGeneratorTest extends TestCase
 
     public function testJoinSegments()
     {
-        $this->assertEquals('https://octobercms.com/plugins/rainlab-pages', Url::buildUrl([
+        $this->assertEquals('https://octobercms.com/plugins/rainlab-pages', UrlGenerator::buildUrl([
             'scheme' => 'https',
             'host' => 'octobercms.com',
             'path' => '/plugins'
@@ -92,7 +92,7 @@ class UrlGeneratorTest extends TestCase
             'path' => '/rainlab-pages'
         ], HTTP_URL_JOIN_PATH));
 
-        $this->assertEquals('https://octobercms.com/?query1=1&query2=2&query3=3', Url::buildUrl([
+        $this->assertEquals('https://octobercms.com/?query1=1&query2=2&query3=3', UrlGenerator::buildUrl([
             'scheme' => 'https',
             'host' => 'octobercms.com',
             'path' => '/',
@@ -101,7 +101,7 @@ class UrlGeneratorTest extends TestCase
             'query' => 'query3=3'
         ], HTTP_URL_JOIN_QUERY));
 
-        $this->assertEquals('https://octobercms.com/plugins/rainlab-pages?query1=1&query2=2&query3=3', Url::buildUrl([
+        $this->assertEquals('https://octobercms.com/plugins/rainlab-pages?query1=1&query2=2&query3=3', UrlGenerator::buildUrl([
             'scheme' => 'https',
             'host' => 'octobercms.com',
             'path' => '/plugins',

--- a/tests/Support/UrlGeneratorTest.php
+++ b/tests/Support/UrlGeneratorTest.php
@@ -1,0 +1,216 @@
+<?php
+use October\Rain\Support\Facades\Url;
+
+class UrlGeneratorTest extends TestCase
+{
+    public function testSimpleUrl()
+    {
+        $this->assertEquals('https://octobercms.com/', Url::buildUrl([
+            'scheme' => 'https',
+            'host' => 'octobercms.com',
+            'path' => '/'
+        ]));
+
+        $this->assertEquals('https://octobercms.com/', http_build_url([
+            'scheme' => 'https',
+            'host' => 'octobercms.com',
+            'path' => '/'
+        ]));
+    }
+
+    public function testComplexUrl()
+    {
+        $this->assertEquals('https://user:pass@github.com:80/octobercms/october?test=1&test=2#comment1', Url::buildUrl([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ]));
+
+        $this->assertEquals('https://user:pass@github.com:80/octobercms/october?test=1&test=2#comment1', http_build_url([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ]));
+    }
+
+    public function testReplacements()
+    {
+        $this->assertEquals('https://octobercms.com', Url::buildUrl([
+            'scheme' => 'https',
+            'host' => 'wordpress.org'
+        ], [
+            'scheme' => 'https',
+            'host' => 'octobercms.com'
+        ]));
+
+        $this->assertEquals('https://octobercms.com:80/changelog', Url::buildUrl([
+            'scheme' => 'https',
+            'host' => 'octobercms.com'
+        ], [
+            'port' => 80,
+            'path' => '/changelog'
+        ]));
+
+        $this->assertEquals('ftp://username:password@ftp.test.com.au:21/newfolder', Url::buildUrl([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ], [
+            'scheme' => 'ftp',
+            'user' => 'username',
+            'pass' => 'password',
+            'host' => 'ftp.test.com.au',
+            'port' => 21,
+            'path' => 'newfolder',
+            'query' => '',
+            'fragment' => ''
+        ]));
+    }
+
+    public function testJoinSegments()
+    {
+        $this->assertEquals('https://octobercms.com/plugins/rainlab-pages', Url::buildUrl([
+            'scheme' => 'https',
+            'host' => 'octobercms.com',
+            'path' => '/plugins'
+        ], [
+            'path' => '/rainlab-pages'
+        ], HTTP_URL_JOIN_PATH));
+
+        $this->assertEquals('https://octobercms.com/?query1=1&query2=2&query3=3', Url::buildUrl([
+            'scheme' => 'https',
+            'host' => 'octobercms.com',
+            'path' => '/',
+            'query' => 'query1=1&query2=2'
+        ], [
+            'query' => 'query3=3'
+        ], HTTP_URL_JOIN_QUERY));
+
+        $this->assertEquals('https://octobercms.com/plugins/rainlab-pages?query1=1&query2=2&query3=3', Url::buildUrl([
+            'scheme' => 'https',
+            'host' => 'octobercms.com',
+            'path' => '/plugins',
+            'query' => 'query1=1&query2=2'
+        ], [
+            'path' => '/rainlab-pages',
+            'query' => 'query3=3'
+        ], HTTP_URL_JOIN_PATH | HTTP_URL_JOIN_QUERY));
+    }
+
+    public function testStripSegments()
+    {
+        $this->assertEquals('https://github.com:80/octobercms/october?test=1&test=2#comment1', http_build_url([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ], [], HTTP_URL_STRIP_AUTH));
+
+        $this->assertEquals('https://github.com', http_build_url([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ], [], HTTP_URL_STRIP_ALL));
+
+        $this->assertEquals('https://github.com:80/octobercms/october?test=1&test=2#comment1', http_build_url([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ], [], HTTP_URL_STRIP_USER));
+
+        $this->assertEquals('https://user@github.com:80/octobercms/october?test=1&test=2#comment1', http_build_url([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ], [], HTTP_URL_STRIP_PASS));
+
+        $this->assertEquals('https://user:pass@github.com/octobercms/october?test=1&test=2#comment1', http_build_url([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ], [], HTTP_URL_STRIP_PORT));
+
+        $this->assertEquals('https://user:pass@github.com:80?test=1&test=2#comment1', http_build_url([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ], [], HTTP_URL_STRIP_PATH));
+
+        $this->assertEquals('https://user:pass@github.com:80/octobercms/october#comment1', http_build_url([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ], [], HTTP_URL_STRIP_QUERY));
+
+        $this->assertEquals('https://user:pass@github.com:80/octobercms/october?test=1&test=2', http_build_url([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ], [], HTTP_URL_STRIP_FRAGMENT));
+
+        $this->assertEquals('https://user:pass@github.com/octobercms/october', http_build_url([
+            'scheme' => 'https',
+            'user' => 'user',
+            'pass' => 'pass',
+            'host' => 'github.com',
+            'port' => 80,
+            'path' => '/octobercms/october',
+            'query' => 'test=1&test=2',
+            'fragment' => 'comment1'
+        ], [], HTTP_URL_STRIP_PORT | HTTP_URL_STRIP_QUERY | HTTP_URL_STRIP_FRAGMENT));
+    }
+}

--- a/tests/Support/UrlGeneratorTest.php
+++ b/tests/Support/UrlGeneratorTest.php
@@ -114,7 +114,7 @@ class UrlGeneratorTest extends TestCase
 
     public function testStripSegments()
     {
-        $this->assertEquals('https://github.com:80/octobercms/october?test=1&test=2#comment1', http_build_url([
+        $segments = [
             'scheme' => 'https',
             'user' => 'user',
             'pass' => 'pass',
@@ -123,94 +123,51 @@ class UrlGeneratorTest extends TestCase
             'path' => '/octobercms/october',
             'query' => 'test=1&test=2',
             'fragment' => 'comment1'
-        ], [], HTTP_URL_STRIP_AUTH));
+        ];
 
-        $this->assertEquals('https://github.com', http_build_url([
-            'scheme' => 'https',
-            'user' => 'user',
-            'pass' => 'pass',
-            'host' => 'github.com',
-            'port' => 80,
-            'path' => '/octobercms/october',
-            'query' => 'test=1&test=2',
-            'fragment' => 'comment1'
-        ], [], HTTP_URL_STRIP_ALL));
+        $this->assertEquals(
+            'https://github.com:80/octobercms/october?test=1&test=2#comment1',
+            http_build_url($segments, [], HTTP_URL_STRIP_AUTH)
+        );
 
-        $this->assertEquals('https://github.com:80/octobercms/october?test=1&test=2#comment1', http_build_url([
-            'scheme' => 'https',
-            'user' => 'user',
-            'pass' => 'pass',
-            'host' => 'github.com',
-            'port' => 80,
-            'path' => '/octobercms/october',
-            'query' => 'test=1&test=2',
-            'fragment' => 'comment1'
-        ], [], HTTP_URL_STRIP_USER));
+        $this->assertEquals(
+            'https://github.com',
+            http_build_url($segments, [], HTTP_URL_STRIP_ALL)
+        );
 
-        $this->assertEquals('https://user@github.com:80/octobercms/october?test=1&test=2#comment1', http_build_url([
-            'scheme' => 'https',
-            'user' => 'user',
-            'pass' => 'pass',
-            'host' => 'github.com',
-            'port' => 80,
-            'path' => '/octobercms/october',
-            'query' => 'test=1&test=2',
-            'fragment' => 'comment1'
-        ], [], HTTP_URL_STRIP_PASS));
+        $this->assertEquals(
+            'https://github.com:80/octobercms/october?test=1&test=2#comment1',
+            http_build_url($segments, [], HTTP_URL_STRIP_USER)
+        );
 
-        $this->assertEquals('https://user:pass@github.com/octobercms/october?test=1&test=2#comment1', http_build_url([
-            'scheme' => 'https',
-            'user' => 'user',
-            'pass' => 'pass',
-            'host' => 'github.com',
-            'port' => 80,
-            'path' => '/octobercms/october',
-            'query' => 'test=1&test=2',
-            'fragment' => 'comment1'
-        ], [], HTTP_URL_STRIP_PORT));
+        $this->assertEquals(
+            'https://user@github.com:80/octobercms/october?test=1&test=2#comment1',
+            http_build_url($segments, [], HTTP_URL_STRIP_PASS)
+        );
 
-        $this->assertEquals('https://user:pass@github.com:80?test=1&test=2#comment1', http_build_url([
-            'scheme' => 'https',
-            'user' => 'user',
-            'pass' => 'pass',
-            'host' => 'github.com',
-            'port' => 80,
-            'path' => '/octobercms/october',
-            'query' => 'test=1&test=2',
-            'fragment' => 'comment1'
-        ], [], HTTP_URL_STRIP_PATH));
+        $this->assertEquals(
+            'https://user:pass@github.com/octobercms/october?test=1&test=2#comment1',
+            http_build_url($segments, [], HTTP_URL_STRIP_PORT)
+        );
 
-        $this->assertEquals('https://user:pass@github.com:80/octobercms/october#comment1', http_build_url([
-            'scheme' => 'https',
-            'user' => 'user',
-            'pass' => 'pass',
-            'host' => 'github.com',
-            'port' => 80,
-            'path' => '/octobercms/october',
-            'query' => 'test=1&test=2',
-            'fragment' => 'comment1'
-        ], [], HTTP_URL_STRIP_QUERY));
+        $this->assertEquals(
+            'https://user:pass@github.com:80?test=1&test=2#comment1',
+            http_build_url($segments, [], HTTP_URL_STRIP_PATH)
+        );
 
-        $this->assertEquals('https://user:pass@github.com:80/octobercms/october?test=1&test=2', http_build_url([
-            'scheme' => 'https',
-            'user' => 'user',
-            'pass' => 'pass',
-            'host' => 'github.com',
-            'port' => 80,
-            'path' => '/octobercms/october',
-            'query' => 'test=1&test=2',
-            'fragment' => 'comment1'
-        ], [], HTTP_URL_STRIP_FRAGMENT));
+        $this->assertEquals(
+            'https://user:pass@github.com:80/octobercms/october#comment1',
+            http_build_url($segments, [], HTTP_URL_STRIP_QUERY)
+        );
 
-        $this->assertEquals('https://user:pass@github.com/octobercms/october', http_build_url([
-            'scheme' => 'https',
-            'user' => 'user',
-            'pass' => 'pass',
-            'host' => 'github.com',
-            'port' => 80,
-            'path' => '/octobercms/october',
-            'query' => 'test=1&test=2',
-            'fragment' => 'comment1'
-        ], [], HTTP_URL_STRIP_PORT | HTTP_URL_STRIP_QUERY | HTTP_URL_STRIP_FRAGMENT));
+        $this->assertEquals(
+            'https://user:pass@github.com:80/octobercms/october?test=1&test=2',
+            http_build_url($segments, [], HTTP_URL_STRIP_FRAGMENT)
+        );
+
+        $this->assertEquals(
+            'https://user:pass@github.com/octobercms/october',
+            http_build_url($segments, [], HTTP_URL_STRIP_PORT | HTTP_URL_STRIP_QUERY | HTTP_URL_STRIP_FRAGMENT)
+        );
     }
 }


### PR DESCRIPTION
Allows October sites to use the `http_build_url` method, either natively through the PECL HTTP extension, or through the userland polyfill implemented in this PR. This method is a counterpart to the [`parse_url`](https://php.net/parse_url) method provided in PHP - in essence, taking a structured array of URL components and making it a single URL string.

In addition, the PR extends the `Illuminate\Routing\UrlGenerator` class with a new class `October\Rain\Route\UrlGenerator` and uses this as the new endpoint for the `Url` facade.