### PR TITLE
Make auth exception messages more vague

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -232,7 +232,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
 
         $user = $query->first();
         if (!$this->validateUserModel($user)) {
-            throw new AuthException('A user was not found with the given credentials.');
+            throw new AuthException('Username or Password is incorrect.');
         }
 
         /*
@@ -243,13 +243,12 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
                 // Incorrect password
                 if ($credential == 'password') {
                     throw new AuthException(sprintf(
-                        'A user was found to match all plain text credentials however hashed credential "%s" did not match.',
-                        $credential
+                        'Given Username or Password is incorrect. Please try again.'
                     ));
                 }
 
                 // User not found
-                throw new AuthException('A user was not found with the given credentials.');
+                throw new AuthException('Username or Password is incorrect.');
             }
         }
 
@@ -293,7 +292,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
     {
         $user = $this->findUserByLogin($loginName);
         if (!$user) {
-            throw new AuthException("A user was not found with the given credentials.");
+            throw new AuthException("Username or Password is incorrect.");
         }
 
         $userId = $user->getKey();


### PR DESCRIPTION
https://huntr.dev/users/d3m0n-r00t has fixed the Username Enumeration vulnerability 🔨. d3m0n-r00t has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/library/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/packagist/october/october/1/README.md

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-packagist-october%2Foctober

### ⚙️ Description *
Username enumeration is possible at the login page of octobercms login page. Username enumeration is possible at the login page of octobercms login page. This was due to the error message it showed while giving wrong credentials.

### 🐛 Proof of Concept (PoC) *
   1. Clone and setup octobercms.
   2. Username enumeration is possible at http://localhost/octobercms/backend/backend/auth/signin
   3. Correct usernames provides "a user found ....."

```
if (!$this->validateUserModel($user)) {
            throw new AuthException('A user was not found with the given credentials.');
        }

        /*
         * Check the hashed credentials match
         */
        foreach ($hashedCredentials as $credential => $value) {
            if (!$user->checkHashValue($credential, $value)) {
                // Incorrect password
                if ($credential == 'password') {
                    throw new AuthException(sprintf(
                        'A user was found to match all plain text credentials however hashed credential "%s" did not match.',
                        $credential
                    ));
                }

                // User not found
                throw new AuthException('A user was not found with the given credentials.');
```
https://github.com/octobercms/library/blob/develop/src/Auth/Manager.php
### 🔥 Proof of Fix (PoF) *
```
if (!$this->validateUserModel($user)) {
            throw new AuthException('Username or Password is incorrect.');
        }

        /*
         * Check the hashed credentials match
         */
        foreach ($hashedCredentials as $credential => $value) {
            if (!$user->checkHashValue($credential, $value)) {
                // Incorrect password
                if ($credential == 'password') {
                    throw new AuthException(sprintf(
                        'Given Username or Password is incorrect. Please try again.'
                    ));
                }

                // User not found
                throw new AuthException('Username or Password is incorrect.');
```
https://github.com/d3m0n-r00t/library/blob/username-enum-fix/src/Auth/Manager.php
### 👍 User Acceptance Testing (UAT)
Only the error message is changed. The app should work fine.