### PR TITLE
MailFake adaptation for october

### DIFF
--- a/src/Support/Facades/Mail.php
+++ b/src/Support/Facades/Mail.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Support\Facades;
 
+use October\Rain\Support\Facade;
 use October\Rain\Support\Testing\Fakes\MailFake;
 
 /**
@@ -24,7 +25,7 @@ use October\Rain\Support\Testing\Fakes\MailFake;
  * @see \October\Rain\Mail\Mailer
  * @see \October\Rain\Support\Testing\Fakes\MailFake
  */
-class Mail extends \October\Rain\Support\Facade
+class Mail extends Facade
 {
     /**
      * Replace the bound instance with a fake.

--- a/src/Support/Facades/Mail.php
+++ b/src/Support/Facades/Mail.php
@@ -1,0 +1,50 @@
+<?php namespace October\Rain\Support\Facades;
+
+use October\Rain\Support\Testing\Fakes\MailFake;
+
+/**
+ * @method static \Illuminate\Mail\PendingMail to($users)
+ * @method static \Illuminate\Mail\PendingMail bcc($users)
+ * @method static void raw(string $text, $callback)
+ * @method static void send(\Illuminate\Contracts\Mail\Mailable|string|array $view, array $data = [], \Closure|string $callback = null)
+ * @method static array failures()
+ * @method static mixed queue(\Illuminate\Contracts\Mail\Mailable|string|array $view, string $queue = null)
+ * @method static mixed later(\DateTimeInterface|\DateInterval|int $delay, \Illuminate\Contracts\Mail\Mailable|string|array $view, string $queue = null)
+ * @method static void assertSent(string $mailable, callable|int $callback = null)
+ * @method static void assertNotSent(string $mailable, callable|int $callback = null)
+ * @method static void assertNothingSent()
+ * @method static void assertQueued(string $mailable, callable|int $callback = null)
+ * @method static void assertNotQueued(string $mailable, callable $callback = null)
+ * @method static void assertNothingQueued()
+ * @method static \Illuminate\Support\Collection sent(string $mailable, \Closure|string $callback = null)
+ * @method static bool hasSent(string $mailable)
+ * @method static \Illuminate\Support\Collection queued(string $mailable, \Closure|string $callback = null)
+ * @method static bool hasQueued(string $mailable)
+ *
+ * @see \October\Rain\Mail\Mailer
+ * @see \October\Rain\Support\Testing\Fakes\MailFake
+ */
+class Mail extends Facade
+{
+    /**
+     * Replace the bound instance with a fake.
+     *
+     * @return \Illuminate\Support\Testing\Fakes\MailFake
+     */
+    public static function fake()
+    {
+        static::swap($fake = new MailFake);
+
+        return $fake;
+    }
+
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'mailer';
+    }
+}

