### PR TITLE
Apply white background to jpg image when its converted from png

### DIFF
--- a/src/Resize/Resizer.php
+++ b/src/Resize/Resizer.php
@@ -458,6 +458,9 @@ class Resizer
             case 'jpeg':
                 // Check JPG support is enabled
                 if (imagetypes() & IMG_JPG) {
+                    $width = imagesx($image);
+                    $height = imagesy($image);
+
                     $imageCanvas = imagecreatetruecolor($width, $height);
                     $white = imagecolorallocate($imageCanvas, 255, 255, 255);
                     imagefill($imageCanvas, 0, 0, $white);


### PR DESCRIPTION
When image is converted from PNG it applies black background color, but mostly JPG images are needed with white color.