### PR TITLE
Add requiredPermissions to controller stubs

### DIFF
--- a/src/Scaffold/Console/controller/controller.stub
+++ b/src/Scaffold/Console/controller/controller.stub
@@ -24,6 +24,11 @@ class {{studly_name}} extends Controller
     public $listConfig = 'config_list.yaml';
 
     /**
+     * @var array required permissions
+     */
+    public $requiredPermissions = ['{{lower_author}}.{{lower_plugin}}.{{lower_name}}'];
+
+    /**
      * __construct the controller
      */
     public function __construct()


### PR DESCRIPTION
I think this should be required in future because somebody can use it to access something they didnt have permission if somebody forgets to add it in controller.