### PR TITLE
Fix getRelationType method

### DIFF
--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -222,7 +222,7 @@ trait HasRelationships
     public function getRelationType($name)
     {
         foreach (static::$relationTypes as $type) {
-            if ($this->getRelationTypeDefinition($type, $name)) {
+            if ($this->getRelationTypeDefinition($type, $name) !== null) {
                 return $type;
             }
         }

--- a/tests/Database/RelationsTest.php
+++ b/tests/Database/RelationsTest.php
@@ -219,6 +219,20 @@ class RelationsTest extends DbTestCase
         $this->assertEquals(2, $post->terms->count());
         $this->assertEquals('term #2', $post->terms->first()->name);
     }
+
+    public function testUndefinedMorphsRelation()
+    {
+        $this->expectException('BadMethodCallException');
+
+        $morphs = new Morphs;
+        $morphs->unknownRelation();
+    }
+
+    public function testDefinedMorphsRelation()
+    {
+        $morphs = new Morphs;
+        $value = $morphs->related();
+    }
 }
 
 class Post extends \October\Rain\Database\Model
@@ -265,5 +279,14 @@ class Term extends \October\Rain\Database\Model
             'otherKey'   => 'post_id',
             'conditions' => 'type = "post"'
         ],
+    ];
+}
+
+class Morphs extends \October\Rain\Database\Model
+{
+    public $table = 'morphs';
+
+    public $morphTo = [
+        'related' => [],
     ];
 }


### PR DESCRIPTION
morphTo relations have an empty definition, so we need to test against null instead.

The change that lead to this problem was below:

https://github.com/octobercms/library/pull/460/files#diff-b0185ec47eb87315ad4b78f740db185dd938ca525888d249d820c1a7d5be9754R200-R206