### PR TITLE
Don't minify css rules inside parentheses

### DIFF
--- a/src/Parse/Assetic/StylesheetMinify.php
+++ b/src/Parse/Assetic/StylesheetMinify.php
@@ -51,8 +51,8 @@ class StylesheetMinify implements FilterInterface
         // -6.0100em to -6.01em, .0100 to .01, 1.200px to 1.2px
         $css = preg_replace('/((?<!\\\\)\:|\s)(\-?)(\d?\.\d+?)0+([^\d])/S', '$1$2$3$4', $css);
 
-        // Strips units if value is 0 (converts 0px to 0)
-        $css = preg_replace('/(:| )(\.?)0(em|ex|px|in|cm|mm|pt|pc)/i', '${1}0', $css);
+        // Strips units if value is 0 (converts 0px to 0), ignores values inside ()
+        $css = preg_replace('/(:| )(\.?)0(em|ex|px|in|cm|mm|pt|pc)(?![^\(]*\))/i', '${1}0', $css);
 
         // Shortern 6-character hex color codes to 3-character where possible
         $css = preg_replace('/#([a-f0-9])\\1([a-f0-9])\\2([a-f0-9])\\3/i', '#\1\2\3', $css);

--- a/tests/Parse/Assetic/MockAsset.php
+++ b/tests/Parse/Assetic/MockAsset.php
@@ -1,0 +1,86 @@
+<?php
+
+use Assetic\Asset\AssetInterface;
+use Assetic\Filter\FilterInterface;
+
+/**
+ * Class MockAsset
+ *
+ * This class implements the AssetInterface and can be used
+ * to test Assetic filters.
+ */
+class MockAsset implements AssetInterface
+{
+    public $content;
+
+    public function __construct(string $content = '')
+    {
+        $this->content = $content;
+    }
+
+    public function ensureFilter(FilterInterface $filter)
+    {
+    }
+
+    public function getFilters()
+    {
+    }
+
+    public function clearFilters()
+    {
+    }
+
+    public function load(FilterInterface $additionalFilter = null)
+    {
+    }
+
+    public function dump(FilterInterface $additionalFilter = null)
+    {
+    }
+
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    public function setContent($content)
+    {
+        $this->content = $content;
+    }
+
+    public function getSourceRoot()
+    {
+    }
+
+    public function getSourcePath()
+    {
+    }
+
+    public function getSourceDirectory()
+    {
+    }
+
+    public function getTargetPath()
+    {
+    }
+
+    public function setTargetPath($targetPath)
+    {
+    }
+
+    public function getLastModified()
+    {
+    }
+
+    public function getVars()
+    {
+    }
+
+    public function setValues(array $values)
+    {
+    }
+
+    public function getValues()
+    {
+    }
+}

--- a/tests/Parse/Assetic/StylesheetMinifyTest.php
+++ b/tests/Parse/Assetic/StylesheetMinifyTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use October\Rain\Parse\Assetic\StylesheetMinify;
+
+class StylesheetMinifyTest extends TestCase
+{
+    public function testUnitRemoval()
+    {
+        include __DIR__ . '/MockAsset.php';
+
+        $input  = 'body {width: calc(99.9% * 1/1 - 0px); height: 0px;}';
+        $output = 'body {width:calc(99.9% * 1/1 - 0px);height:0}';
+
+        $mockAsset = new MockAsset($input);
+        $result    = new StylesheetMinify();
+        $result->filterDump($mockAsset);
+
+        $this->assertEquals($output, $mockAsset->getContent());
+    }
+}


### PR DESCRIPTION
This is my solution to https://github.com/octobercms/october/issues/4438. 

By adding the negative lookahead `(?![^\(]*\))` everything inside of `()` is ignored. This includes `calc()` rules.

If someone can come up with a RegEx that only matches `calc()` that would be even better. I couldn't get it done within a few minutes so I've opted for this simpler solution.