### PR TITLE
Update MediaLibrary location in Syntax parser

### DIFF
--- a/src/Parse/Syntax/Parser.php
+++ b/src/Parse/Syntax/Parser.php
@@ -46,7 +46,7 @@ class Parser
 
             $textFilters = [
                 'md' => ['Markdown', 'parse'],
-                'media' => ['System\Classes\MediaLibrary', 'url']
+                'media' => [\Media\Classes\MediaLibrary::class, 'url'],
             ];
 
             $this->textParser = new TextParser(['filters' => $textFilters]);


### PR DESCRIPTION
Encountered this when using the Responsiv.CampaignManager plugin, which makes use of this parser. Actually it fails silently because `is_callable` returns false here: https://github.com/octobercms/library/blob/3.x/src/Parse/Bracket.php#L112

As far as I know, this should be the new location of the MediaLibrary in October 3.0 and 3.1.

Tested on php 8.1 (I assume it hasn't changed recently), using `::class` is safe even if the media module is not installed and the target class doesn't exist.