### PR TITLE
Add getRelationTypeDefinition methods

### DIFF
--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -142,7 +142,7 @@ trait HasRelationships
     /**
      * Returns all defined relations of given type.
      * @param string $type Relation type
-     * @return array
+     * @return array|string|null
      */
     public function getRelationTypeDefinitions($type)
     {

--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -154,7 +154,7 @@ trait HasRelationships
     }
 
     /**
-     * Returns all defined relations of given type.
+     * Returns the given relation definition.
      * @param string $type Relation type
      * @param string $name Relation name
      * @return array

--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -135,7 +135,36 @@ trait HasRelationships
     public function getRelationDefinition($name)
     {
         if (($type = $this->getRelationType($name)) !== null) {
-            return (array) $this->{$type}[$name] + $this->getRelationDefaults($type);
+            return (array) $this->getRelationTypeDefinition($type, $name) + $this->getRelationDefaults($type);
+        }
+    }
+
+    /**
+     * Returns all defined relations of given type.
+     * @param string $type Relation type
+     * @return array
+     */
+    public function getRelationTypeDefinitions($type)
+    {
+        if (in_array($type, static::$relationTypes)) {
+            return $this->{$type};
+        }
+
+        return [];
+    }
+
+    /**
+     * Returns all defined relations of given type.
+     * @param string $type Relation type
+     * @param string $name Relation name
+     * @return array
+     */
+    public function getRelationTypeDefinition($type, $name)
+    {
+        $definitions = $this->getRelationTypeDefinitions($type);
+
+        if (isset($definitions[$name])) {
+            return $definitions[$name];
         }
     }
 
