### PR TITLE
Fix SQL error when using useRelationCount + Sortable trait

### DIFF
--- a/src/Database/Scopes/SortableScope.php
+++ b/src/Database/Scopes/SortableScope.php
@@ -17,7 +17,30 @@ class SortableScope implements ScopeInterface
      */
     public function apply(BuilderBase $builder, ModelBase $model)
     {
+        if ($this->calledByAggregator($builder)) {
+            return;
+        }
+
         $builder->getQuery()->orderBy($model->getQualifiedSortOrderColumn());
+    }
+
+    /**
+     * check if the current query is called by an aggregator, i.e. when used with
+     * useRelationCount, by checking if it contains a count(*) statement
+     */
+    protected function calledByAggregator(BuilderBase $builder): bool
+    {
+        if (empty($builder->getQuery()->columns)) {
+            return false;
+        }
+
+        foreach ($builder->getQuery()->columns as $column) {
+            if (strtolower((string)$column) === 'count(*)') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Database/SortableTest.php
+++ b/tests/Database/SortableTest.php
@@ -31,6 +31,18 @@ class SortableTest extends TestCase
         $this->assertEquals('select * from "test" order by "name" asc, "email" desc', $query1);
         $this->assertEquals('select * from "test" order by "sort_order" asc, "name" asc', $query2);
     }
+
+    public function testSkipsOrderByWhenCountingTotalNumberOfModels()
+    {
+        // Given a ParentTestModel which has many TestModels, which are sortable
+        $parentModel = new ParentTestModel;
+
+        // When we try to get the total number of related TestModels (i.e. when using a listcolumn with useRelationCount)
+        $query = $parentModel->newQuery()->withCount('testmodels')->toSql();
+
+        // Then expect the Sortable trait to skip adding an unnecessary ORDER BY to avoid SQL errors
+        $this->assertEquals('select "test_parent".*, (select count(*) from "test" where "test_parent"."id" = "test"."parent_test_model_id") as "testmodels_count" from "test_parent"', $query);
+    }
 }
 
 class TestModel extends \October\Rain\Database\Model
@@ -38,4 +50,14 @@ class TestModel extends \October\Rain\Database\Model
     use \October\Rain\Database\Traits\Sortable;
 
     protected $table = 'test';
+}
+
+class ParentTestModel extends \October\Rain\Database\Model
+{
+    protected $table = 'test_parent';
+
+    public $hasMany = [
+        'testmodels' => TestModel::class
+    ];
+
 }


### PR DESCRIPTION
As discussed by e-mail with @samgeorges :

This fixes an SQL error when using a listview with column with a `relationCount` for a child model, which has the Sortable trait. This issue applies only to v2.x and doesn't seem to occur in v3.

**How to reproduce issue:**
- OctoberCMS 2.2.32
- Use a list with a column displaying the count of a relation using relationCount: true
- Make sure the relation model has been made sortable using the Sortable trait.

Example:
- Let’s say we have a Slideshow model and a Slide model. 
- Each Slideshow can have multiple Slides using a hasMany relation.
- The Slideshow listview displays a column with the Slides count for each slideshow
- The Slide model is Sortable. 

**This fails because:**
- relationCount: true adds a ->withCount() to the querybuilder (Backend\Widgets\Lists->prepareQuery()) method.
- This causes Laravel to generate a subquery counting the number of results
- But, the Sortable trait modifies this subquery and adds an ORDER BY clause.
- This causes MySQL to fail when strict mode is enabled. 

**Solution**
- This pull-request updates the SortableScope trait with a check to verify the scope isn't used in conjunction with a count(*) select statement.
-  Added corresponding test to SortableTest



