### PR TITLE
Fix douple decoding of jsonable attributes

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1112,6 +1112,11 @@ class Model extends EloquentModel
                 continue;
             }
 
+            // Prevent double decoding of jsonable attributes.
+            if (!is_string($attributes[$key])) {
+                continue;
+            }
+
             $jsonValue = json_decode($attributes[$key], true);
             if (json_last_error() === JSON_ERROR_NONE) {
                 $attributes[$key] = $jsonValue;


### PR DESCRIPTION
This fixes https://github.com/rainlab/translate-plugin/issues/485