### PR TITLE
Pass current SCSS asset path down to children to use as new root path.

### DIFF
--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -134,9 +134,10 @@ class ScssphpFilter implements DependencyExtractorInterface
         foreach (CssUtils::extractImports($content) as $match) {
             $file = $sc->findImport($match);
             if ($file) {
-                $children[] = $child = $factory->createAsset($file, array(), array('root' => $loadPath));
+                $children[] = $child = $factory->createAsset($file, [], ['root' => $loadPath]);
                 $child->load();
-                $children = array_merge($children, $this->getChildren($factory, $child->getContent(), $loadPath));
+                $childLoadPath = $child->all()[0]->getSourceDirectory();
+                $children = array_merge($children, $this->getChildren($factory, $child->getContent(), $childLoadPath));
             }
         }
 


### PR DESCRIPTION
Previously, this method would pass the same loadPath to all assets down the hierarchy, which would result in any relative paths not being able to be found. This change will take the current directory of the current asset and use that as a base for all child assets.

Will need to test this with a few SCSS-based themes.