### PR TITLE
Fix type declarations

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -239,7 +239,7 @@ class Model extends EloquentModel
      * Create a new Eloquent query builder for the model.
      *
      * @param  \October\Rain\Database\QueryBuilder $query
-     * @return \October\Rain\Database\Builder|static
+     * @return \October\Rain\Database\Builder
      */
     public function newEloquentBuilder($query)
     {


### PR DESCRIPTION
We've been playing around with larastan, which works great with October 3 / Laravel 9.

This PR fixes lots of the errors reported by larastan since it removes the `static` return type which is wrong for the `newEloquentBuilder` method. It always returns a `Builder`.

Refs https://github.com/octobercms/october-private/pull/202