### PR TITLE
Allow using custom or built-in Laravel/Symfony error responses

### DIFF
--- a/src/Foundation/Exception/Handler.php
+++ b/src/Foundation/Exception/Handler.php
@@ -68,6 +68,10 @@ class Handler extends ExceptionHandler
         $response = $this->callCustomHandlers($exception);
 
         if (!is_null($response)) {
+            if ($response instanceof \Symfony\Component\HttpFoundation\Response) {
+                return $response;
+            }
+
             return Response::make($response, $statusCode);
         }
 
@@ -150,7 +154,7 @@ class Handler extends ExceptionHandler
                 $response = $handler($exception, $code, $fromConsole);
             }
             catch (Exception $e) {
-                $response = $this->formatException($e);
+                $response = $this->convertExceptionToResponse($e);
             }
             // If this handler returns a "non-null" response, we will return it so it will
             // get sent back to the browsers. Once the handler returns a valid response


### PR DESCRIPTION
Fixes https://github.com/octobercms/october/issues/3416.

This PR allows to use fully custom responses (Symfony\Component\HttpFoundation\Response) from custom error handlers and fixes the bug mentioned in octobercms/october#3416 and octobercms/october#3127  also allows throwing other Exceptions.

While this is not directly described as a possibility in the docs (https://octobercms.com/docs/services/error-log#exception-handling), where the only example is returning a string which works regardless, I think it's a good thing and also closes octobercms/october#3416 and octobercms/october#3127, which is a bug that occurs when using an error response method that throws an exception.

Checking if the response from a custom handler is a "Response" object fixes the effect that the headers of the first response gets rendered into the content.