### PR TITLE
Fix array offset on bool.

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -236,8 +236,7 @@ class File extends Model
     {
         if ($this->isImage()) {
             $dimensions = $this->getImageDimensions();
-
-            return $dimensions[0];
+            return is_array($dimensions) ? $dimensions[0] : null;
         }
     }
 
@@ -249,8 +248,7 @@ class File extends Model
     {
         if ($this->isImage()) {
             $dimensions = $this->getImageDimensions();
-
-            return $dimensions[1];
+            return is_array($dimensions) ? $dimensions[1] : null;
         }
     }
 

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -230,7 +230,7 @@ class File extends Model
 
     /**
      * getWidthAttribute helper attribute for get image width
-     * @return string
+     * @return string|bool
      */
     public function getWidthAttribute()
     {
@@ -242,7 +242,7 @@ class File extends Model
 
     /**
      * getHeightAttribute helper attribute for get image height
-     * @return string
+     * @return string|bool
      */
     public function getHeightAttribute()
     {


### PR DESCRIPTION
`getImageDimensions()` method returns array or boolean.  We are not checking either we got array or boolean inside `getHeightAttribute()` and `getWidthAttribute()` methods.