### PR TITLE
Make translator implementation compatible with translator interface

### DIFF
--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -245,11 +245,10 @@ class Translator implements TranslatorContract
      *
      * @param  string  $id
      * @param  array   $parameters
-     * @param  string  $domain
      * @param  string  $locale
      * @return string
      */
-    public function trans($id, array $parameters = [], $domain = 'messages', $locale = null)
+    public function trans($id, array $parameters = [], $locale = null)
     {
         return $this->get($id, $parameters, $locale);
     }
@@ -260,11 +259,10 @@ class Translator implements TranslatorContract
      * @param  string  $id
      * @param  int     $number
      * @param  array   $parameters
-     * @param  string  $domain
      * @param  string  $locale
      * @return string
      */
-    public function transChoice($id, $number, array $parameters = [], $domain = 'messages', $locale = null)
+    public function transChoice($id, $number, array $parameters = [], $locale = null)
     {
         return $this->choice($id, $number, $parameters, $locale);
     }


### PR DESCRIPTION
The current implementation of the translator is not compatible with the interface.

The translator interface requires 3 parameters for method `trans`

```php
public function trans($key, array $replace = [], $locale = null);
```

The current implementation has 4 parameters.
```php
public function trans($id, array $parameters = [], $domain = 'messages', $locale = null)
{
     return $this->get($id, $parameters, $locale);
}
```

If I resolve the translator interface I can't set the locale, because it will set the domain parameter (which isn't used) instead of the locale parameter.

For example this will not work:
```php
/** @var Illuminate\Contracts\Translation\Translator $translator */
$translator = resolve(Illuminate\Contracts\Translation\Translator::class);
$translator->trans('my_key', [], 'nl');
```

The same goes for the method `transChoice`