### PR TITLE
Move registering of routes to boot method of ServiceProvider

### DIFF
--- a/src/Support/ModuleServiceProvider.php
+++ b/src/Support/ModuleServiceProvider.php
@@ -25,22 +25,13 @@ abstract class ModuleServiceProvider extends ServiceProviderBase
             $this->loadViewsFrom($modulePath . '/views', $module);
             $this->loadTranslationsFrom($modulePath . '/lang', $module);
             $this->loadConfigFrom($modulePath . '/config', $module);
-        }
-    }
 
-    /**
-     * Register the service provider.
-     * @return void
-     */
-    public function register()
-    {
-        if ($module = $this->getModule(func_get_args())) {
             /*
-             * Add routes, if available
-             */
+            * Register routes, if available
+            */
             $routesFile = base_path() . '/modules/' . $module . '/routes.php';
             if (File::isFile($routesFile)) {
-                require $routesFile;
+                $this->loadRoutesFrom($routesFile);
             }
         }
     }


### PR DESCRIPTION
Related PR: https://github.com/octobercms/october/pull/4714

And note from laravel docs - https://laravel.com/docs/5.5/providers#writing-service-providers
> You should never attempt to register any event listeners, routes, or any other piece of functionality within the register method.