### PR TITLE
Backport change to 1.0 - convert guarded rules to fillable rules

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -50,7 +50,7 @@ class File extends Model
      * @var array The attributes that aren't mass assignable.
      */
     protected $guarded = [];
-    
+
     /**
      * @var array Known image extensions.
      */

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -30,12 +30,27 @@ class File extends Model
     public $morphTo = [
         'attachment' => []
     ];
+    
+    /**
+     * @var array The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'file_name',
+        'title',
+        'description',
+        'field',
+        'attachment_id',
+        'attachment_type',
+        'is_public',
+        'sort_order',
+        'data',
+    ];
 
     /**
      * @var array The attributes that aren't mass assignable.
      */
-    protected $guarded = ['disk_name'];
-
+    protected $guarded = [];
+    
     /**
      * @var array Known image extensions.
      */


### PR DESCRIPTION
Backports the fix in 1.1 - https://github.com/octobercms/library/blob/6cd6af6940ca15598ad1bab64e2db4a005d9d38f/src/Database/Attach/File.php - as Laravel have deployed the same security fix to L5.5 as well.

Fixes https://github.com/octobercms/october/issues/5270.