### PR TITLE
Allow to install latest jenssegers/date

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "symfony/yaml": "^3.4",
         "twig/twig": "~2.0",
         "league/csv": "~9.1",
-        "jenssegers/date": "~3.5",
+        "jenssegers/date": "~3.5 || ~4.0",
         "laravel/framework": "~6.0",
         "laravel/tinker": "~2.0"
     },


### PR DESCRIPTION
jenssegers/date now relies on Carbon 2 for the translatons which support more languages.

All the features of jenssegers are now provided out of the box by Carbon, so the new jenssegers/date is way lighter (https://github.com/jenssegers/date/blob/master/src/Date.php) and directly use internal methods of Carbon to just add the translation support right in `parse()` and `createFromFormat()` method.

De facto, it fixed a lot of remaining bugs of jenssegers/date 3: https://github.com/jenssegers/date/pull/317