### PR TITLE
Fix custom system paths

### DIFF
--- a/src/Foundation/Bootstrap/RegisterOctober.php
+++ b/src/Foundation/Bootstrap/RegisterOctober.php
@@ -9,6 +9,27 @@ use Illuminate\Contracts\Foundation\Application;
  */
 class RegisterOctober
 {
+    protected $cachePaths = [
+        'cms',
+        'cms/cache',
+        'cms/combiner',
+        'cms/twig',
+        'framework',
+        'framework/cache',
+        'framework/views',
+        'temp',
+        'temp/public',
+    ];
+
+    protected $storagePaths = [
+        'app',
+        'app/media',
+        'app/uploads',
+        'framework',
+        'framework/sessions',
+        'logs',
+    ];
+
     /**
      * bootstrap the application
      */
@@ -41,26 +62,15 @@ class RegisterOctober
             $app->useThemesPath($this->parseConfiguredPath($app, $themesPath));
         }
 
-        $this->makeSystemPaths($app->cachePath(), [
-            'cms',
-            'cms/cache',
-            'cms/combiner',
-            'cms/twig',
-            'framework',
-            'framework/cache',
-            'framework/views',
-            'temp',
-            'temp/public',
-        ]);
-
-        $this->makeSystemPaths($app->storagePath(), [
-            'app',
-            'app/media',
-            'app/uploads',
-            'framework',
-            'framework/sessions',
-            'logs',
-        ]);
+        // Make system paths
+        if($app->cachePath() === $app->storagePath()) {
+            $this->makeSystemPaths($app->cachePath(), array_unique(
+                array_merge($this->cachePaths, $this->storagePaths)
+            ));
+        } else {
+            $this->makeSystemPaths($app->cachePath(), $this->cachePaths);
+            $this->makeSystemPaths($app->storagePath(), $this->storagePaths);
+        }
 
         // Initialize class loader cache
         $loader = $app->make(ClassLoader::class);


### PR DESCRIPTION
By default ``cache_path`` and ``storage_path`` are the same, so it would make sense to support that for custom paths too. 

Right now when we set the same custom value for these two paths in the ``system.php`` config file, subfolders are only generated for the ``cache_path``, while the ``storage_path`` subfolders are skipped since the root folder already exists: https://github.com/octobercms/library/blob/3.x/src/Foundation/Bootstrap/RegisterOctober.php#L86

This PR fixes that by merging $cachePaths and $storagePaths when both paths are the same.