### PR TITLE
Add option to parse hidden field

### DIFF
--- a/src/Parse/Syntax/FieldParser.php
+++ b/src/Parse/Syntax/FieldParser.php
@@ -339,13 +339,13 @@ class FieldParser
          */
         $regex = '#';
         $regex .= '(\w+)'; // Any word
-        $regex .= '="'; // Equal sign and open quote
+        $regex .= '=?"?'; // maybe Equal sign and open quote
 
         $regex .= '('; // Capture
         $regex .= '(?:\\\\.|[^"\\\\]+)*'; // Include escaped quotes \"
         $regex .= '|[^"]'; // Or anything other than a quote
         $regex .= '*)'; // Capture value
-        $regex .= '"';
+        $regex .= '"?'; // maybe closed quote
         $regex .= '#';
 
         preg_match_all($regex, $string, $match);

--- a/src/Parse/Syntax/Parser.php
+++ b/src/Parse/Syntax/Parser.php
@@ -194,6 +194,10 @@ class Parser
             return '';
         }
 
+        if (isset($params['hidden'])) {
+            return '';
+        }
+
         /*
          * Used by Twig for loop
          */

--- a/tests/Parse/SyntaxParserTest.php
+++ b/tests/Parse/SyntaxParserTest.php
@@ -23,6 +23,17 @@ class SyntaxParserTest extends TestCase
         $this->assertEquals('<h1>{{ joker.websiteName }}</h1>', $result);
     }
 
+    public function testParseHiddenFieldToTwig()
+    {
+        $content = '<h1>{text name="websiteName" label="Website Name" hidden}Our wonderful website{/text}</h1>';
+
+        $result = Parser::parse($content)->toTwig();
+        $this->assertEquals('<h1></h1>', $result);
+
+        $result = Parser::parse($content, ['varPrefix' => 'joker.'])->toTwig();
+        $this->assertEquals('<h1></h1>', $result);
+    }
+
     public function testParseRepeaterToTwig()
     {
         $content = '';


### PR DESCRIPTION
I added this as an option, because I would like to define the twig markup separately in my template. So you can declare all your fields upfront and render them in which way you want.