### PR TITLE
Use Twig as parser for scaffolding stub contents

### DIFF
--- a/src/Scaffold/GeneratorCommand.php
+++ b/src/Scaffold/GeneratorCommand.php
@@ -7,6 +7,7 @@ use October\Rain\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Exception;
+use Twig;
 
 abstract class GeneratorCommand extends Command
 {
@@ -103,8 +104,9 @@ abstract class GeneratorCommand extends Command
         /*
          * Parse each variable in to the destination content and path
          */
+        $destinationContent = Twig::parse($destinationContent, $this->vars);
+
         foreach ($this->vars as $key => $var) {
-            $destinationContent = str_replace('{{' . $key . '}}', $var, $destinationContent);
             $destinationFile = str_replace('{{' . $key . '}}', $var, $destinationFile);
         }
 

--- a/src/Scaffold/GeneratorCommand.php
+++ b/src/Scaffold/GeneratorCommand.php
@@ -105,10 +105,7 @@ abstract class GeneratorCommand extends Command
          * Parse each variable in to the destination content and path
          */
         $destinationContent = Twig::parse($destinationContent, $this->vars);
-
-        foreach ($this->vars as $key => $var) {
-            $destinationFile = str_replace('{{' . $key . '}}', $var, $destinationFile);
-        }
+        $destinationFile = Twig::parse($destinationFile, $this->vars);
 
         $this->makeDirectory($destinationFile);
 


### PR DESCRIPTION
This allows usage of twig in stub files for scaffolding. 

Allows to create dynamic commands in one stub file, mostly needed for this issue:
https://github.com/octobercms/october/issues/2833

This should not be breaking change because stub files already using same variable definition like twig.