### PR TITLE
Fixed Error in Comment

### DIFF
--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -50,7 +50,7 @@
  *       $http->toFile('some/path/to/a/file.txt');
  *
  *       // Sets a cURL option manually
- *       $http->setOption('CURLOPT_SSL_VERIFYHOST', false);
+ *       $http->setOption(CURLOPT_SSL_VERIFYHOST, false);
  *
  *   });
  *

--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -520,7 +520,22 @@ class Http
             return;
         }
 
-        $this->requestOptions[$option] = $value;
+        if (is_string($option) && defined($option)) {
+            $optionKey = constant($option);
+            $this->requestOptions[$optionKey] = $value;
+        } elseif (is_int($option)) {
+            $constants = get_defined_constants(true);
+            $curlOptConstants = preg_grep('/^CURLOPT_/', array_flip($constants['curl']));
+
+            if (isset($curlOptConstants[$option])) {
+                $this->requestOptions[$option] = $value;
+            } else {
+                throw new \Exception('Array keys must be CURLOPT constants or equivalent integer values');
+            }
+        } else {
+            throw new \Exception('Array keys must be CURLOPT constants or equivalent integer values');
+        }
+
         return $this;
     }
 

--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -1,5 +1,7 @@
 <?php namespace October\Rain\Network;
 
+use October\Rain\Exception\ApplicationException;
+
 /**
  * HTTP Network Access
  *
@@ -530,10 +532,10 @@ class Http
             if (isset($curlOptConstants[$option])) {
                 $this->requestOptions[$option] = $value;
             } else {
-                throw new \Exception('Array keys must be CURLOPT constants or equivalent integer values');
+                throw new ApplicationException($option.' parameter must be a CURLOPT constant or equivalent integer');
             }
         } else {
-            throw new \Exception('Array keys must be CURLOPT constants or equivalent integer values');
+            throw new ApplicationException($option.' parameter must be a CURLOPT constant or equivalent integer');
         }
 
         return $this;

--- a/src/Network/README.md
+++ b/src/Network/README.md
@@ -63,6 +63,6 @@ Used as a cURL wrapper for the HTTP protocol.
        $http->toFile('some/path/to/a/file.txt');
 
        // Sets a cURL option manually
-       $http->setOption('CURLOPT_SSL_VERIFYHOST', false);
+       $http->setOption(CURLOPT_SSL_VERIFYHOST, false);
 
     });


### PR DESCRIPTION
Http library throws error if you use setOption key as string like **$http->setOption('CURLOPT_RETURNTRANSFER', true);**

> "curl_setopt_array(): Array keys must be CURLOPT constants or equivalent integer values" on line 261 of .../vendor/october/rain/src/Network/Http.php"

Both README and Http.php comments fixed by changing array key to the CURLOPT constant.