### PR TITLE
Add runningInFrontend helper

### DIFF
--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -261,6 +261,15 @@ class Application extends ApplicationBase
     {
         return $this['execution.context'] === 'backend';
     }
+    
+    /**
+     * runningInFrontend determines if we are running in the frontend area.
+     * @return bool
+     */
+    public function runningInFrontend()
+    {
+        return !$this->runningInBackend() && !$this->runningInConsole();
+    }
 
     /**
      * hasDatabase returns true if a database connection is present.


### PR DESCRIPTION
Right now we have lots of code such as this in our codebase:

```php
if(!app()->runningInBackend() && !app()->runningInConsole()) {
    // Do something
}
```

Adding a new ``runningInFrontend`` helper would make this check a bit cleaner. Would you consider adding this to the core?