### PR TITLE
Prevent block termination from ending parent buffer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/src/Html/BlockBuilder.php
+++ b/src/Html/BlockBuilder.php
@@ -43,10 +43,6 @@ class BlockBuilder
     public function endPut($append = false)
     {
         $this->endBlock($append);
-
-        if (!count($this->blockStack) && (ob_get_length() > 0)) {
-            ob_end_clean();
-        }
     }
 
     /**
@@ -66,8 +62,7 @@ class BlockBuilder
 
         if ($append) {
             $this->append($name, $contents);
-        }
-        else {
+        } else {
             $this->blocks[$name] = $contents;
         }
     }
@@ -81,9 +76,11 @@ class BlockBuilder
      */
     public function set($name, $content)
     {
-        $this->put($name);
-        echo $content;
-        $this->endPut();
+        if (!isset($this->blocks[$name])) {
+            $this->blocks[$name] = null;
+        }
+
+        $this->blocks[$name] = $content;
     }
 
     /**

--- a/src/Html/BlockBuilder.php
+++ b/src/Html/BlockBuilder.php
@@ -15,6 +15,7 @@ class BlockBuilder
 
     /**
      * Helper for startBlock
+     *
      * @param string $name Specifies the block name.
      * @return void
      */
@@ -25,6 +26,9 @@ class BlockBuilder
 
     /**
      * Begins the layout block.
+     *
+     * This method enables output buffering, so all output will be captured as a part of this block.
+     *
      * @param string $name Specifies the block name.
      * @return void
      */
@@ -36,6 +40,7 @@ class BlockBuilder
 
     /**
      * Helper for endBlock and also clears the output buffer.
+     *
      * @param boolean $append Indicates that the new content should be appended to the existing block content.
      * @return void
      * @throws \Exception if there are no items in the block stack
@@ -47,6 +52,9 @@ class BlockBuilder
 
     /**
      * Closes the layout block.
+     *
+     * This captures all buffered output as the block's content, and ends output buffering.
+     *
      * @param boolean $append Indicates that the new content should be appended to the existing block content.
      * @return void
      * @throws \Exception if there are no items in the block stack
@@ -69,6 +77,9 @@ class BlockBuilder
 
     /**
      * Sets a content of the layout block.
+     *
+     * Output buffering is not used for this method.
+     *
      * @param string $name Specifies the block name.
      * @param string $content Specifies the block content.
      * @return void
@@ -76,15 +87,14 @@ class BlockBuilder
      */
     public function set($name, $content)
     {
-        if (!isset($this->blocks[$name])) {
-            $this->blocks[$name] = null;
-        }
-
         $this->blocks[$name] = $content;
     }
 
     /**
      * Appends a content of the layout block.
+     *
+     * Output buffering is not used for this method.
+     *
      * @param string $name Specifies the block name.
      * @param string $content Specifies the block content.
      * @return void
@@ -92,7 +102,7 @@ class BlockBuilder
     public function append($name, $content)
     {
         if (!isset($this->blocks[$name])) {
-            $this->blocks[$name] = null;
+            $this->blocks[$name] = '';
         }
 
         $this->blocks[$name] .= $content;
@@ -100,6 +110,7 @@ class BlockBuilder
 
     /**
      * Returns the layout block contents and deletes the block from memory.
+     *
      * @param string $name Specifies the block name.
      * @param string $default Specifies a default block value to use if the block requested is not exists.
      * @return string
@@ -118,6 +129,7 @@ class BlockBuilder
 
     /**
      * Returns the layout block contents but not deletes the block from memory.
+     *
      * @param string $name Specifies the block name.
      * @param string $default Specifies a default block value to use if the block requested is not exists.
      * @return string
@@ -133,11 +145,22 @@ class BlockBuilder
 
     /**
      * Clears all the registered blocks.
+     *
      * @return void
      */
     public function reset()
     {
         $this->blockStack = [];
         $this->blocks = [];
+    }
+
+    /**
+     * Gets the block stack at this point.
+     *
+     * @return array
+     */
+    public function getBlockStack()
+    {
+        return $this->blockStack;
     }
 }

--- a/tests/Html/BlockBuilderTest.php
+++ b/tests/Html/BlockBuilderTest.php
@@ -186,4 +186,47 @@ class BlockBuilderTest extends TestCase
             $this->Block->get('inner')
         );
     }
+
+    public function testContainBetweenBlocks()
+    {
+        ob_start();
+
+        $this->Block->put('test');
+
+        echo ''
+            . '<div>' . "\n"
+            . '    Test' . "\n"
+            . '</div>';
+
+        $this->Block->endPut();
+
+        echo 'In between';
+
+        $this->Block->put('test2');
+
+        echo ''
+            . '<div>' . "\n"
+            . '    Test2' . "\n"
+            . '</div>';
+
+        $this->Block->endPut();
+
+        $content = ob_get_clean();
+
+        $this->assertEquals(
+            ''
+            . '<div>' . "\n"
+            . '    Test' . "\n"
+            . '</div>',
+            $this->Block->get('test')
+        );
+        $this->assertEquals(
+            ''
+            . '<div>' . "\n"
+            . '    Test2' . "\n"
+            . '</div>',
+            $this->Block->get('test2')
+        );
+        $this->assertEquals('In between', $content);
+    }
 }

