### PR TITLE
Fix override of custom validation rules starting with 'unique'

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -376,7 +376,7 @@ trait Validation
                 /*
                  * Remove primary key unique validation rule if the model already exists
                  */
-                if (($rulePart == 'unique' || starts_with($rulePart, 'unique:')) && $this->exists) {
+                if (($rulePart === 'unique' || starts_with($rulePart, 'unique:')) && $this->exists) {
                     $ruleParts[$key] = $this->processValidationUniqueRule($rulePart, $field);
                 }
                 /*

--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -376,7 +376,7 @@ trait Validation
                 /*
                  * Remove primary key unique validation rule if the model already exists
                  */
-                if (starts_with($rulePart, 'unique') && $this->exists) {
+                if (($rulePart == 'unique' || starts_with($rulePart, 'unique:')) && $this->exists) {
                     $ruleParts[$key] = $this->processValidationUniqueRule($rulePart, $field);
                 }
                 /*


### PR DESCRIPTION
Creating a custom validation rule starting with *unique* and adding it to your model results in unintended behaviour when updating the model, as your custom role is overridden with the default *unique* rule.

For example:
```php
Validator::extendDependent('unique_with', function (string $attribute, $value, array $parameters, \Illuminate\Validation\Validator $validator) {
    dd('hi');
});

class MyModel extends Model
{
    use \October\Rain\Database\Traits\Validation;

    public $table = 'my_table';
    public $rules = [
        'key' => 'unique_with:foo,bar',
    ];
}
```
The `dd()` will never execute with this rule on your model, because these lines 
https://github.com/octobercms/library/blob/bb6d88a0f8b33b535de71101ea281245ebe7267c/src/Database/Traits/Validation.php#L379-L381
replace our rule with
> unique:my_table,1,id
