### PR TITLE
Make the stylesheet minifier aware of CSS vars

### DIFF
--- a/src/Assetic/Filter/StylesheetMinify.php
+++ b/src/Assetic/Filter/StylesheetMinify.php
@@ -53,9 +53,6 @@ class StylesheetMinify implements FilterInterface
         // -6.0100em to -6.01em, .0100 to .01, 1.200px to 1.2px
         $css = preg_replace('/((?<!\\\\)\:|\s)(\-?)(\d?\.\d+?)0+([^\d])/S', '$1$2$3$4', $css);
 
-        // Strips units if value is 0 (converts 0px to 0), ignores values inside ()
-        $css = preg_replace('/(:| )(\.?)0(em|ex|px|in|cm|mm|pt|pc)(?![^\(]*\))/i', '${1}0', $css);
-
         // Shortern 6-character hex color codes to 3-character where possible
         $css = preg_replace('/#([a-f0-9])\\1([a-f0-9])\\2([a-f0-9])\\3/i', '#\1\2\3', $css);
 

--- a/src/Assetic/Filter/StylesheetMinify.php
+++ b/src/Assetic/Filter/StylesheetMinify.php
@@ -32,16 +32,16 @@ class StylesheetMinify implements FilterInterface
         $css = preg_replace('/\s{2,}/', ' ', $css);
 
         // Remove spaces before and after comment
-        $css = preg_replace('/(\s+)(\/\*(.*?)\*\/)(\s+)/', '$2', $css);
+        $css = preg_replace('/(\s+)(\/\*(.*?)\*\/)(\s+)[^\/]/', '$2', $css);
 
-        // Remove comment blocks, everything between /* and */
-        $css = preg_replace('#/\*.*?\*/#s', '', $css);
+        // Remove comment blocks, everything between /* and */, ignore comments inside ()
+        $css = preg_replace('#/\*[^\/]+\*/(?![^\(]*\))#s', '', $css);
 
         // Remove ; before }
         $css = preg_replace('/;(?=\s*})/', '', $css);
 
-        // Remove space after , : ; { } */ >
-        $css = preg_replace('/(,|:|;|\{|}|\*\/|>) /', '$1', $css);
+        // Remove space after , : ; { } > or */ (if not followed by another /)
+        $css = preg_replace('((,|:|;|\{|}|>) |(\*\/ [^\/]))', '$1', $css);
 
         // Remove space before , ; { } >
         $css = preg_replace('/(,|;|\{|}|>)/', '$1', $css);

--- a/tests/Assetic/StylesheetMinifyTest.php
+++ b/tests/Assetic/StylesheetMinifyTest.php
@@ -2,14 +2,51 @@
 
 use October\Rain\Assetic\Filter\StylesheetMinify;
 
+include __DIR__ . '/MockAsset.php';
+
 class StylesheetMinifyTest extends TestCase
 {
+
     public function testUnitRemoval()
     {
-        include __DIR__ . '/MockAsset.php';
-
         $input  = 'body {width: calc(99.9% * 1/1 - 0px); height: 0px;}';
         $output = 'body {width:calc(99.9% * 1/1 - 0px);height:0}';
+
+        $mockAsset = new MockAsset($input);
+        $result    = new StylesheetMinify();
+        $result->filterDump($mockAsset);
+
+        $this->assertEquals($output, $mockAsset->getContent());
+    }
+
+    public function testCommentRemoval()
+    {
+        $input  = 'body {/* First comment */} /* Second comment */';
+        $output = 'body {}';
+
+        $mockAsset = new MockAsset($input);
+        $result    = new StylesheetMinify();
+        $result->filterDump($mockAsset);
+
+        $this->assertEquals($output, $mockAsset->getContent());
+    }
+
+    public function testCommentPreservationInVar()
+    {
+        $input  = '--ring-inset: var(--empty, /*!*/ /*!*/);';
+        $output = '--ring-inset:var(--empty,/*!*/ /*!*/);';
+
+        $mockAsset = new MockAsset($input);
+        $result    = new StylesheetMinify();
+        $result->filterDump($mockAsset);
+
+        $this->assertEquals($output, $mockAsset->getContent());
+    }
+
+    public function testUnitPreservationInVar()
+    {
+        $input  = '--offset-width: 0px';
+        $output = '--offset-width:0px';
 
         $mockAsset = new MockAsset($input);
         $result    = new StylesheetMinify();

--- a/tests/Assetic/StylesheetMinifyTest.php
+++ b/tests/Assetic/StylesheetMinifyTest.php
@@ -10,7 +10,7 @@ class StylesheetMinifyTest extends TestCase
     public function testUnitRemoval()
     {
         $input  = 'body {width: calc(99.9% * 1/1 - 0px); height: 0px;}';
-        $output = 'body {width:calc(99.9% * 1/1 - 0px);height:0}';
+        $output = 'body {width:calc(99.9% * 1/1 - 0px);height:0px}';
 
         $mockAsset = new MockAsset($input);
         $result    = new StylesheetMinify();

--- a/tests/Assetic/StylesheetMinifyTest.php
+++ b/tests/Assetic/StylesheetMinifyTest.php
@@ -7,7 +7,7 @@ include __DIR__ . '/MockAsset.php';
 class StylesheetMinifyTest extends TestCase
 {
 
-    public function testUnitRemoval()
+    public function testSpaceRemoval()
     {
         $input  = 'body {width: calc(99.9% * 1/1 - 0px); height: 0px;}';
         $output = 'body {width:calc(99.9% * 1/1 - 0px);height:0px}';


### PR DESCRIPTION
**Edit:** Found the Blog entry that describes the issue and added the link.

We are using Tailwind in October. Unfortunately, October's stylesheet minifier makes some optimizations that break the Tailwind output.

Tailwind makes heavy use of CSS variables. It also includes some workarounds like the following code:

```css
    --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
```

The space after the `,` in the `var` function is actually relevant. The minifier must not remove it. Tailwind inserts these special comments to tell a minifier to leave the space untouched.

Read more about it here: https://adamwathan.me/composing-the-uncomposable-with-css-variables/

The stylesheet minifier currently removes all comments and unnecessary whitespace regardless of the context. It also removes any units of zero values (`0px` becomes `0`).

This PR changes a few of the regexes in the Stylesheet minifier to leave comments inside `()` untouched. It also makes sure spaces between two comments are not removed. Finally, it removes the conversion of zero values with units to values without a unit.

These are the changes to the regexes:

#### Remove spaces before and after comment

`[^\/]` was added to the end so spaces after a comment are only removed, if there is no `/` after the space (makes sure that the space between `/*!*/ /*!*/` is not removed)

#### Remove comment blocks, everything between /* and */

Added a Negative Lookahead at the end, that makes sure that comments inside `()` are ignored. This includes comments inside any `var()` declaration.

#### Remove space after , : ; { } */ >

This regex has been modified so it matches each of the above character followed by a space OR `*/` followed by a space but NOT followed by a space AND a `/`. This is again to prevent the space between comments from being removed.
