### PR TITLE
Include InvalidArgumentException class

### DIFF
--- a/src/Database/Connectors/ConnectionFactory.php
+++ b/src/Database/Connectors/ConnectionFactory.php
@@ -8,6 +8,7 @@ use October\Rain\Database\Connections\SQLiteConnection;
 use October\Rain\Database\Connections\PostgresConnection;
 use October\Rain\Database\Connections\SqlServerConnection;
 use PDOException;
+use InvalidArgumentException;
 
 class ConnectionFactory extends ConnectionFactoryBase
 {


### PR DESCRIPTION
Fixes issue where OctoberCMS throws an error that the class is not found.