### PR TITLE
Fix transChoice broken with October build 466

### DIFF
--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -142,6 +142,8 @@ class Translator extends TranslatorBase
             $localeParts = explode('-', $locale, 2);
             $locale = $localeParts[0] . '_' . strtoupper($localeParts[1]);
         }
+        
+        $replace['count'] = $number;
 
         return $this->makeReplacements($this->getSelector()->choose($line, $number, $locale), $replace);
     }


### PR DESCRIPTION
October 466 introduced a regression in our install.
The transChoice filter stopped working (the ":count" placeholder is no longer replaced on strings).

Not sure what caused the regression, but copying this line from Laravel's Translator implementation fixes the issue.