### PR TITLE
Trim the list of available artisan commands

### DIFF
--- a/src/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Foundation/Providers/ArtisanServiceProvider.php
@@ -7,6 +7,50 @@ use Illuminate\Foundation\Providers\ArtisanServiceProvider as ArtisanServiceProv
 class ArtisanServiceProvider extends ArtisanServiceProviderBase
 {
     /**
+     * The commands to be registered.
+     *
+     * @var array
+     */
+    protected $commands = [
+        'CacheClear'      => 'command.cache.clear',
+        'CacheForget'     => 'command.cache.forget',
+        'ClearCompiled'   => 'command.clear-compiled',
+        'ConfigCache'     => 'command.config.cache',
+        'ConfigClear'     => 'command.config.clear',
+        'Down'            => 'command.down',
+        'Environment'     => 'command.environment',
+        'KeyGenerate'     => 'command.key.generate',
+        'Optimize'        => 'command.optimize',
+        'PackageDiscover' => 'command.package.discover',
+        'QueueFailed'     => 'command.queue.failed',
+        'QueueFlush'      => 'command.queue.flush',
+        'QueueForget'     => 'command.queue.forget',
+        'QueueListen'     => 'command.queue.listen',
+        'QueueRestart'    => 'command.queue.restart',
+        'QueueRetry'      => 'command.queue.retry',
+        'QueueWork'       => 'command.queue.work',
+        'RouteCache'      => 'command.route.cache',
+        'RouteClear'      => 'command.route.clear',
+        'RouteList'       => 'command.route.list',
+        'ScheduleFinish'  => \Illuminate\Console\Scheduling\ScheduleFinishCommand::class,
+        'ScheduleRun'     => \Illuminate\Console\Scheduling\ScheduleRunCommand::class,
+        'StorageLink'     => 'command.storage.link',
+        'Up'              => 'command.up',
+        'ViewClear'       => 'command.view.clear',
+    ];
+
+    /**
+     * The commands to be registered.
+     *
+     * @var array
+     */
+    protected $devCommands = [
+        'AppName'           => 'command.app.name',
+        'Serve'             => 'command.serve',
+        'VendorPublish'     => 'command.vendor.publish',
+    ];
+
+    /**
      * Register the service provider.
      *
      * @return void


### PR DESCRIPTION
Trim the list of available artisan commands down to those that work.
Commands that are not listed in the array will not be registered,
can not be used on the command and will not appear on the command line when using 'php artisan'.

This PR is a part of an answer to https://github.com/octobercms/docs/issues/394.
I will also submit a small PR for the docs repo, that the 'make' commands from laravel are not supported.

List of disabled command for reference:

* auth
  * clear-resets
* db
  * seed
* event
  * geenerate
* cache
  * table
* make
  * auth
  * command
  * event
  * exception
  * factory
  * job
  * listener
  * mail
  * middleware
  * migrate
  * model
  * notification
  * policy
  * provider
  * request
  * resource
  * rule
  * seeder
  * test
* migrate
  * fresh
  * install
  * refresh
  * reset
  * rollback
  * status
* notifications
  * table
* preset
* queue
  * table
  * failed-table
* session
  * table
* storage
  * link
