### PR TITLE
Use translation string than pluralized placeholder

### DIFF
--- a/src/Scaffold/Console/controller/config_form.stub
+++ b/src/Scaffold/Console/controller/config_form.stub
@@ -16,16 +16,16 @@ defaultRedirect: {{lower_author}}/{{lower_plugin}}/{{lower_name}}
 
 # Create page
 create:
-    title: Create {{title_singular_name}}
+    title: backend::lang.form.create_title
     redirect: {{lower_author}}/{{lower_plugin}}/{{lower_name}}/update/:id
     redirectClose: {{lower_author}}/{{lower_plugin}}/{{lower_name}}
 
 # Update page
 update:
-    title: Edit {{title_singular_name}}
+    title: backend::lang.form.update_title
     redirect: {{lower_author}}/{{lower_plugin}}/{{lower_name}}
     redirectClose: {{lower_author}}/{{lower_plugin}}/{{lower_name}}
 
 # Preview page
 preview:
-    title: Preview {{title_singular_name}}
+    title: backend::lang.form.preview_title


### PR DESCRIPTION
The controller appears to automatically detect and fill the appropriate model name into the above translation string without having to specify it. So it seems like a good idea to have this set here itself.

Benefits:
1. As a developer I don't need to replace this with the translation string each time for each controller's form config.
2. As a newbie developer who doesn't know that there is a system translation string that automatically fills in the model name, it would be redundant to be creating in-plugin strings for the same.