### PR TITLE
Fix & improvement to Sortable behavior

### DIFF
--- a/src/Database/Behaviors/Sortable.php
+++ b/src/Database/Behaviors/Sortable.php
@@ -89,6 +89,13 @@ class Sortable extends ExtensionBase
      */
     public function getSortOrderColumn()
     {
-        return defined($this->model.'::SORT_ORDER') ? $this->model::SORT_ORDER : 'sort_order';
+        if (defined(get_class($this->model).'::SORT_ORDER')) {
+            $column = $this->model::SORT_ORDER;
+        } else if (isset($this->model->sort_order_column)) {
+            $column = $this->model->sort_order_column;
+        } else {
+            $column = 'sort_order';
+        }
+        return $column;
     }
 }


### PR DESCRIPTION
- Fix broken method to check for SORT_ORDER const existance on Class;
  The previous code to check if the SORT_ORDER constant was defined on the model class didn't work.
- Add a more dynamic method to get the sort_order from the model's sort_order_column property;
  You can now dynamically extended a model to change the sort_order_column using addDynamicProperty (since a constant cannot be defined when extending a model).