### PR TITLE
Fix "unique" validation rule when used with external database

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -439,7 +439,7 @@ trait Validation
             $whereValue
         ) = array_pad(explode(',', $definition), 6, null);
 
-        $table = 'unique:' . $this->getTable();
+        $table = 'unique:' . $this->getConnectionName()  . '.' . $this->getTable();
         $column = $column ?: $fieldName;
         $key = $keyName ? $this->$keyName : $this->getKey();
         $keyName = $keyName ?: $this->getKeyName();

--- a/tests/Database/Traits/ValidationTest.php
+++ b/tests/Database/Traits/ValidationTest.php
@@ -17,12 +17,12 @@ class ValidationTest extends TestCase
 
         $this->exists = true;
         $this->assertEquals([
-            'email' => ['unique:users,email,7,the_id']
+            'email' => ['unique:mysql.users,email,7,the_id']
         ], $this->processValidationRules($rules));
 
         $this->exists = false;
         $this->assertEquals([
-            'email' => ['unique:users']
+            'email' => ['unique:mysql.users']
         ], $this->processValidationRules($rules));
 
         /*
@@ -32,12 +32,12 @@ class ValidationTest extends TestCase
 
         $this->exists = true;
         $this->assertEquals([
-            'email' => ['unique:users,email_address,7,the_id']
+            'email' => ['unique:mysql.users,email_address,7,the_id']
         ], $this->processValidationRules($rules));
 
         $this->exists = false;
         $this->assertEquals([
-            'email' => ['unique:users,email_address']
+            'email' => ['unique:mysql.users,email_address']
         ], $this->processValidationRules($rules));
 
         /*
@@ -47,12 +47,12 @@ class ValidationTest extends TestCase
 
         $this->exists = true;
         $this->assertEquals([
-            'email' => ['unique:users,email_address,7,the_id']
+            'email' => ['unique:mysql.users,email_address,7,the_id']
         ], $this->processValidationRules($rules));
 
         $this->exists = false;
         $this->assertEquals([
-            'email' => ['unique:users,email_address,10']
+            'email' => ['unique:mysql.users,email_address,10']
         ], $this->processValidationRules($rules));
 
         /*
@@ -62,12 +62,12 @@ class ValidationTest extends TestCase
 
         $this->exists = true;
         $this->assertEquals([
-            'email' => ['unique:users,email_address,20,id,account_id,1']
+            'email' => ['unique:mysql.users,email_address,20,id,account_id,1']
         ], $this->processValidationRules($rules));
 
         $this->exists = false;
         $this->assertEquals([
-            'email' => ['unique:users,email_address,NULL,id,account_id,1']
+            'email' => ['unique:mysql.users,email_address,NULL,id,account_id,1']
         ], $this->processValidationRules($rules));
     }
     

--- a/tests/Database/Traits/ValidationTest.php
+++ b/tests/Database/Traits/ValidationTest.php
@@ -22,7 +22,7 @@ class ValidationTest extends TestCase
 
         $this->exists = false;
         $this->assertEquals([
-            'email' => ['unique:mysql.users']
+            'email' => ['unique:users']
         ], $this->processValidationRules($rules));
 
         /*
@@ -37,7 +37,7 @@ class ValidationTest extends TestCase
 
         $this->exists = false;
         $this->assertEquals([
-            'email' => ['unique:mysql.users,email_address']
+            'email' => ['unique:users,email_address']
         ], $this->processValidationRules($rules));
 
         /*
@@ -52,7 +52,7 @@ class ValidationTest extends TestCase
 
         $this->exists = false;
         $this->assertEquals([
-            'email' => ['unique:mysql.users,email_address,10']
+            'email' => ['unique:users,email_address,10']
         ], $this->processValidationRules($rules));
 
         /*
@@ -67,7 +67,7 @@ class ValidationTest extends TestCase
 
         $this->exists = false;
         $this->assertEquals([
-            'email' => ['unique:mysql.users,email_address,NULL,id,account_id,1']
+            'email' => ['unique:users,email_address,NULL,id,account_id,1']
         ], $this->processValidationRules($rules));
     }
     


### PR DESCRIPTION
`Validation::processValidationUniqueRule()` ignores custom connection name when modifying rule that requires database lookup.