### PR TITLE
No longer serialize cookies

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -458,7 +458,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
             }
             elseif ($cookieArray = Cookie::get($this->sessionKey)) {
                 $this->viaRemember = true;
-                $userArray = $cookieArray;
+                $userArray = @json_decode($cookieArray, true);
             }
             else {
                 return false;
@@ -616,7 +616,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
             Session::put($this->sessionKey, $toPersist);
 
             if ($remember) {
-                Cookie::queue(Cookie::forever($this->sessionKey, $toPersist));
+                Cookie::queue(Cookie::forever($this->sessionKey, json_encode($toPersist)));
             }
         }
 

--- a/src/Cookie/Middleware/EncryptCookies.php
+++ b/src/Cookie/Middleware/EncryptCookies.php
@@ -2,20 +2,17 @@
 
 use Config;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+use Illuminate\Cookie\Middleware\EncryptCookies as EncryptCookiesBase;
 
-class EncryptCookies extends \Illuminate\Cookie\Middleware\EncryptCookies
+class EncryptCookies extends EncryptCookiesBase
 {
-    /**
-     * Indicates if cookies should be serialized.
-     *
-     * @var bool
-     */
-    protected static $serialize = true;
-
     public function __construct(EncrypterContract $encrypter)
     {
         parent::__construct($encrypter);
+
+        // Find unencrypted cookies as specified by the configuration
         $except = Config::get('cookie.unencryptedCookies', []);
+
         $this->disableFor($except);
     }
 }


### PR DESCRIPTION
This is based on a security patch that was released by Laravel. We implemented their workaround for the time being, this fixes it properly by disabling cookie serialization all together.

Ref: https://laravel.com/docs/5.6/upgrade#upgrade-5.6.30

> Since this vulnerability is not able to be exploited without access to your application's encryption key, we have chosen to provide a way to re-enable encrypted cookie serialization while you make your application compatible with these changes.