### PR TITLE
Support session keys passed through createMany()

### DIFF
--- a/src/Database/Relations/BelongsToMany.php
+++ b/src/Database/Relations/BelongsToMany.php
@@ -214,7 +214,7 @@ class BelongsToMany extends BelongsToManyBase
             $sessionKey = null;
         }
 
-        if ($sessionKey === null) {
+        if ($sessionKey === null || $sessionKey === false) {
             $this->attach($model->getKey(), $pivotData);
             $this->parent->reloadRelations($this->relationName);
         }


### PR DESCRIPTION
## Issue

When calling `$model->someBelongsToManyRelation()->createMany([...])` a deferred binding is created in the database with session key 0. Calling `$model->save()` after this does not commit the deferred binding. A deferred binding is created even when `$model` exists in the database. This issue only affects belongsToMany relations from what I can tell.

## Steps to Replicate

I've created a simple plugin [here](https://github.com/Flynsarmy/oc-baddefer-plugin) to replicate the issue.

## In Depth

`createMany()` is called through the Illuminate file *vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php*.
It loops through each passed array calling `$this->create($record, (array) ($joinings[$key] ?? []), false);` - notice that third argument passed (the one for sessionKey) is `false`.

`create()` is our own method called in *vendor/october/rain/src/Database/Relations/BelongsToMany.php*.
It calls `$this->add($model, $sessionKey, $pivotData);` which in turn checks for a `$sessionKey` of null, and if not found, calls `$this->parent->bindDeferred($this->relationName, $model, $sessionKey);`. Because our sessionKey is `false` instead of `null` this is where we end up.

## Solution

We have two options here. We could override Laravel's `createMany()` method passing the `null` we expect, or we could support Laravel's `false` value in our `BelongsToMany` class. I chose the latter but happy to change my PR to the former if preferred.