### PR TITLE
Allow replacements to be made for unregistered strings

### DIFF
--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -138,7 +138,7 @@ class Translator implements TranslatorContract
         // that will be quick to spot in the UI if language keys are wrong or missing
         // from the application's language files. Otherwise we can return the line.
         if (!isset($line)) {
-            return $key;
+            return $this->makeReplacements($key, $replace);
         }
 
         return $line;


### PR DESCRIPTION
If you do `trans("hello :where", ['where' => 'world'])`, the `:where` parameter is only substituted if the `hello :where` string is registered in one of the language files. If not, parameter substitutions are not made.