### PR TITLE
Fix one character discrepancy between limited HTML strings and CRLF/LF line breaks

### DIFF
--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -484,7 +484,6 @@ class HtmlBuilder
      */
     protected static function getReadableLength($str)
     {
-        $str = str_replace(["\n", "\r"], "\n", $str);
         return strlen(preg_replace('/\s+/', ' ', $str));
     }
 

--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -428,14 +428,14 @@ class HtmlBuilder
             list($tag, $tagPosition) = $match[0];
 
             $str = substr($html, $position, $tagPosition - $position);
-            if ($printedLength + strlen($str) > $maxLength) {
+            if ($printedLength + self::getReadableLength($str) > $maxLength) {
                 $result .= substr($str, 0, $maxLength - $printedLength) . $end;
                 $printedLength = $maxLength;
                 break;
             }
 
             $result .= $str;
-            $printedLength += strlen($str);
+            $printedLength += self::getReadableLength($str);
             if ($printedLength >= $maxLength) {
                 $result .= $end;
                 break;
@@ -472,6 +472,20 @@ class HtmlBuilder
         }
 
         return $result;
+    }
+
+    /**
+     * Gets the readable length of a string for limit calculations.
+     *
+     * Considers multiple spaces and line breaks to be 1 character, regardless of OS.
+     *
+     * @param string $str
+     * @return int
+     */
+    protected static function getReadableLength($str)
+    {
+        $str = str_replace(["\n", "\r"], "\n", $str);
+        return strlen(preg_replace('/\s+/', ' ', $str));
     }
 
     /**

--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -435,7 +435,7 @@ class HtmlBuilder
             }
 
             $result .= $str;
-            $printedLength += self::getReadableLength($str);
+            $printedLength += static::getReadableLength($str);
             if ($printedLength >= $maxLength) {
                 $result .= $end;
                 break;

--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -428,7 +428,7 @@ class HtmlBuilder
             list($tag, $tagPosition) = $match[0];
 
             $str = substr($html, $position, $tagPosition - $position);
-            if ($printedLength + self::getReadableLength($str) > $maxLength) {
+            if ($printedLength + static::getReadableLength($str) > $maxLength) {
                 $result .= substr($str, 0, $maxLength - $printedLength) . $end;
                 $printedLength = $maxLength;
                 break;

--- a/tests/Html/HtmlBuilderTest.php
+++ b/tests/Html/HtmlBuilderTest.php
@@ -22,14 +22,36 @@ class HtmlBuilderTest extends TestCase
         $this->assertEquals('<p>The quick brown fox jumped over the lazy dog</p><p>The qu...</p>', $result);
 
         $result = with(new HtmlBuilder)->limit(trim("
-            <p>The quick brown fox jumped over the lazy dog</p>
-            <p>The quick brown fox jumped over the lazy dog</p>
+            <p>The quick brown fox jumped over the lazy dog</p>\n<p>The quick brown fox jumped over the lazy dog</p>
         "), 60);
 
-        $this->assertEquals(trim('
-            <p>The quick brown fox jumped over the lazy dog</p>
-            <p>The...</p>
-        '), $result);
+        $this->assertEquals(trim("
+            <p>The quick brown fox jumped over the lazy dog</p>\n<p>The quick brown...</p>
+        "), $result);
+
+        $result = with(new HtmlBuilder)->limit(trim("
+            <p>The quick brown fox jumped over the lazy dog</p>\r\n<p>The quick brown fox jumped over the lazy dog</p>
+        "), 60);
+
+        $this->assertEquals(trim("
+            <p>The quick brown fox jumped over the lazy dog</p>\r\n<p>The quick brown...</p>
+        "), $result);
+
+        $result = with(new HtmlBuilder)->limit(trim("
+            <p>The quick brown fox jumped          over the lazy dog</p>\r\n<p>The quick brown fox jumped over the lazy dog</p>
+        "), 60);
+
+        $this->assertEquals(trim("
+            <p>The quick brown fox jumped          over the lazy dog</p>\r\n<p>The quick brown...</p>
+        "), $result);
+
+        $result = with(new HtmlBuilder)->limit(trim("
+            <p>The quick brown fox jumped over&nbsp;&nbsp;the lazy dog</p>\n<p>The quick brown fox jumped over the lazy dog</p>
+        "), 60);
+
+        $this->assertEquals(trim("
+            <p>The quick brown fox jumped over&nbsp;&nbsp;the lazy dog</p>\n<p>The quick brow...</p>
+        "), $result);
     }
 
     public function testLimitEncoding()


### PR DESCRIPTION
Linked to https://github.com/octobercms/library/pull/510 - this came up in the Windows unit tests. This PR should be merged in with that PR before merge.

Windows CRLF line breaks are considered to be two characters, whereas Unix LF line breaks are one. This causes a discrepancy between Windows and Linux for strings that use `HtmlBuilder::limit()` method, where HTML strings that are limited in Windows will be shorter than on Linux.

This adds a new method to `HtmlBuilder` which will get the "readable" length of a string and consider both line break types to one character, as well as any extra spacing in between characters which is rendered as a single space in HTML.