--- a/src/Support/Facades/Mail.php
+++ b/src/Support/Facades/Mail.php
@@ -29,7 +29,7 @@ class Mail extends Facade
     /**
      * Replace the bound instance with a fake.
      *
-     * @return \Illuminate\Support\Testing\Fakes\MailFake
+     * @return \October\Rain\Support\Testing\Fakes\MailFake
      */
     public static function fake()
     {

--- a/src/Support/Facades/Mail.php
+++ b/src/Support/Facades/Mail.php
@@ -24,7 +24,7 @@ use October\Rain\Support\Testing\Fakes\MailFake;
  * @see \October\Rain\Mail\Mailer
  * @see \October\Rain\Support\Testing\Fakes\MailFake
  */
-class Mail extends Facade
+class Mail extends \October\Rain\Support\Facade
 {
     /**
      * Replace the bound instance with a fake.

--- a/src/Support/Testing/Fakes/MailFake.php
+++ b/src/Support/Testing/Fakes/MailFake.php
@@ -1,0 +1,83 @@
+<?php namespace October\Rain\Support\Testing\Fakes;
+
+use October\Rain\Mail\Mailable;
+
+class MailFake extends \Illuminate\Support\Testing\Fakes\MailFake
+{
+    /**
+     * Get all of the mailed mailables for a given type.
+     *
+     * @param  string  $type
+     * @return \Illuminate\Support\Collection
+     */
+    protected function mailablesOf($type)
+    {
+        return collect($this->mailables)->filter(function ($mailable) use ($type) {
+            return $mailable->view === $type;
+        });
+    }
+
+    /**
+     * Get all of the mailed mailables for a given type.
+     *
+     * @param  string  $type
+     * @return \Illuminate\Support\Collection
+     */
+    protected function queuedMailablesOf($type)
+    {
+        return collect($this->queuedMailables)->filter(function ($mailable) use ($type) {
+            return $mailable->view === $type;
+        });
+    }
+
+    /**
+     * Send a new message using a view.
+     *
+     * @param  string|array  $view
+     * @param  array  $data
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public function send($view, $data = [], $callback = null)
+    {
+        if (! $view instanceof Mailable) {
+            $view = $this->buildMailable($view, $data, $callback);
+        }
+
+        parent::send($view, $data = [], $callback = null);
+    }
+
+    /**
+     * Queue a new e-mail message for sending.
+     *
+     * @param  string|array  $view
+     * @param  array  $data
+     * @param  \Closure|string  $callback
+     * @param  string|null  $queue
+     * @return mixed
+     */
+    public function queue($view, $data = null, $callback = null, $queue = null)
+    {
+        if (!$view instanceof Mailable) {
+            $view = $this->buildMailable($view, $data, $callback, true);
+        }
+
+        return parent::queue($view, $data = null, $callback = null, $queue = null);
+    }
+
+    public function buildMailable($view, $data, $callback, $queued = false)
+    {
+        $mailable = new Mailable;
+
+        if($queued) {
+            $mailable->view($view)->withSerializedData($data);
+        } else {
+            $mailable->view($view, $data);
+        }
+
+        if ($callback !== null) {
+            call_user_func($callback, $mailable);
+        }
+        return $mailable;
+    }
+}

--- a/src/Support/Testing/Fakes/MailFake.php
+++ b/src/Support/Testing/Fakes/MailFake.php
@@ -18,7 +18,7 @@ class MailFake extends \Illuminate\Support\Testing\Fakes\MailFake
     }
 
     /**
-     * Get all of the mailed mailables for a given type.
+     * Get all of the queued mailables for a given type.
      *
      * @param  string  $type
      * @return \Illuminate\Support\Collection
@@ -65,6 +65,15 @@ class MailFake extends \Illuminate\Support\Testing\Fakes\MailFake
         return parent::queue($view, $data = null, $callback = null, $queue = null);
     }
 
+    /**
+     * Create a Mailable object from a view file.
+     *
+     * @param  string|array  $view
+     * @param  array  $data
+     * @param  \Closure|string  $callback
+     * @param  bool  $queued
+     * @return \October\Rain\Mail\Mailable
+     */
     public function buildMailable($view, $data, $callback, $queued = false)
     {
         $mailable = new Mailable;

--- a/src/Support/Testing/Fakes/MailFake.php
+++ b/src/Support/Testing/Fakes/MailFake.php
@@ -40,7 +40,7 @@ class MailFake extends \Illuminate\Support\Testing\Fakes\MailFake
      */
     public function send($view, $data = [], $callback = null)
     {
-        if (! $view instanceof Mailable) {
+        if (!$view instanceof Mailable) {
             $view = $this->buildMailable($view, $data, $callback);
         }
 

--- a/src/Support/Testing/Fakes/MailFake.php
+++ b/src/Support/Testing/Fakes/MailFake.php
@@ -69,7 +69,7 @@ class MailFake extends \Illuminate\Support\Testing\Fakes\MailFake
     {
         $mailable = new Mailable;
 
-        if($queued) {
+        if ($queued) {
             $mailable->view($view)->withSerializedData($data);
         } else {
             $mailable->view($view, $data);

--- a/tests/Support/MailFakeTest.php
+++ b/tests/Support/MailFakeTest.php
@@ -27,7 +27,7 @@ class MailFakeTest extends TestCase
     {
         Mail::send($this->view, [], function ($mailer) {
             $mailer->to($this->recipient);
-            $mailer->subject('MailFake test');
+            $mailer->subject($this->subject);
         });
         Mail::assertSent($this->view, 1);
 

--- a/tests/Support/MailFakeTest.php
+++ b/tests/Support/MailFakeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+class MailFakeTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->mailer = new \October\Rain\Support\Testing\Fakes\MailFake();
+        $this->view = 'mail-test-view';
+        $this->recipient = 'fake@localhost';
+        $this->subject = 'MailFake test';
+    }
+
+    public function testSend()
+    {
+        $this->mailer->send($this->view, [], function ($mailer) {
+            $mailer->to($this->recipient);
+            $mailer->subject('MailFake test');
+        });
+
+        $this->mailer->assertSent($this->view, 1);
+
+        $this->mailer->assertSent($this->view, function ($mailer) {
+            return $mailer->hasTo($this->recipient);
+        });
+
+        $this->mailer->assertSent($this->view, function ($mailer) {
+            return $mailer->subject === $this->subject;
+        });
+    }
+
+    public function testQueue()
+    {
+        $this->mailer->queue($this->view, [], function ($mailer) {
+            $mailer->to($this->recipient);
+            $mailer->subject($this->subject);
+        });
+
+        $this->mailer->assertQueued($this->view, 1);
+
+        $this->mailer->assertQueued($this->view, function ($mailer) {
+            return $mailer->hasTo($this->recipient);
+        });
+
+        $this->mailer->assertSent($this->view, function ($mailer) {
+            return $mailer->subject === $this->subject;
+        });
+    }
+}

--- a/tests/Support/MailFakeTest.php
+++ b/tests/Support/MailFakeTest.php
@@ -5,6 +5,14 @@ class MailFakeTest extends TestCase
     public function setUp(): void
     {
         $this->mailer = new \October\Rain\Support\Testing\Fakes\MailFake();
+
+        // Mock App facade
+        if (!class_exists('App')) {
+            class_alias('\Illuminate\Support\Facades\App', 'App');
+        }
+
+        App::shouldReceive('getLocale')->andreturn('en/US');
+
         $this->view = 'mail-test-view';
         $this->recipient = 'fake@localhost';
         $this->subject = 'MailFake test';
@@ -41,7 +49,7 @@ class MailFakeTest extends TestCase
             return $mailer->hasTo($this->recipient);
         });
 
-        $this->mailer->assertSent($this->view, function ($mailer) {
+        $this->mailer->assertQueued($this->view, function ($mailer) {
             return $mailer->subject === $this->subject;
         });
     }


### PR DESCRIPTION
Fixes: https://github.com/octobercms/october/issues/4942

This is mostly based on [previous work](https://gist.github.com/alxy/6e74d306be7bd0c9d1f134f34d547a44) by @alxy

Until the new Mail Facade in this PR is used by October, `Mail::fake()` can be replaced by `Mail::swap(new MailFake())` as shown below:
```
use \October\Rain\Support\Testing\Fakes\MailFake;

Mail::swap( new MailFake() );

$view = 'author.plugin::mail.view-name';
Mail::send($view, [], function ($mailer) {
    $mailer->to = 'yourself@yourdomain.com';
});

Mail::assertSent($view, 1);
```
*TODO: create PR to `october/october` repo to change the Mail facade to October's version from this PR.*