### PR TITLE
Http docblock asks for an array, when really what it wants is a callable

### DIFF
--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -164,7 +164,7 @@ class Http
     /**
      * Make a HTTP GET call.
      * @param string $url
-     * @param array  $options
+     * @param callable $options
      * @return self
      */
     public static function get($url, $options = null)
@@ -176,7 +176,7 @@ class Http
     /**
      * Make a HTTP POST call.
      * @param string $url
-     * @param array  $options
+     * @param callable $options
      * @return self
      */
     public static function post($url, $options = null)
@@ -188,7 +188,7 @@ class Http
     /**
      * Make a HTTP DELETE call.
      * @param string $url
-     * @param array  $options
+     * @param callable $options
      * @return self
      */
     public static function delete($url, $options = null)
@@ -200,7 +200,7 @@ class Http
     /**
      * Make a HTTP PATCH call.
      * @param string $url
-     * @param array  $options
+     * @param callable $options
      * @return self
      */
     public static function patch($url, $options = null)
@@ -212,7 +212,7 @@ class Http
     /**
      * Make a HTTP PUT call.
      * @param string $url
-     * @param array  $options
+     * @param callable $options
      * @return self
      */
     public static function put($url, $options = null)
@@ -224,7 +224,7 @@ class Http
     /**
      * Make a HTTP OPTIONS call.
      * @param string $url
-     * @param array  $options
+     * @param callable $options
      * @return self
      */
     public static function options($url, $options = null)


### PR DESCRIPTION
My editor barfed when I tried to pass an anonymous function here, and… the phpdoc expected array. While it the callable $options _could_ be an array, if it were using the callable literal style [$object, 'method'], it's more likely to be passed an anonymous function (like described in the example)