### PR TITLE
save/retrieve locale when serializing mail data in the queue

### DIFF
--- a/src/Mail/Mailable.php
+++ b/src/Mail/Mailable.php
@@ -48,7 +48,7 @@ class Mailable extends MailableBase
      */
     public function withSerializedData($data)
     {
-        // save current locale to be serialized
+        // Ensure that the current locale is stored with the rest of the data for proper translation of queued messages
         $defaultData = [
             '_current_locale' => App::getLocale(),
         ];

--- a/src/Mail/Mailable.php
+++ b/src/Mail/Mailable.php
@@ -55,8 +55,7 @@ class Mailable extends MailableBase
     public function withSerializedData($data)
     {
         // save current locale in $data to be serialized
-        list($locale) = explode('-', App::getLocale());
-        $data['_saved_locale'] = $locale;
+        $data['_saved_locale'] = App::getLocale());
 
         foreach ($data as $param => $value) {
             $this->viewData[$param] = $this->getSerializedPropertyValue($value);

--- a/src/Mail/Mailable.php
+++ b/src/Mail/Mailable.php
@@ -33,12 +33,6 @@ class Mailable extends MailableBase
     {
         $data = $this->viewData;
 
-        // retrieve saved locale
-        if (isset($data['_current_locale'])) {
-            App::setLocale($data['_current_locale']);
-            unset($data['_current_locale']);
-        }
-
         foreach ($data as $param => $value) {
             $data[$param] = $this->getRestoredPropertyValue($value);
         }

--- a/src/Mail/Mailable.php
+++ b/src/Mail/Mailable.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Mail;
 
+use App;
 use Illuminate\Mail\Mailable as MailableBase;
 
 /**
@@ -32,6 +33,12 @@ class Mailable extends MailableBase
     {
         $data = $this->viewData;
 
+        // retrieved saved locale
+        if (isset($data['_saved_locale'])) {
+            App::setLocale($data['_saved_locale']);
+            unset($data['_saved_locale']);
+        }
+
         foreach ($data as $param => $value) {
             $data[$param] = $this->getRestoredPropertyValue($value);
         }
@@ -47,6 +54,10 @@ class Mailable extends MailableBase
      */
     public function withSerializedData($data)
     {
+        // save current locale in $data to be serialized
+        list($locale) = explode('-', App::getLocale());
+        $data['_saved_locale'] = $locale;
+
         foreach ($data as $param => $value) {
             $this->viewData[$param] = $this->getSerializedPropertyValue($value);
         }

--- a/src/Mail/Mailable.php
+++ b/src/Mail/Mailable.php
@@ -33,10 +33,10 @@ class Mailable extends MailableBase
     {
         $data = $this->viewData;
 
-        // retrieved saved locale
-        if (isset($data['_saved_locale'])) {
-            App::setLocale($data['_saved_locale']);
-            unset($data['_saved_locale']);
+        // retrieve saved locale
+        if (isset($data['_current_locale'])) {
+            App::setLocale($data['_current_locale']);
+            unset($data['_current_locale']);
         }
 
         foreach ($data as $param => $value) {
@@ -54,8 +54,12 @@ class Mailable extends MailableBase
      */
     public function withSerializedData($data)
     {
-        // save current locale in $data to be serialized
-        $data['_saved_locale'] = App::getLocale());
+        // save current locale to be serialized
+        $defaultData = [
+            '_current_locale' => App::getLocale(),
+        ];
+
+        $data = array_merge($defaultData, $data);
 
         foreach ($data as $param => $value) {
             $this->viewData[$param] = $this->getSerializedPropertyValue($value);


### PR DESCRIPTION
When a mail is queued, we need to save the locale that was used to generate the mail in order to be able to localize the mail view when the mail is dequeued.

Upon dequeueing the mail, we retrieve the locale and set the App locale with it.