### PR TITLE
Allow using Rule objects in validation rules

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -355,6 +355,12 @@ trait Validation
 
         foreach ($rules as $field => $ruleParts) {
             /*
+             * Rule class instances should not be checked here
+             */
+            if(is_object($rulePart)) {
+                continue;
+            }
+            /*
              * Trim empty rules
              */
             if (is_string($ruleParts) && trim($ruleParts) == '') {

--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -355,12 +355,6 @@ trait Validation
 
         foreach ($rules as $field => $ruleParts) {
             /*
-             * Rule class instances should not be checked here
-             */
-            if(is_object($rulePart)) {
-                continue;
-            }
-            /*
              * Trim empty rules
              */
             if (is_string($ruleParts) && trim($ruleParts) == '') {
@@ -379,6 +373,12 @@ trait Validation
              * Analyse each rule individually
              */
             foreach ($ruleParts as $key => $rulePart) {
+                /*
+                 * Rule class instances should not be checked here
+                 */
+                if(is_object($rulePart)) {
+                    continue;
+                }
                 /*
                  * Remove primary key unique validation rule if the model already exists
                  */


### PR DESCRIPTION
Right now, if we do something like this in a model:
```php
public function beforeValidate()
    {
        $this->rules = array_merge($this->rules, [
            'prices' => ['required', new CustomRule()],
        ]);
    }
```

We get an error because the Validation trait assumes everything there is a string. We can allow this usage of rules by checking if `$rulePart` is an object, and if that's true, continue the loop. This is in function `processValidationRules`.

```php
                if(is_object($rulePart)) {
                    continue;
                }
```