### PR TITLE
Make File paths more unique

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -708,7 +708,7 @@ class File extends Model
             $ext = $this->data->guessExtension();
         }
         
-        $name = Str::random();
+        $name = strtolower(Str::random(22));
 
         return $this->disk_name = !empty($ext) ? $name.'.'.$ext : $name;
     }

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -973,7 +973,7 @@ class File extends Model
     */
     protected function getPartitionDirectory()
     {
-        return implode('/', array_slice(str_split($this->disk_name, 3), 0, 3)) . '/';
+        return implode('/', array_slice(str_split(substr($this->disk_name, 13), 3), 0, 3)) . '/';
     }
 
     /**

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -3,6 +3,7 @@
 use Cache;
 use Storage;
 use File as FileHelper;
+use October\Rain\Support\Str;
 use October\Rain\Network\Http;
 use October\Rain\Database\Model;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -707,7 +708,7 @@ class File extends Model
             $ext = $this->data->guessExtension();
         }
         
-        $name = str_replace('.', '', uniqid(null, true));
+        $name = Str::random();
 
         return $this->disk_name = !empty($ext) ? $name.'.'.$ext : $name;
     }
@@ -973,7 +974,7 @@ class File extends Model
     */
     protected function getPartitionDirectory()
     {
-        return implode('/', array_slice(str_split(substr($this->disk_name, 13), 3), 0, 3)) . '/';
+        return implode('/', array_slice(str_split($this->disk_name, 3), 0, 3)) . '/';
     }
 
     /**


### PR DESCRIPTION
I've faced a problem where the temp path was shared between many files at each runtime! It couldn't be a coincidence after 5/6 refresh.

To reproduce (at least one way, the one I've followed to ran into this):
Just loop calling the getThumb function:
```twig
    {% for file in files %}
        getPath for {{ file.getFilename() }}: {{ file.getPath() }}<br>
        getThumb for {{ file.getFilename() }}: {{ file.getThumb(100, 100) }}
    {% endfor %}
```
returns:
> getPath for capture-decran-de-2020-06-09-**00-12-20**.png: //localhost:3000/storage/app/uploads/public/**5ee/659/0a8**/5ee6590a85a37857751894.png
> getThumb for capture-decran-de-2020-06-09-**00-12-20**.png: //localhost:3000/storage/app/uploads/public/**5ee/659/0a8**/thumb__100_100_0_0_auto.png
___
> getPath for capture-decran-de-2020-06-09-**13-29-22**.png: //localhost:3000/storage/app/uploads/public/**5ee/659/0a8**/5ee6590a85c5a110138871.png
> getThumb for capture-decran-de-2020-06-09-**13-29-22**.png: //localhost:3000/storage/app/uploads/public/**5ee/659/0a8**/thumb__100_100_0_0_auto.png
___
> getPath for capture-decran-de-2020-06-09-**13-35-48**.png: //localhost:3000/storage/app/uploads/public/**5ee/659/0a8**/5ee6590a85d8c323265258.png
> getThumb for capture-decran-de-2020-06-09-**13-35-48**.png: //localhost:3000/storage/app/uploads/public/**5ee/659/0a8**/thumb__100_100_0_0_auto.png

The problem is that uniqid is based on the current time in microseconds, it's mentioned that it may return a non-unique id but if you try to run many uniqid() "simultaneously", the first characters would be the same. The end of the generated string is more "unique" than the start.

Look a this little test, which in the function would have generate 20 similar paths!

maz@Maz:~/websites/me$ php artisan tinker
Psy Shell v0.9.12 (PHP 7.4.6 — cli) by Justin Hileman
> for($i = 0; $i < 20; $i++) { echo uniqid(null, true). "\n"; }
**5ee665636***679d2.80259532
**5ee665636**683c3.60840028
**5ee665636**68548.61747877
**5ee665636**68729.93979041
**5ee665636**68885.10867562
**5ee665636**689a8.15563143
**5ee665636**68b38.44254708
**5ee665636**68ca8.77327403
**5ee665636**68e07.04888608
**5ee665636**68f53.45817785
**5ee665636**690a9.49324510
**5ee665636**69205.34624093
**5ee665636**69375.77893116
**5ee665636**695c1.55307522
**5ee665636**69777.13772748
**5ee665636**698f8.77848691
**5ee665636**69a61.45040098
**5ee665636**69c76.80682655
**5ee665636**69e32.28284276
**5ee665636**69f65.47962678