### PR TITLE
Added event for translation helper function

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -236,7 +236,7 @@ if (!function_exists('trans'))
     function trans($id = null, $parameters = [], $domain = 'messages', $locale = null)
     {
         $result = app('translator')->trans($id, $parameters, $domain, $locale);
-        $event = Event::fire('lang.trans', [$id, $result], true);
+        $event = Event::fire('trans.beforeDisplay', [$id, $result], true);
 
         if (is_string($event)) {
             $result = $event;

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -235,7 +235,14 @@ if (!function_exists('trans'))
      */
     function trans($id = null, $parameters = [], $domain = 'messages', $locale = null)
     {
-        return app('translator')->trans($id, $parameters, $domain, $locale);
+        $result = app('translator')->trans($id, $parameters, $domain, $locale);
+        $event = Event::fire('lang.trans', [$id, $result], true);
+
+        if (is_string($event)) {
+            $result = $event;
+        }
+
+        return $result;
     }
 }
 


### PR DESCRIPTION
I've added an event to listen for translations. With this event you can manipulate the content before displaying it.

``` php
Event::listen('trans.beforeDisplay', function ($id, $result) {
    if ($id !== 'codecycler.test::lang.test') {
        return;
    }

    return 'Test';
});
```