### PR TITLE
use :: notation for casting in pgsql

### DIFF
--- a/src/Database/Dongle.php
+++ b/src/Database/Dongle.php
@@ -177,7 +177,7 @@ class Dongle
             return $sql;
         }
 
-        return 'CAST('.$sql.' AS '.$asType.')';
+        return $sql.'::'.$asType;
     }
 
     /**


### PR DESCRIPTION
type-casting in pgsql produce an error when the query is executed.

how to reproduce:
- create a model that has a a relation to `system_files`
- query that model with eager-loading (e.g. using `->has()`)
- error occurred
```("SQLSTATE[42601]: Syntax error: 7 ERROR: syntax error at or near "as" LINE 1: ...les"."attachment_id" = "CAST(table_name"."id" as "TEXT)"```

with this notation it's easier to fix an error with `wrapValue()` in laravel, since detecting a double-colon is much easier than an "as"  statement as it can be confused with alias notation.