### PR TITLE
Converting bound events to serializable closures to allow caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "league/csv": "~9.1",
         "nesbot/carbon": "^2.0",
         "laravel/framework": "~6.0",
-        "laravel/tinker": "~2.0"
+        "laravel/tinker": "~2.0",
+        "opis/closure": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4|^9.3.3",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "nesbot/carbon": "^2.0",
         "laravel/framework": "~6.0",
         "laravel/tinker": "~2.0",
-        "opis/closure": "^3.1"
+        "opis/closure": "^3.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4|^9.3.3",

--- a/src/Support/Traits/Emitter.php
+++ b/src/Support/Traits/Emitter.php
@@ -1,5 +1,8 @@
 <?php namespace October\Rain\Support\Traits;
 
+use Closure;
+use Opis\Closure\SerializableClosure as OpisSerializableClosure;
+
 /**
  * Adds event related features to any class.
  *
@@ -29,6 +32,9 @@ trait Emitter
      */
     public function bindEvent($event, $callback, $priority = 0)
     {
+        if ($callback instanceof Closure) {
+            $callback = new OpisSerializableClosure($callback);
+        }
         $this->emitterEventCollection[$event][$priority][] = $callback;
         unset($this->emitterEventSorted[$event]);
         return $this;
@@ -40,6 +46,9 @@ trait Emitter
      */
     public function bindEventOnce($event, $callback)
     {
+        if ($callback instanceof Closure) {
+            $callback = new OpisSerializableClosure($callback);
+        }
         $this->emitterSingleEventCollection[$event][] = $callback;
         return $this;
     }
@@ -117,6 +126,9 @@ trait Emitter
          */
         if (isset($this->emitterSingleEventCollection[$event])) {
             foreach ($this->emitterSingleEventCollection[$event] as $callback) {
+                if ($callback instanceof OpisSerializableClosure) {
+                    $callback = $callback->getClosure();
+                }
                 $response = call_user_func_array($callback, $params);
                 if (is_null($response)) {
                     continue;
@@ -139,6 +151,9 @@ trait Emitter
             }
 
             foreach ($this->emitterEventSorted[$event] as $callback) {
+                if ($callback instanceof OpisSerializableClosure) {
+                    $callback = $callback->getClosure();
+                }
                 $response = call_user_func_array($callback, $params);
                 if (is_null($response)) {
                     continue;


### PR DESCRIPTION
Solves "Exception: Serialization of 'Closure' is not allowed" error when caching models to a file store that have traits added.