### PR TITLE
Prevent double saving of models in relation manager widget.

### DIFF
--- a/src/Database/Relations/HasOneOrMany.php
+++ b/src/Database/Relations/HasOneOrMany.php
@@ -57,7 +57,10 @@ trait HasOneOrMany
     {
         if ($sessionKey === null) {
             $model->setAttribute($this->getForeignKeyName(), $this->getParentKey());
-            $model->save();
+
+            if (!$model->exists || $model->isDirty()) {
+                $model->save();
+            }
 
             /*
              * Use the opportunity to set the relation in memory


### PR DESCRIPTION
In some cases the relationship has already been associated outside this workflow, this change prevents the save events from triggering twice. This works because it mimics Laravel's internals, where if nothing changes on a model, the database is never engaged, otherwise it would produce a nil update query

Replaces https://github.com/octobercms/october/pull/4723. Fixes https://github.com/octobercms/october/issues/4246