### PR TITLE
Add most of test classes namespace

### DIFF
--- a/tests/Assetic/MockAsset.php
+++ b/tests/Assetic/MockAsset.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace October\Rain\Tests\Assetic;
+
 use October\Rain\Assetic\Asset\AssetInterface;
 use October\Rain\Assetic\Filter\FilterInterface;
 

--- a/tests/Assetic/StylesheetMinifyTest.php
+++ b/tests/Assetic/StylesheetMinifyTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Assetic;
+
 use October\Rain\Assetic\Filter\StylesheetMinify;
+use October\Rain\Tests\TestCase;
 
 class StylesheetMinifyTest extends TestCase
 {

--- a/tests/Config/ConfigWriterTest.php
+++ b/tests/Config/ConfigWriterTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Config;
+
 use October\Rain\Config\ConfigWriter;
+use October\Rain\Tests\TestCase;
 
 class ConfigWriterTest extends TestCase
 {

--- a/tests/Database/Attach/ResizerTest.php
+++ b/tests/Database/Attach/ResizerTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Database\Attach;
+
 use October\Rain\Database\Attach\Resizer;
+use October\Rain\Tests\TestCase;
 
 class ResizerTest extends TestCase
 {

--- a/tests/Database/Behaviors/PurgeableTest.php
+++ b/tests/Database/Behaviors/PurgeableTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Database\Behaviors;
+
 use October\Rain\Database\Model;
+use October\Rain\Tests\TestCase;
 
 class PurgeableTest extends TestCase
 {
@@ -48,7 +51,7 @@ class TestModelDirect extends Model
     public $implement = [
         'October.Rain.Database.Behaviors.Purgeable'
     ];
-    
+
     public $purgeable = [];
 }
 

--- a/tests/Database/DongleTest.php
+++ b/tests/Database/DongleTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Database;
+
 use October\Rain\Database\Dongle;
+use October\Rain\Tests\TestCase;
 
 class DongleTest extends TestCase
 {

--- a/tests/Database/ModelAddersTest.php
+++ b/tests/Database/ModelAddersTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use October\Rain\Tests\TestCase;
+
 class ModelAddersTest extends TestCase
 {
     public function testAddCasts()

--- a/tests/Database/SortableTest.php
+++ b/tests/Database/SortableTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use October\Rain\Tests\TestCase;
+
 class SortableTest extends TestCase
 {
     public function setUp(): void
     {
-        $capsule = new Illuminate\Database\Capsule\Manager;
+        $capsule = new \Illuminate\Database\Capsule\Manager;
         $capsule->addConnection([
             'driver'   => 'sqlite',
             'database' => ':memory:',

--- a/tests/Database/Traits/EncryptableTest.php
+++ b/tests/Database/Traits/EncryptableTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Encryption\Encrypter;
+use October\Rain\Tests\TestCase;
 
 class EncryptableTest extends TestCase
 {

--- a/tests/Database/Traits/SluggableTest.php
+++ b/tests/Database/Traits/SluggableTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use October\Rain\Tests\TestCase;
+
 class SluggableTest extends TestCase
 {
 
     public function setUp(): void
     {
-        $capsule = new Illuminate\Database\Capsule\Manager;
+        $capsule = new \Illuminate\Database\Capsule\Manager;
         $capsule->addConnection([
             'driver'   => 'sqlite',
             'database' => ':memory:',

--- a/tests/Database/Traits/ValidationTest.php
+++ b/tests/Database/Traits/ValidationTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Database\Traits;
+
+use October\Rain\Tests\TestCase;
+
 class ValidationTest extends TestCase
 {
     use \October\Rain\Database\Traits\Validation;
@@ -70,7 +74,7 @@ class ValidationTest extends TestCase
             'email' => ['unique:users,email_address,NULL,id,account_id,1']
         ], $this->processValidationRules($rules));
     }
-    
+
     protected function getConnectionName()
     {
         return 'mysql';

--- a/tests/Database/UpdaterTest.php
+++ b/tests/Database/UpdaterTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use October\Rain\Tests\TestCase;
 use October\Rain\Database\Updater;
 
 class UpdaterTest extends TestCase
@@ -13,7 +14,7 @@ class UpdaterTest extends TestCase
 
     public function testClassNameGetsParsedCorrectly()
     {
-        $reflector = new ReflectionClass(TestPlugin\SampleClass::class);
+        $reflector = new \ReflectionClass(TestPlugin\SampleClass::class);
         $filePath = $reflector->getFileName();
 
         $classFullName = $this->updater->getClassFromFile($filePath);

--- a/tests/Extension/ExtendableTest.php
+++ b/tests/Extension/ExtendableTest.php
@@ -2,6 +2,7 @@
 
 use October\Rain\Extension\Extendable;
 use October\Rain\Extension\ExtensionBase;
+use October\Rain\Tests\TestCase;
 
 class ExtendableTest extends TestCase
 {
@@ -149,7 +150,7 @@ class ExtendableTest extends TestCase
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Class ExtendableTestInvalidExtendableClass contains an invalid $implement value');
-        
+
         $result = new ExtendableTestInvalidExtendableClass;
     }
 

--- a/tests/Extension/ExtensionTest.php
+++ b/tests/Extension/ExtensionTest.php
@@ -2,6 +2,7 @@
 
 use October\Rain\Extension\Extendable;
 use October\Rain\Extension\ExtensionBase;
+use October\Rain\Tests\TestCase;
 
 class ExtensionTest extends TestCase
 {

--- a/tests/Filesystem/PathResolverTest.php
+++ b/tests/Filesystem/PathResolverTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Filesystem;
+
 use October\Rain\Filesystem\PathResolver;
+use October\Rain\Tests\TestCase;
 
 /**
  * The tests below will test both the resolve_path() method (and wrapped PathResolver::resolve() method),

--- a/tests/Halcyon/DatasourceResolverTest.php
+++ b/tests/Halcyon/DatasourceResolverTest.php
@@ -1,8 +1,11 @@
 <?php
 
+namespace October\Rain\Tests\Halcyon;
+
 use October\Rain\Filesystem\Filesystem;
 use October\Rain\Halcyon\Datasource\Resolver;
 use October\Rain\Halcyon\Datasource\FileDatasource;
+use October\Rain\Tests\TestCase;
 
 class DatasourceResolverTest extends TestCase
 {

--- a/tests/Halcyon/MemoryRepositoryTest.php
+++ b/tests/Halcyon/MemoryRepositoryTest.php
@@ -1,7 +1,10 @@
 <?php
 
+namespace October\Rain\Tests\Halcyon;
+
 use October\Rain\Halcyon\MemoryRepository;
 use Illuminate\Cache\ArrayStore;
+use October\Rain\Tests\TestCase;
 
 class MemoryRepositoryTest extends TestCase
 {

--- a/tests/Halcyon/ModelTest.php
+++ b/tests/Halcyon/ModelTest.php
@@ -4,6 +4,7 @@ use October\Rain\Halcyon\Model;
 use October\Rain\Halcyon\Datasource\Resolver;
 use October\Rain\Halcyon\Datasource\FileDatasource;
 use October\Rain\Filesystem\Filesystem;
+use October\Rain\Tests\TestCase;
 
 class HalcyonModelTest extends TestCase
 {

--- a/tests/Halcyon/SectionParserTest.php
+++ b/tests/Halcyon/SectionParserTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Halcyon;
+
 use October\Rain\Halcyon\Processors\SectionParser;
+use October\Rain\Tests\TestCase;
 
 class SectionParserTest extends TestCase
 {

--- a/tests/Halcyon/ValidationTraitTest.php
+++ b/tests/Halcyon/ValidationTraitTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Halcyon;
+
+use October\Rain\Tests\TestCase;
+
 class ValidationTraitTest extends TestCase
 {
     public function testArrayFieldNames()

--- a/tests/Html/HtmlBuilderTest.php
+++ b/tests/Html/HtmlBuilderTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Html;
+
 use October\Rain\Html\HtmlBuilder;
+use October\Rain\Tests\TestCase;
 
 class HtmlBuilderTest extends TestCase
 {

--- a/tests/Html/HtmlHelperTest.php
+++ b/tests/Html/HtmlHelperTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Html;
+
 use October\Rain\Html\Helper as HtmlHelper;
+use October\Rain\Tests\TestCase;
 
 class HtmlHelperTest extends TestCase
 {

--- a/tests/Mail/MailerTest.php
+++ b/tests/Mail/MailerTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Mail;
+
 use October\Rain\Mail\Mailer;
+use October\Rain\Tests\TestCase;
 
 class MailerTest extends TestCase
 {
@@ -11,7 +14,7 @@ class MailerTest extends TestCase
     protected static function callProtectedMethod($object, $name, $params = [])
     {
         $className = get_class($object);
-        $class = new ReflectionClass($className);
+        $class = new \ReflectionClass($className);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
         return $method->invokeArgs($object, $params);

--- a/tests/Network/HttpTest.php
+++ b/tests/Network/HttpTest.php
@@ -1,7 +1,10 @@
 <?php
 
+namespace October\Rain\Tests\Network;
+
 use October\Rain\Exception\ApplicationException;
 use October\Rain\Network\Http;
+use October\Rain\Tests\TestCase;
 
 class HttpTest extends TestCase
 {

--- a/tests/Parse/BracketTest.php
+++ b/tests/Parse/BracketTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Parse;
+
 use October\Rain\Parse\Bracket as TextParser;
+use October\Rain\Tests\TestCase;
 
 class BracketTest extends TestCase
 {

--- a/tests/Parse/IniTest.php
+++ b/tests/Parse/IniTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Parse;
+
 use October\Rain\Parse\Ini as IniParser;
+use October\Rain\Tests\TestCase;
 
 class IniTest extends TestCase
 {

--- a/tests/Parse/SyntaxFieldParserTest.php
+++ b/tests/Parse/SyntaxFieldParserTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Parse;
+
 use October\Rain\Parse\Syntax\FieldParser;
+use October\Rain\Tests\TestCase;
 
 class SyntaxFieldParserTest extends TestCase
 {
@@ -362,7 +365,7 @@ class SyntaxFieldParserTest extends TestCase
     protected static function callProtectedMethod($object, $name, $params = [])
     {
         $className = get_class($object);
-        $class = new ReflectionClass($className);
+        $class = new \ReflectionClass($className);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
         return $method->invokeArgs($object, $params);
@@ -371,7 +374,7 @@ class SyntaxFieldParserTest extends TestCase
     public static function getProtectedProperty($object, $name)
     {
         $className = get_class($object);
-        $class = new ReflectionClass($className);
+        $class = new \ReflectionClass($className);
         $property = $class->getProperty($name);
         $property->setAccessible(true);
         return $property->getValue($object);
@@ -380,7 +383,7 @@ class SyntaxFieldParserTest extends TestCase
     public static function setProtectedProperty($object, $name, $value)
     {
         $className = get_class($object);
-        $class = new ReflectionClass($className);
+        $class = new \ReflectionClass($className);
         $property = $class->getProperty($name);
         $property->setAccessible(true);
         return $property->setValue($object, $value);

--- a/tests/Parse/SyntaxParserTest.php
+++ b/tests/Parse/SyntaxParserTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use October\Rain\Parse\Syntax\Parser;
+use October\Rain\Tests\TestCase;
 
 class DropDownOptions
 {

--- a/tests/Router/RouterHelperTest.php
+++ b/tests/Router/RouterHelperTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Router;
+
 use October\Rain\Router\Helper;
+use October\Rain\Tests\TestCase;
 
 class RouterHelperTest extends TestCase
 {

--- a/tests/Router/RouterTest.php
+++ b/tests/Router/RouterTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Router;
+
 use October\Rain\Router\Router;
+use October\Rain\Tests\TestCase;
 
 class RouteTest extends TestCase
 {

--- a/tests/Scaffold/ScaffoldBaseTest.php
+++ b/tests/Scaffold/ScaffoldBaseTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Scaffold;
+
 use October\Rain\Scaffold\GeneratorCommand;
+use October\Rain\Tests\TestCase;
 
 class ScaffoldBaseTestCommand extends GeneratorCommand
 {
@@ -23,7 +26,7 @@ class ScaffoldBaseTest extends TestCase
     protected static function callProtectedMethod($object, $name, $params = [])
     {
         $className = get_class($object);
-        $class = new ReflectionClass($className);
+        $class = new \ReflectionClass($className);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
         return $method->invokeArgs($object, $params);
@@ -32,7 +35,7 @@ class ScaffoldBaseTest extends TestCase
     public static function getProtectedProperty($object, $name)
     {
         $className = get_class($object);
-        $class = new ReflectionClass($className);
+        $class = new \ReflectionClass($className);
         $property = $class->getProperty($name);
         $property->setAccessible(true);
         return $property->getValue($object);
@@ -41,7 +44,7 @@ class ScaffoldBaseTest extends TestCase
     public static function setProtectedProperty($object, $name, $value)
     {
         $className = get_class($object);
-        $class = new ReflectionClass($className);
+        $class = new \ReflectionClass($className);
         $property = $class->getProperty($name);
         $property->setAccessible(true);
         return $property->setValue($object, $value);

--- a/tests/Support/ArrTest.php
+++ b/tests/Support/ArrTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Support;
+
 use October\Rain\Support\Arr;
+use October\Rain\Tests\TestCase;
 
 class ArrTest extends TestCase
 {

--- a/tests/Support/CountableTest.php
+++ b/tests/Support/CountableTest.php
@@ -1,4 +1,9 @@
 <?php
+
+namespace October\Rain\Tests\Support;
+
+use October\Rain\Tests\TestCase;
+
 class CountableTest extends TestCase
 {
     public function testCountable()
@@ -17,7 +22,7 @@ class CountableTest extends TestCase
 
         $this->assertTrue(is_countable($collection));
 
-        $arrayObj = new ArrayObject([
+        $arrayObj = new \ArrayObject([
             'foo' => 'bar',
             'foo2' => 'bar2'
         ]);

--- a/tests/Support/EmitterTest.php
+++ b/tests/Support/EmitterTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace October\Rain\Tests\Support;
+
+use October\Rain\Tests\TestCase;
+
 class EmitterTest extends TestCase
 {
     /**

--- a/tests/Support/UrlGeneratorTest.php
+++ b/tests/Support/UrlGeneratorTest.php
@@ -1,5 +1,9 @@
 <?php
+
+namespace October\Rain\Tests\Support;
+
 use October\Rain\Router\UrlGenerator;
+use October\Rain\Tests\TestCase;
 
 class UrlGeneratorTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,8 @@
 <?php
 
-class TestCase extends PHPUnit\Framework\TestCase
+namespace October\Rain\Tests;
+
+class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * Creates the application.
@@ -14,7 +16,7 @@ class TestCase extends PHPUnit\Framework\TestCase
     protected static function callProtectedMethod($object, $name, $params = [])
     {
         $className = get_class($object);
-        $class = new ReflectionClass($className);
+        $class = new \ReflectionClass($className);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
         return $method->invokeArgs($object, $params);

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -1,9 +1,12 @@
 <?php
 
+namespace October\Rain\Tests\Translation;
+
 use Illuminate\Filesystem\Filesystem;
 use October\Rain\Events\Dispatcher;
 use October\Rain\Translation\FileLoader;
 use October\Rain\Translation\Translator;
+use October\Rain\Tests\TestCase;
 
 class TranslatorTest extends TestCase
 {

--- a/tests/Validation/EmailValidationTest.php
+++ b/tests/Validation/EmailValidationTest.php
@@ -1,9 +1,12 @@
 <?php
 
+namespace October\Rain\Tests\Validation;
+
 use Illuminate\Filesystem\Filesystem;
 use October\Rain\Translation\FileLoader;
 use October\Rain\Translation\Translator;
 use October\Rain\Validation\Factory;
+use October\Rain\Tests\TestCase;
 
 class EmailValidationTest extends TestCase
 {

--- a/tests/Validation/RuleObjectTest.php
+++ b/tests/Validation/RuleObjectTest.php
@@ -4,6 +4,7 @@ use Illuminate\Filesystem\Filesystem;
 use October\Rain\Translation\FileLoader;
 use October\Rain\Translation\Translator;
 use October\Rain\Validation\Factory;
+use October\Rain\Tests\TestCase;
 
 class RuleObjectTest extends TestCase
 {


### PR DESCRIPTION
According to the `composer.json` file, it contains the `October\\Rain\\Tests\\` namespace for all classes.

It should be good to add above namespace for test classes.

And some classes don't add this namespace because they contain two or more example classes on the same PHP files or include some classes manually on `fixtures` folder during the `PHPUnit::setUp` method calling.