### PR TITLE
Allow subdirectories in DBDatasource filenames

### DIFF
--- a/src/Halcyon/Datasource/DbDatasource.php
+++ b/src/Halcyon/Datasource/DbDatasource.php
@@ -202,7 +202,7 @@ class DbDatasource extends Datasource implements DatasourceInterface
 
         foreach ($results as $item) {
             $resultItem = [];
-            $fileName = str_replace($dirName . DIRECTORY_SEPARATOR, '', $item->path);
+            $fileName = ltrim(str_replace($dirName, '', $item->path), '/');
 
             // Apply the fileMatch filter
             if (!empty($fileMatch) && !fnmatch($fileMatch, $fileName)) {

--- a/src/Halcyon/Datasource/DbDatasource.php
+++ b/src/Halcyon/Datasource/DbDatasource.php
@@ -202,7 +202,7 @@ class DbDatasource extends Datasource implements DatasourceInterface
 
         foreach ($results as $item) {
             $resultItem = [];
-            $fileName = pathinfo($item->path, PATHINFO_BASENAME);
+            $fileName = str_replace($dirName . DIRECTORY_SEPARATOR, '', $item->path);
 
             // Apply the fileMatch filter
             if (!empty($fileMatch) && !fnmatch($fileMatch, $fileName)) {


### PR DESCRIPTION
The basename call here was retrieving only the filename, stripping out the subdirectories when retrieving available paths. This meant that DB results with subdirectories were not corresponding to correct filenames.

Fixes https://github.com/octobercms/october/issues/4642