### PR TITLE
Allow morphTo relations to specify custom keys

### DIFF
--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -269,14 +269,6 @@ trait HasRelationships
             ));
         }
 
-        if (isset($relation[0]) && $relationType == 'morphTo') {
-            throw new InvalidArgumentException(sprintf(
-                "Relation '%s' on model '%s' is a morphTo relation and should not contain additional arguments.",
-                $relationName,
-                get_called_class()
-            ));
-        }
-
         switch ($relationType) {
             case 'hasOne':
             case 'hasMany':


### PR DESCRIPTION
Remove a check that asserts that a morphTo relationship should not have any additional arguments. if the morphMany relationship defines custom id or type keys, then the morphTo relationship must define them as well, or the relationship will not be found.

In my case, the database already has some unwieldly column names that i'm using and I don't want to use the magic column names in HasRelationships->getMorphs