### PR TITLE
Add alias for 'flash' so it is resolvable using the class name (2.x)

### DIFF
--- a/src/Flash/FlashServiceProvider.php
+++ b/src/Flash/FlashServiceProvider.php
@@ -14,9 +14,11 @@ class FlashServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('flash', function ($app) {
-            return new FlashBag;
+        $this->app->singleton('flash', function () {
+            return new FlashBag();
         });
+
+        $this->app->alias('flash', FlashBag::class);
     }
 
     /**


### PR DESCRIPTION
This allows developers to resolve the FlashBag using Dependency Injection:

```php
public function __construct(
    private FlashBag $flash
) {
}

public function doSomething(): void
{
    $this->flash->info('I did something...');
}
```

Refs: https://github.com/octobercms/october-private/issues/264