### PR TITLE
Update Laravel Tinker to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "twig/twig": "~2.0",
         "league/csv": "~9.1",
         "jenssegers/date": "~3.5",
-        "laravel/tinker": "~1.0"
+        "laravel/tinker": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0",


### PR DESCRIPTION
Laravel updated Tinker to 2.0 as of version 6.8.0. This PR is to keep the version October uses in line with Laravel.