### PR TITLE
Ignore minify if the assets has .min.js

### DIFF
--- a/src/Assetic/Filter/JSMinFilter.php
+++ b/src/Assetic/Filter/JSMinFilter.php
@@ -27,6 +27,13 @@ class JSMinFilter implements FilterInterface
 
     public function filterDump(AssetInterface $asset)
     {
-        $asset->setContent(\JSMin::minify($asset->getContent()));
+        // Ignore minify if the assets has .min.js. 
+        // 1. Improve performance.
+        // 2. Avoid error when minify a minified js.
+        if(strpos($asset->getSourcePath(),'.min.js') !== false) {
+            $asset->setContent($asset->getContent());
+        }else{
+            $asset->setContent(\JSMin::minify($asset->getContent()));
+        }
     }
 }


### PR DESCRIPTION
Today i catch some error in js when disable debug mode.
And I found the problem is because of the .min.js (which already minified), so I ignore all the minified js, and it work well now. 