### PR TITLE
Multiple fixes related to PR #543

### DIFF
--- a/src/Database/Relations/BelongsToMany.php
+++ b/src/Database/Relations/BelongsToMany.php
@@ -89,6 +89,18 @@ class BelongsToMany extends BelongsToManyBase
     }
 
     /**
+     * Override sync() method of BelongToMany relation in order to flush the query cache.
+     * @param array $ids
+     * @param bool $detaching
+     * @return array
+     */
+    public function sync($ids, $detaching = true)
+    {
+        parent::sync($ids, $detaching);
+        $this->flushDuplicateCache();
+    }
+
+    /**
      * Create a new instance of this related model with deferred binding support.
      */
     public function create(array $attributes = [], array $pivotData = [], $sessionKey = null)

--- a/src/Database/Relations/BelongsToMany.php
+++ b/src/Database/Relations/BelongsToMany.php
@@ -160,7 +160,7 @@ class BelongsToMany extends BelongsToManyBase
     {
         $attachedIdList = $this->parseIds($ids);
         if (empty($attachedIdList)) {
-            $attachedIdList = $this->allRelatedIds();
+            $attachedIdList = $this->allRelatedIds()->all();
         }
 
         /**

--- a/src/Database/Relations/DefinedConstraints.php
+++ b/src/Database/Relations/DefinedConstraints.php
@@ -137,6 +137,7 @@ trait DefinedConstraints
         // add relation's conditions and scopes to the query
         $this->addDefinedConstraintsToQuery($query);
 
-        return $query->join($this->related->getTable(), $this->relatedPivotKey, '=', $this->relatedKey);
+        $related = $this->getRelated();
+        return $query->join($related->getTable(), $related->getQualifiedKeyName(), '=', $this->getOtherKey());
     }
 }

--- a/src/Database/Relations/DefinedConstraints.php
+++ b/src/Database/Relations/DefinedConstraints.php
@@ -138,6 +138,9 @@ trait DefinedConstraints
         $this->addDefinedConstraintsToQuery($query);
 
         $related = $this->getRelated();
-        return $query->join($related->getTable(), $related->getQualifiedKeyName(), '=', $this->getOtherKey());
+
+        return $query
+            ->join($related->getTable(), $related->getQualifiedKeyName(), '=', $this->getOtherKey())
+            ->select($this->getTable().'.*');
     }
 }


### PR DESCRIPTION
Related to #543 
- $attachedIdList should be an array/collection not an object
- Add fully qualified key names in newPivotQuery() to prevent conflicts.

Fixes https://github.com/octobercms/october/issues/5479#issuecomment-772704701