### PR TITLE
Fixes checking a permission that is not available.

### DIFF
--- a/src/Auth/Models/User.php
+++ b/src/Auth/Models/User.php
@@ -523,7 +523,7 @@ class User extends Model implements \Illuminate\Contracts\Auth\Authenticatable
 
                     // Otherwise, we'll fallback to standard permissions checking where
                     // we match that permissions explicitly exist.
-                    elseif ($permission == $mergedPermission && $mergedPermissions[$permission] == 1) {
+                    elseif ($permission == $mergedPermission && isset($mergedPermissions[$permission]) && $mergedPermissions[$permission] == 1) {
                         $matched = true;
                         break;
                     }


### PR DESCRIPTION
For example when we have this code in a custom plugin `boot()` function:

```
        BackendMenu::registerCallback(function ($manager) {
            if (!BackendAuth::getUser()->hasAccess(['cms.manage_pages'])) {
                $manager->removeMainMenuItem('October.Cms', 'cms');
            }
        });
```

And there are no roles set, this error will be thrown:

```
ErrorException: Undefined index: cms.manage_pages in /vendor/october/rain/src/Auth/Models/User.php:526
```