### PR TITLE
add methods to peek the protected $casts array

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -469,9 +469,31 @@ class Model extends EloquentModel
     }
 
     /**
-     * Checks if an attribute is jsonable or not.
+     * Get the cast type for an attribute
+     *
+     * @param string $key
+     * @return string|null
+     */
+    public function getCast($key)
+    {
+        return array_get($this->casts, $key);
+    }
+
+    /**
+     * Get the casts attributes array
      *
      * @return array
+     */
+    public function getCasts()
+    {
+        return $this->casts;
+    }
+
+    /**
+     * Checks if an attribute is jsonable or not.
+     *
+     * @param string $key
+     * @return bool
      */
     public function isJsonable($key)
     {

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -42,6 +42,11 @@ class Model extends EloquentModel
     protected $jsonable = [];
 
     /**
+     * @var array List of attribute names which are casts
+     */
+    protected $casts = [];
+
+    /**
      * @var array List of datetime attributes to convert to an instance of Carbon/DateTime objects.
      */
     protected $dates = [];

--- a/tests/Database/ModelAddersTest.php
+++ b/tests/Database/ModelAddersTest.php
@@ -6,6 +6,8 @@ class ModelAddersTest extends TestCase
     {
         $model = new TestModel();
 
+        $model->addCasts(['id' => 'int']);
+
         $this->assertEquals(['id' => 'int'], $model->getCasts());
 
         $model->addCasts(['foo' => 'int']);


### PR DESCRIPTION
There is currently no way to know if a model attribute is a cast or which cast type it's using.