--- a/tests/Html/BlockBuilderTest.php
+++ b/tests/Html/BlockBuilderTest.php
@@ -1,0 +1,189 @@
+<?php
+
+use October\Rain\Html\BlockBuilder;
+
+class BlockBuilderTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->Block = new BlockBuilder();
+    }
+
+    public function testPutBlock()
+    {
+        $this->Block->put('test');
+
+        $this->assertEquals(['test'], $this->Block->getBlockStack());
+
+        echo ''
+            . '<div>' . "\n"
+            . '    Test' . "\n"
+            . '</div>';
+
+        $this->Block->endPut();
+
+        $this->assertEquals(
+            ''
+            . '<div>' . "\n"
+            . '    Test' . "\n"
+            . '</div>',
+            $this->Block->get('test')
+        );
+
+        // Overwrite block
+        $this->Block->put('test');
+
+        $this->assertEquals(['test'], $this->Block->getBlockStack());
+
+        echo ''
+            . '<div>' . "\n"
+            . '    Test2' . "\n"
+            . '</div>';
+
+        $this->Block->endPut();
+
+        $this->assertEquals(
+            ''
+            . '<div>' . "\n"
+            . '    Test2' . "\n"
+            . '</div>',
+            $this->Block->get('test')
+        );
+
+        // Append block
+        $this->Block->put('test');
+
+        $this->assertEquals(['test'], $this->Block->getBlockStack());
+
+        echo '' . "\n"
+            . '<div>' . "\n"
+            . '    Test3' . "\n"
+            . '</div>';
+
+        $this->Block->endPut(true);
+
+        $this->assertEquals(
+            ''
+            . '<div>' . "\n"
+            . '    Test2' . "\n"
+            . '</div>' . "\n"
+            . '<div>' . "\n"
+            . '    Test3' . "\n"
+            . '</div>',
+            $this->Block->get('test')
+        );
+    }
+
+    public function testSetBlock()
+    {
+        ob_start();
+
+        $this->Block->set('test', 'Inside block');
+        echo 'Outside block';
+
+        $content = ob_get_clean();
+
+        $this->assertEquals('Inside block', $this->Block->get('test'));
+        $this->assertEquals('Outside block', $content);
+    }
+
+    public function testAppendBlock()
+    {
+        ob_start();
+
+        $this->Block->set('test', 'Inside block');
+
+        echo 'Outside block';
+
+        $this->Block->append('test', ' appended');
+
+        $content = ob_get_clean();
+
+        $this->assertEquals('Inside block appended', $this->Block->get('test'));
+        $this->assertEquals('Outside block', $content);
+    }
+
+    public function testPlaceholderBlock()
+    {
+        $this->Block->put('test');
+
+        echo ''
+            . '<div>' . "\n"
+            . '    Test' . "\n"
+            . '</div>';
+
+        $this->Block->endPut();
+
+        $this->assertEquals(
+            ''
+            . '<div>' . "\n"
+            . '    Test' . "\n"
+            . '</div>',
+            $this->Block->placeholder('test')
+        );
+        $this->assertNull($this->Block->get('test'));
+    }
+
+    public function testResetBlocks()
+    {
+        $this->Block->put('test');
+
+        echo ''
+            . '<div>' . "\n"
+            . '    Test' . "\n"
+            . '</div>';
+
+        $this->Block->endPut();
+
+        $this->Block->reset();
+
+        $this->assertNull($this->Block->get('test'));
+    }
+
+    public function testNestedBlocks()
+    {
+        ob_start();
+
+        // Start outer block
+        $this->Block->put('test');
+
+        echo ''
+            . '<div>' . "\n";
+
+        $this->assertEquals(['test'], $this->Block->getBlockStack());
+
+        // Start inner block
+        $this->Block->put('inner');
+
+        echo ''
+            . '    Test' . "\n";
+
+        $this->assertEquals(['test', 'inner'], $this->Block->getBlockStack());
+
+        // End inner block
+        $this->Block->endPut();
+
+        echo ''
+            . '</div>';
+
+        $this->assertEquals(['test'], $this->Block->getBlockStack());
+
+        // End outer block
+        $this->Block->endPut();
+
+        $content = ob_get_clean();
+
+        $this->assertEmpty($content);
+        $this->assertEquals(
+            ''
+            . '<div>' . "\n"
+            . '</div>',
+            $this->Block->get('test')
+        );
+        $this->assertEquals(
+            ''
+            . '    Test' . "\n",
+            $this->Block->get('inner')
+        );
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/octobercms/october/issues/5108

These 3 lines in the BlockBuilder are basically breaking out of a parent output buffer in the scenario mentioned in the linked issue:
https://github.com/octobercms/library/blob/develop/src/Html/BlockBuilder.php#L47-L49

Essentially, if there's any output between the two blocks (such as some normal content, or even just whitespace), those lines will do another `ob_end_clean`, which actually breaks out of the parent buffer (in your case, the `body` buffer, which is delivered here: https://github.com/octobercms/october/blob/develop/modules/system/traits/ViewMaker.php#L126-L127). This is what causes the content to end up at the top of the page if you use multiple blocks.

This should allow multiple blocks to be used. If any content is within the blocks, it should be picked up and appended to the body via the `ViewMaker` code linked above.