### PR TITLE
Don't cast Revision old/new values to DateTime when value is empty

### DIFF
--- a/src/Database/Models/Revision.php
+++ b/src/Database/Models/Revision.php
@@ -22,7 +22,7 @@ class Revision extends Model
      */
     public function getNewValueAttribute($value)
     {
-        if ($this->cast == 'date') {
+        if ($this->cast == 'date' && !is_null($value)) {
             return $this->asDateTime($value);
         }
 
@@ -35,7 +35,7 @@ class Revision extends Model
      */
     public function getOldValueAttribute($value)
     {
-        if ($this->cast == 'date') {
+        if ($this->cast == 'date' && !is_null($value)) {
             return $this->asDateTime($value);
         }
 


### PR DESCRIPTION
This avoid `InvalidArgumentException: Data missing in vendor/nesbot/carbon/src/Carbon/Carbon.php:917` when a revisioned date field as `old_value` or `new_value` empty.

This commit implement same check that the Laravel `getAttributeValue` method use before calling `asDateTime`: [/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L353-L354](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L353-L354)