### PR TITLE
Improved getDetailedMessage

### DIFF
--- a/src/Exception/ErrorHandler.php
+++ b/src/Exception/ErrorHandler.php
@@ -112,9 +112,9 @@ class ErrorHandler
     public static function getDetailedMessage($exception)
     {
         /*
-         * Application Exceptions never display a detailed error
+         * Base Exceptions never display a detailed error
          */
-        if (!($exception instanceof ApplicationException) && Config::get('app.debug', false)) {
+        if (!($exception instanceof ExceptionBase) && Config::get('app.debug', false)) {
             return sprintf(
                 '"%s" on line %s of %s',
                 $exception->getMessage(),


### PR DESCRIPTION
Switched from ApplicationException to the ExceptionBase class so that any new Exception class that inherits the ExceptionBase class will properly render it's message to the OctoberCMS system.

Use case: If I create a new Exception eg. ApiException that calls an API and returns a failure message, I should be able to extend ExceptionBase and throw it so that when the AJAX framework flashes the error, it shows a clean, human-readable error message such as `"Username was not provided with the request"` rather than something like: `"Username was not provided with the request" on line 50 of /path/to/where/exception/occured.php`.