### PR TITLE
Change order of overrides

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -272,7 +272,7 @@ trait Validation
             $attributeNames = array_merge($this->validationDefaultAttrNames, $attributeNames);
 
             if (property_exists($this, 'attributeNames')) {
-                $attributeNames = array_merge($this->attributeNames, $attributeNames);
+                $attributeNames = array_merge($attributeNames, $this->attributeNames);
             }
 
             $translatedAttributeNames = [];


### PR DESCRIPTION
I think the order of overrides is wrong here.

Attribute names that are explicitly defined on the model instance via the `$attributeNames` property should override any default names. As `array_merge()` uses the last value found if duplicate keys exist, we need to switch the order here to get the described behavior. Otherwise, setting this property has no effect in most cases.