### PR TITLE
Inject queue name into auto-created Mailables.

### DIFF
--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -2,6 +2,7 @@
 
 use Event;
 use Config;
+use Queue;
 use Illuminate\Mail\Mailer as MailerBase;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Support\Collection;
@@ -193,7 +194,8 @@ class Mailer extends MailerBase
     public function queue($view, $data = null, $callback = null, $queue = null)
     {
         if (!$view instanceof MailableContract) {
-            $mailable = $this->buildQueueMailable($view, $data, $callback);
+            $mailable = $this->buildQueueMailable($view, $data, $callback, $queue);
+            $queue = null;
         }
         else {
             $mailable = $view;
@@ -230,7 +232,8 @@ class Mailer extends MailerBase
     public function later($delay, $view, $data = null, $callback = null, $queue = null)
     {
         if (!$view instanceof MailableContract) {
-            $mailable = $this->buildQueueMailable($view, $data, $callback);
+            $mailable = $this->buildQueueMailable($view, $data, $callback, $queue);
+            $queue = null;
         }
         else {
             $mailable = $view;
@@ -261,9 +264,13 @@ class Mailer extends MailerBase
      * @param  mixed  $callback
      * @return mixed
      */
-    protected function buildQueueMailable($view, $data, $callback)
+    protected function buildQueueMailable($view, $data, $callback, $queueName = null)
     {
         $mailable = new Mailable;
+
+        if (!empty($queueName)) {
+            $mailable->queue = $queueName;
+        }
 
         $mailable->view($view)->withSerializedData($data);
 

--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -2,7 +2,6 @@
 
 use Event;
 use Config;
-use Queue;
 use Illuminate\Mail\Mailer as MailerBase;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Support\Collection;


### PR DESCRIPTION
The [docs stipulate](https://octobercms.com/docs/services/mail#queueing-mail) using a string for the view parameter when using Mail. When a string is given, the `October\Rain\Mail\Mailer` class is converting the string into a `Mailable` object to pass through Laravel's mail functionality. This `Mailable` object is not being populated with the queue name, and is instead trying to use the queue name as the manager that is passed through to the Mailable object. This is failing when the Mailable is added to the queue, therefore breaking the `Mail::queueOn()` and `Mail::laterOn()` functions.

This fix takes the queue name and injects it into the `Mailable` object, then sets the queue parameter to `null` so that the default QueueManager is used to create the queued job.

Fixes https://github.com/octobercms/october/issues/4870.