### PR TITLE
Removed extra '=' character

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -543,7 +543,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
      */
     public function id()
     {
-        if ($user == $this->getUser()) {
+        if ($user = $this->getUser()) {
             return $user->getAuthIdentifier();
         }
 


### PR DESCRIPTION
This fix is for https://github.com/octobercms/october/issues/4442

I changed the comparison operator to set the `$user` variable instead.