### PR TITLE
Force CSRF cookie to be decrypted

### DIFF
--- a/src/Cookie/Middleware/EncryptCookies.php
+++ b/src/Cookie/Middleware/EncryptCookies.php
@@ -16,6 +16,10 @@ class EncryptCookies extends \Illuminate\Cookie\Middleware\EncryptCookies
     {
         parent::__construct($encrypter);
         $except = Config::get('cookie.unencryptedCookies', []);
+
+        // Disable encryption on CSRF token cookie
+        $except[] = 'csrfToken';
+
         $this->disableFor($except);
     }
 }


### PR DESCRIPTION
Related PR: https://github.com/octobercms/october/pull/4701.

The CSRF token cookie has to be decrypted in order to be used by the JS framework. Instead of forcing October site devs to add the cookie to their `cookine.unencryptedCookies` config, this will force an override for just this token.