### PR TITLE
Fixed StylesheetMinify regex

### DIFF
--- a/src/Assetic/Filter/StylesheetMinify.php
+++ b/src/Assetic/Filter/StylesheetMinify.php
@@ -32,19 +32,19 @@ class StylesheetMinify implements FilterInterface
         $css = preg_replace('/\s{2,}/', ' ', $css);
 
         // Remove spaces before and after comment
-        $css = preg_replace('/(\s+)(\/\*(.*?)\*\/)(\s+)[^\/]/', '$2', $css);
+        $css = preg_replace('/(\s+)(\/\*[^!](.*?)\*\/)(\s+)/', '$2', $css);
 
-        // Remove comment blocks, everything between /* and */, ignore comments inside ()
-        $css = preg_replace('#/\*[^\/]+\*/(?![^\(]*\))#s', '', $css);
+        // Remove comment blocks, everything between /* and */, ignore /*! comments
+        $css = preg_replace('#/\*[^\!].*?\*/#s', '', $css);
 
         // Remove ; before }
         $css = preg_replace('/;(?=\s*})/', '', $css);
 
-        // Remove space after , : ; { } > or */ (if not followed by another /)
-        $css = preg_replace('((,|:|;|\{|}|>) |(\*\/ [^\/]))', '$1', $css);
+        // Remove space after , : ; { } */ >, but not after !*/
+        $css = preg_replace('/(,|:|;|\{|}|[^!]\*\/|>) /', '$1', $css);
 
         // Remove space before , ; { } >
-        $css = preg_replace('/(,|;|\{|}|>)/', '$1', $css);
+        $css = preg_replace('/ (,|;|\{|}|>)/', '$1', $css);
         
         // Remove newline before } >
         $css = preg_replace('/(\r\n|\r|\n)(})/', '$2', $css);

--- a/tests/Assetic/StylesheetMinifyTest.php
+++ b/tests/Assetic/StylesheetMinifyTest.php
@@ -10,7 +10,7 @@ class StylesheetMinifyTest extends TestCase
     public function testSpaceRemoval()
     {
         $input  = 'body {width: calc(99.9% * 1/1 - 0px); height: 0px;}';
-        $output = 'body {width:calc(99.9% * 1/1 - 0px);height:0px}';
+        $output = 'body{width:calc(99.9% * 1/1 - 0px);height:0px}';
 
         $mockAsset = new MockAsset($input);
         $result    = new StylesheetMinify();
@@ -22,7 +22,19 @@ class StylesheetMinifyTest extends TestCase
     public function testCommentRemoval()
     {
         $input  = 'body {/* First comment */} /* Second comment */';
-        $output = 'body {}';
+        $output = 'body{}';
+
+        $mockAsset = new MockAsset($input);
+        $result    = new StylesheetMinify();
+        $result->filterDump($mockAsset);
+
+        $this->assertEquals($output, $mockAsset->getContent());
+    }
+
+    public function testSpecialCommentPreservation()
+    {
+        $input  = 'body {/*! Keep me */}';
+        $output = 'body{/*! Keep me */}';
 
         $mockAsset = new MockAsset($input);
         $result    = new StylesheetMinify();
@@ -47,6 +59,32 @@ class StylesheetMinifyTest extends TestCase
     {
         $input  = '--offset-width: 0px';
         $output = '--offset-width:0px';
+
+        $mockAsset = new MockAsset($input);
+        $result    = new StylesheetMinify();
+        $result->filterDump($mockAsset);
+
+        $this->assertEquals($output, $mockAsset->getContent());
+    }
+
+    public function testComplex()
+    {
+        $input = <<<CSS
+            [class^="icon-"]:before,
+            [class*=" icon-"]:before {
+                speak: none;
+                --ring-inset:var(--empty,/*!*/ /*!*/); /* variable */
+            }
+
+            /* makes the font 33% larger relative to the icon container */
+            .icon-large:before {
+                speak: initial;
+            }
+        CSS;
+
+        $output = <<<CSS
+        [class^="icon-"]:before,[class*=" icon-"]:before{speak:none;--ring-inset:var(--empty,/*!*/ /*!*/)}.icon-large:before{speak:initial}
+        CSS;
 
         $mockAsset = new MockAsset($input);
         $result    = new StylesheetMinify();


### PR DESCRIPTION
This PR fixes the problem introduced in #566.

It is a lot closer to the original minifier. 

1. Added exceptions for `/*!` comments. The comments are left untouched (not removed, spaces before and after remain)
2. I also fixed the `Remove space before , ; { } >` regex as it did not seem to do anything. This means a rule like `body {}` is now properly minified to `body{}` because the space before `{` is now correctly removed.


