### PR TITLE
Fix error using count helper on morph relations

### DIFF
--- a/src/Database/Relations/DefinedConstraints.php
+++ b/src/Database/Relations/DefinedConstraints.php
@@ -67,9 +67,9 @@ trait DefinedConstraints
             $countSql = $this->parent->getConnection()->raw('count(*) as count');
 
             $relation
-                ->select($relation->getForeignKey(), $countSql)
-                ->groupBy($relation->getForeignKey())
-                ->orderBy($relation->getForeignKey())
+                ->select($relation->getQualifiedForeignKeyName(), $countSql)
+                ->groupBy($relation->getQualifiedForeignKeyName())
+                ->orderBy($relation->getQualifiedForeignKeyName())
             ;
         }
     }


### PR DESCRIPTION
On Laravel 5.5, the function getForeignKey no longer exists on relations. Some relations (e.g.: Attach) kept working because this function was overridden in October but, for example, on Morph, it was not so it now breaks.

The function getQualifiedForeignKeyName however, is available across all types of relations and is safer to use as it includes the table name in the returned value (which prevents possible ambiguous references on the final query).