@@ -148,7 +177,7 @@ trait HasRelationships
         $result = [];
 
         foreach (static::$relationTypes as $type) {
-            $result[$type] = $this->{$type};
+            $result[$type] = $this->getRelationTypeDefinitions($type);
 
             /*
              * Apply default values for the relation type
@@ -171,7 +200,7 @@ trait HasRelationships
     public function getRelationType($name)
     {
         foreach (static::$relationTypes as $type) {
-            if (isset($this->{$type}[$name])) {
+            if ($this->getRelationTypeDefinition($type, $name)) {
                 return $type;
             }
         }

--- a/tests/Database/Concerns/HasRelationshipsTest.php
+++ b/tests/Database/Concerns/HasRelationshipsTest.php
@@ -18,7 +18,7 @@ class HasRelationshipsTest extends TestCase
         });
         $model = new TestModelBelongsTo();
         $this->assertEquals([
-            'relatedModel' => 'TestModelNoRelation', 
+            'relatedModel' => 'TestModelNoRelation',
             'secondRelatedModel' => 'TestModelNoRelation'
         ], $model->getRelationTypeDefinitions('belongsTo'));
     }
@@ -43,23 +43,19 @@ class HasRelationshipsTest extends TestCase
 }
 
 /*
- * Class with implementation in the class itself
+ * Class with belongsTo relation
  */
 class TestModelBelongsTo extends Model
 {
     public $belongsTo = [
         'relatedModel' => 'TestModelNoRelation'
     ];
-    
-    public $purgeable = [];
 }
 
 /*
- * Class with implementation in the class itself but without property
+ * Class with no belongsTo relation
  */
 class TestModelNoRelation extends Model
 {
-    public $implement = [
-        'October.Rain.Database.Behaviors.Purgeable'
-    ];
+
 }

--- a/tests/Database/Concerns/HasRelationshipsTest.php
+++ b/tests/Database/Concerns/HasRelationshipsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use October\Rain\Database\Model;
+
+class HasRelationshipsTest extends TestCase
+{
+    public function testGetRelationTypeDefinitions()
+    {
+        $model = new TestModelBelongsTo();
+        $this->assertEquals([], $model->getRelationTypeDefinitions('belongsToMany'));
+        $this->assertEquals(['relatedModel' => 'TestModelNoRelation'], $model->getRelationTypeDefinitions('belongsTo'));
+    }
+
+    public function testDynamicGetRelationTypeDefinitions()
+    {
+        TestModelBelongsTo::extend(function ($model) {
+            $model->belongsTo['secondRelatedModel'] = 'TestModelNoRelation';
+        });
+        $model = new TestModelBelongsTo();
+        $this->assertEquals([
+            'relatedModel' => 'TestModelNoRelation', 
+            'secondRelatedModel' => 'TestModelNoRelation'
+        ], $model->getRelationTypeDefinitions('belongsTo'));
+    }
+
+    public function testGetRelationTypeDefinition()
+    {
+        $model = new TestModelBelongsTo();
+        $this->assertEquals(null, $model->getRelationTypeDefinition('belongsTo', 'nonExistantRelation'));
+        $this->assertEquals('TestModelNoRelation', $model->getRelationTypeDefinition('belongsTo', 'relatedModel'));
+        $this->assertEquals(null, $model->getRelationTypeDefinition('belongsToMany', 'nonExistantRelation'));
+        $this->assertEquals(null, $model->getRelationTypeDefinition('belongsToMany', 'relatedModel'));
+    }
+
+    public function testDynamicGetRelationTypeDefinition()
+    {
+        TestModelBelongsTo::extend(function ($model) {
+            $model->belongsTo['secondRelatedModel'] = 'TestModelNoRelation';
+        });
+        $model = new TestModelBelongsTo();
+        $this->assertEquals('TestModelNoRelation', $model->getRelationTypeDefinition('belongsTo', 'secondRelatedModel'));
+    }
+}
+
+/*
+ * Class with implementation in the class itself
+ */
+class TestModelBelongsTo extends Model
+{
+    public $belongsTo = [
+        'relatedModel' => 'TestModelNoRelation'
+    ];
+    
+    public $purgeable = [];
+}
+
+/*
+ * Class with implementation in the class itself but without property
+ */
+class TestModelNoRelation extends Model
+{
+    public $implement = [
+        'October.Rain.Database.Behaviors.Purgeable'
+    ];
+}

--- a/tests/Database/Concerns/HasRelationshipsTest.php
+++ b/tests/Database/Concerns/HasRelationshipsTest.php
@@ -8,18 +8,28 @@ class HasRelationshipsTest extends TestCase
     {
         $model = new TestModelBelongsTo();
         $this->assertEquals([], $model->getRelationTypeDefinitions('belongsToMany'));
-        $this->assertEquals(['relatedModel' => 'TestModelNoRelation'], $model->getRelationTypeDefinitions('belongsTo'));
+        $this->assertEquals([
+            'relatedModel' => 'TestModelNoRelation',
+            'anotherRelatedModel' => [
+                'TestModelNoRelation',
+                'order' => 'name desc',
+            ],
+        ], $model->getRelationTypeDefinitions('belongsTo'));
     }
 
     public function testDynamicGetRelationTypeDefinitions()
     {
         TestModelBelongsTo::extend(function ($model) {
-            $model->belongsTo['secondRelatedModel'] = 'TestModelNoRelation';
+            $model->belongsTo['dynamicRelatedModel'] = 'TestModelNoRelation';
         });
         $model = new TestModelBelongsTo();
         $this->assertEquals([
             'relatedModel' => 'TestModelNoRelation',
-            'secondRelatedModel' => 'TestModelNoRelation'
+            'anotherRelatedModel' => [
+                'TestModelNoRelation',
+                'order' => 'name desc',
+            ],
+            'dynamicRelatedModel' => 'TestModelNoRelation'
         ], $model->getRelationTypeDefinitions('belongsTo'));
     }
 
@@ -28,6 +38,7 @@ class HasRelationshipsTest extends TestCase
         $model = new TestModelBelongsTo();
         $this->assertEquals(null, $model->getRelationTypeDefinition('belongsTo', 'nonExistantRelation'));
         $this->assertEquals('TestModelNoRelation', $model->getRelationTypeDefinition('belongsTo', 'relatedModel'));
+        $this->assertEquals(['TestModelNoRelation', 'order' => 'name desc'], $model->getRelationTypeDefinition('belongsTo', 'anotherRelatedModel'));
         $this->assertEquals(null, $model->getRelationTypeDefinition('belongsToMany', 'nonExistantRelation'));
         $this->assertEquals(null, $model->getRelationTypeDefinition('belongsToMany', 'relatedModel'));
     }
@@ -35,10 +46,10 @@ class HasRelationshipsTest extends TestCase
     public function testDynamicGetRelationTypeDefinition()
     {
         TestModelBelongsTo::extend(function ($model) {
-            $model->belongsTo['secondRelatedModel'] = 'TestModelNoRelation';
+            $model->belongsTo['dynamicRelatedModel'] = 'TestModelNoRelation';
         });
         $model = new TestModelBelongsTo();
-        $this->assertEquals('TestModelNoRelation', $model->getRelationTypeDefinition('belongsTo', 'secondRelatedModel'));
+        $this->assertEquals('TestModelNoRelation', $model->getRelationTypeDefinition('belongsTo', 'dynamicRelatedModel'));
     }
 }
 
@@ -48,7 +59,11 @@ class HasRelationshipsTest extends TestCase
 class TestModelBelongsTo extends Model
 {
     public $belongsTo = [
-        'relatedModel' => 'TestModelNoRelation'
+        'relatedModel' => 'TestModelNoRelation',
+        'anotherRelatedModel' => [
+            'TestModelNoRelation',
+            'order' => 'name desc',
+        ]
     ];
 }
 


### PR DESCRIPTION
Rather than read the relation arrays directly, use a methods to retrieve the list of defined relations. These overrideable methods are useful for creating relations on the fly based on data in your model. Fixes  https://github.com/octobercms/october/issues/4930