### PR TITLE
Apply white background to jpg image when its convert from png

### DIFF
--- a/src/Resize/Resizer.php
+++ b/src/Resize/Resizer.php
@@ -458,7 +458,11 @@ class Resizer
             case 'jpeg':
                 // Check JPG support is enabled
                 if (imagetypes() & IMG_JPG) {
-                    imagejpeg($image, $savePath, $imageQuality);
+                    $imageCanvas = imagecreatetruecolor($width, $height);
+                    $white = imagecolorallocate($imageCanvas, 255, 255, 255);
+                    imagefill($imageCanvas, 0, 0, $white);
+                    imagecopy($imageCanvas, $image, 0, 0, 0, 0, $width, $height);
+                    imagejpeg($imageCanvas, $savePath, $imageQuality);
                 }
                 break;
 


### PR DESCRIPTION
When image is converted from PNG it applies black background color, but mostly JPG images are needed with white color.