### PR TITLE
revert breaking change with newPivotQuery

### DIFF
--- a/src/Database/Relations/DefinedConstraints.php
+++ b/src/Database/Relations/DefinedConstraints.php
@@ -121,5 +121,4 @@ trait DefinedConstraints
             $query->$scope($this->parent);
         }
     }
-
 }

--- a/src/Database/Relations/DefinedConstraints.php
+++ b/src/Database/Relations/DefinedConstraints.php
@@ -122,25 +122,4 @@ trait DefinedConstraints
         }
     }
 
-    /**
-     * Create a new query builder for the pivot table.
-     *
-     * This is an extension of Laravel's `newPivotQuery` method that allows `belongsToMany` and `morphToMany` relations
-     * to have conditions.
-     *
-     * @return \Illuminate\Database\Query\Builder
-     */
-    public function newPivotQuery()
-    {
-        $query = parent::newPivotQuery();
-
-        // add relation's conditions and scopes to the query
-        $this->addDefinedConstraintsToQuery($query);
-
-        $related = $this->getRelated();
-
-        return $query
-            ->join($related->getTable(), $related->getQualifiedKeyName(), '=', $this->getOtherKey())
-            ->select($this->getTable().'.*');
-    }
 }

--- a/tests/Database/RelationsTest.php
+++ b/tests/Database/RelationsTest.php
@@ -73,30 +73,6 @@ class RelationsTest extends DbTestCase
         $this->assertEquals(4, $post->terms()->count());
     }
 
-    public function testBelongsToManySyncAll()
-    {
-        $post = Post::first();
-
-        $catid = $post->categories()->first()->id;
-        $tagid = $post->tags()->first()->id;
-
-        $this->assertEquals(2, $post->categories()->count());
-        $this->assertEquals(2, $post->tags()->count());
-
-        $post->categories()->sync([$catid]);
-        $post->tags()->sync([$tagid]);
-
-        $post->reloadRelations();
-
-        $this->assertEquals(1, $post->categories()->count());
-        $this->assertEquals($catid, $post->categories()->first()->id);
-
-        $this->assertEquals(1, $post->tags()->count());
-        $this->assertEquals($tagid, $post->tags()->first()->id);
-
-        $this->assertEquals(2, $post->terms()->count());
-    }
-
     public function testBelongsToManySyncTags()
     {
         $post = Post::first();
@@ -139,19 +115,6 @@ class RelationsTest extends DbTestCase
         $this->assertEquals(0, $post->categories()->count());
         $this->assertEquals(0, $post->tags()->count());
         $this->assertEquals(0, $post->terms()->count());
-    }
-
-    public function testBelongsToManySyncMultipleCategories()
-    {
-        $post = Post::first();
-
-        $category_ids = Term::where('type', 'category')->lists('id');
-        $this->assertEquals(4, count($category_ids));
-
-        $post->categories()->sync($category_ids);
-        $this->assertEquals(4, $post->categories()->count());
-        $this->assertEquals(2, $post->tags()->count());
-        $this->assertEquals(6, $post->terms()->count());
     }
 
     public function testBelongsToManyDetachOneCategory()


### PR DESCRIPTION
I throw the towel, I can't find a proper way to fix this for all cases.

Fixes https://github.com/octobercms/october/issues/5499