### PR TITLE
Allow regular expressions on wildcard parameters

### DIFF
--- a/src/Router/Helper.php
+++ b/src/Router/Helper.php
@@ -124,7 +124,7 @@ class Helper
      */
     public static function segmentIsWildcard($segment)
     {
-        $parts = mb_split("\|", $segment, 2);
+        $parts = mb_split('\|', $segment, 2);
         return mb_strpos($parts[0], ':') === 0 && mb_substr($parts[0], -1) === '*';
     }
 

--- a/src/Router/Helper.php
+++ b/src/Router/Helper.php
@@ -40,11 +40,12 @@ class Helper
     public static function segmentizeUrl($url)
     {
         $url = self::normalizeUrl($url);
-        $segments = explode('/', $url);
+        // Explode by unescaped / characters
+        $segments = mb_split('(?<!\\\)\/', $url);
 
         $result = [];
         foreach ($segments as $segment) {
-            if (strlen($segment)) {
+            if (mb_strlen($segment)) {
                 $result[] = $segment;
             }
         }
@@ -123,7 +124,8 @@ class Helper
      */
     public static function segmentIsWildcard($segment)
     {
-        return mb_strpos($segment, ':') === 0 && mb_substr($segment, -1) === '*';
+        $parts = mb_split("\|", $segment, 2);
+        return mb_strpos($parts[0], ':') === 0 && mb_substr($parts[0], -1) === '*';
     }
 
     /**

--- a/src/Router/Rule.php
+++ b/src/Router/Rule.php
@@ -175,6 +175,15 @@ class Rule
                     return false;
                 }
 
+                $paramValue = $urlSegments[$index];
+
+                /*
+                 * Determine if wildcard and add stored parameters as a suffix
+                 */
+                if (Helper::segmentIsWildcard($patternSegment) && count($wildSegments)) {
+                    $paramValue .= Helper::rebuildUrl($wildSegments);
+                }
+
                 /*
                  * Validate the value with the regular expression
                  */
@@ -182,7 +191,7 @@ class Rule
 
                 if ($regexp) {
                     try {
-                        if (!preg_match($regexp, $urlSegments[$index])) {
+                        if (!preg_match($regexp, $paramValue)) {
                             return false;
                         }
                     }
@@ -193,14 +202,7 @@ class Rule
                 /*
                  * Set the parameter value
                  */
-                $parameters[$paramName] = $urlSegments[$index];
-
-                /*
-                 * Determine if wildcard and add stored parameters as a suffix
-                 */
-                if (Helper::segmentIsWildcard($patternSegment) && count($wildSegments)) {
-                    $parameters[$paramName] .= Helper::rebuildUrl($wildSegments);
-                }
+                $parameters[$paramName] = $paramValue;
             }
         }
 

--- a/tests/Router/RouterHelperTest.php
+++ b/tests/Router/RouterHelperTest.php
@@ -4,6 +4,60 @@ use October\Rain\Router\Helper;
 
 class RouterHelperTest extends TestCase
 {
+    public function testSegmentize()
+    {
+        // Single param
+        $value = Helper::segmentizeUrl("/:my_param_name");
+        $this->assertEquals([':my_param_name'], $value);
+
+        // Single param with regex
+        $value = Helper::segmentizeUrl('/:my_param_name|^[a-z]+[0-9]?$|^[a-z]{3}$');
+        $this->assertEquals([':my_param_name|^[a-z]+[0-9]?$|^[a-z]{3}$'], $value);
+
+        // Multiple params
+        $value = Helper::segmentizeUrl("/param1/:my_param_name");
+        $this->assertEquals(['param1', ':my_param_name'], $value);
+
+        // Skip empty params
+        $value = Helper::segmentizeUrl("/param1//:my_param_name");
+        $this->assertEquals(['param1', ':my_param_name'], $value);
+
+        // Multiple params with regex
+        $value = Helper::segmentizeUrl('/:my_param_name|^[a-z]+[0-9]?$|^[a-z]{3}$/param2');
+        $this->assertEquals([':my_param_name|^[a-z]+[0-9]?$|^[a-z]{3}$', 'param2'], $value);
+
+        // Escaped regex
+        $value = Helper::segmentizeUrl('/:my_param_name*|^[a-z]+\/\d+$');
+        $this->assertEquals([':my_param_name*|^[a-z]+\/\d+$'], $value);
+
+        // Escaped regex with multiple params
+        $value = Helper::segmentizeUrl('/:my_param_name*|^[a-z]+\/\d+$/param2');
+        $this->assertEquals([':my_param_name*|^[a-z]+\/\d+$', 'param2'], $value);
+    }
+
+    public function testSegmentIsWildcard()
+    {
+        // Non wildcard no regex
+        $value = Helper::segmentIsWildcard(":my_param_name");
+        $this->assertFalse($value);
+
+        // Wildcard no regex
+        $value = Helper::segmentIsWildcard(":my_param_name*");
+        $this->assertTrue($value);
+
+        // Non wildcard with regex
+        $value = Helper::segmentIsWildcard(":my_param_name|^[a-z]+[0-9]?$");
+        $this->assertFalse($value);
+
+        // Wildcard with regex
+        $value = Helper::segmentIsWildcard(":my_param_name*|^[a-z]+[0-9]?$");
+        $this->assertTrue($value);
+
+        // Non Wildcard with regex ending in *
+        $value = Helper::segmentIsWildcard(":my_param_name|^[a-z]+[0-9]*");
+        $this->assertFalse($value);
+    }
+
     public function testSegmentIsOptional()
     {
         $value = Helper::segmentIsOptional(':my_param_name');

--- a/tests/Router/RouterTest.php
+++ b/tests/Router/RouterTest.php
@@ -167,6 +167,10 @@ class RouteTest extends TestCase
         $this->assertEquals('code/with', $params['largecode']);
 
         $rule = $router->reset()->route('testRuleId', '/color/:color/largecode/:largecode*|^[a-z]+\/[a-z]+$');
+        $result = $rule->resolveUrl('color/brown/largecode/code/100', $params);
+        $this->assertfalse($result);
+
+        $rule = $router->reset()->route('testRuleId', '/color/:color/largecode/:largecode*|^[a-z]+\/[a-z]+$');
         $result = $rule->resolveUrl('color/brown/largecode/code/with/slashes', $params);
         $this->assertfalse($result);
     }

--- a/tests/Router/RouterTest.php
+++ b/tests/Router/RouterTest.php
@@ -156,6 +156,19 @@ class RouteTest extends TestCase
         $this->assertArrayHasKey('largecode', $params);
         $this->assertEquals('brown', $params['color']);
         $this->assertEquals('code/with/slashes/edit', $params['largecode']);
+
+        $rule = $router->reset()->route('testRuleId', '/color/:color/largecode/:largecode*|^[a-z]+\/[a-z]+$');
+        $result = $rule->resolveUrl('color/brown/largecode/code/with', $params);
+        $this->assertTrue($result);
+        $this->assertEquals(2, count($params));
+        $this->assertArrayHasKey('color', $params);
+        $this->assertArrayHasKey('largecode', $params);
+        $this->assertEquals('brown', $params['color']);
+        $this->assertEquals('code/with', $params['largecode']);
+
+        $rule = $router->reset()->route('testRuleId', '/color/:color/largecode/:largecode*|^[a-z]+\/[a-z]+$');
+        $result = $rule->resolveUrl('color/brown/largecode/code/with/slashes', $params);
+        $this->assertfalse($result);
     }
 
     public function testMatch()


### PR DESCRIPTION
This PR allows page URLs to include regular expressions on their wildcard parameters. For example the following URL is now valid:
> /blog/:page?*|^(page\/\d+)?$

## Use Case
This PR will allow October users to make a single Page work for the following URLs:
> /blog
> /blog/page/2
> /blog/page/4 etc

without it accidentally catching URLs that should load a different Page
> /blog/2020/10/my-post

But really the use cases for allowing regex for wildcard params would be the same as those for allowing it for non-wildcard params.

This PR is backwards compatible and tests have been provided.