### PR TITLE
Guess extension for uploaded files if missing

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -703,7 +703,7 @@ class File extends Model
         $ext = strtolower($this->getExtension());
         
         // If file was uploaded without extension, attempt to guess it
-        if(!$ext && $this->data instanceof UploadedFile) {
+        if (!$ext && $this->data instanceof UploadedFile) {
             $ext = $this->data->guessExtension();
         }
         

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -701,6 +701,12 @@ class File extends Model
         }
 
         $ext = strtolower($this->getExtension());
+        
+        // If file was uploaded without extension, attempt to guess it
+        if(!$ext && $this->data instanceof UploadedFile) {
+            $ext = $this->data->guessExtension();
+        }
+        
         $name = str_replace('.', '', uniqid(null, true));
 
         return $this->disk_name = !empty($ext) ? $name.'.'.$ext : $name;


### PR DESCRIPTION
This change aims to guess file extension from MIME type if file is being uploaded without file extension. The guessed extension is then added to the generated filename.

Some contextual explanation: 

**Why would a file be uploaded without extension?**

It's the case for raw blob files. For instance, in my app I let the user choose a image file and then allow her/him to do some basic editing (like cropping) client-side. Thus, when uploading, I'm no longer uploading the raw file, but a blob file that don't have a filename and thus doesn't have any extension.


**Why storing file without extension is an issue?**

This can break other October features. For instance, the issue I had when uploading blob images, was that the getThumb function silently failed (because it didn't consider images without extension as images, and thus do not resize them). So typically, I was serving high-res image on my website just to display them as thumbnail and didn't notice it for a long time.

You could argue that a solution is to change my client-side code to manually give filename with extension to the blob. The thing is, even on a regular form input field, a user may attempt to upload an image without file extension (for whatever reason), that successfully passes the "image" validation rule (because this rule only check MIME type), but won't work with the getThumb function, which is counter-intuitive.