### PR TITLE
Add factories and seeders support for plugins

### DIFF
--- a/src/Database/Concerns/HasFactory.php
+++ b/src/Database/Concerns/HasFactory.php
@@ -1,0 +1,37 @@
+<?php namespace October\Rain\Database\Concerns;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+trait HasFactory
+{
+    /**
+     * Get a new factory instance for the model.
+     *
+     * @param  callable|array|int|null  $count
+     * @param  callable|array  $state
+     * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
+     */
+    public static function factory($count = null, $state = [])
+    {
+        $factory = static::newFactory() ?: static::factoryForModel(get_called_class());
+
+        return $factory
+            ->count(is_numeric($count) ? $count : null)
+            ->state(is_callable($count) || is_array($count) ? $count : $state);
+    }
+
+    public function factoryForModel($class)
+    {
+        return static::$class.'Factory';
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
+     */
+    protected static function newFactory()
+    {
+        //
+    }
+}

--- a/src/Database/Concerns/HasFactory.php
+++ b/src/Database/Concerns/HasFactory.php
@@ -22,6 +22,8 @@ trait HasFactory
 
     public function factoryForModel($class)
     {
+        $class = str_replace('Models', 'Factories', $class);
+
         return static::$class.'Factory';
     }
 

--- a/src/Database/Concerns/HasFactory.php
+++ b/src/Database/Concerns/HasFactory.php
@@ -20,11 +20,11 @@ trait HasFactory
             ->state(is_callable($count) || is_array($count) ? $count : $state);
     }
 
-    public function factoryForModel($class)
+    public static function factoryForModel(string $class)
     {
-        $class = str_replace('Models', 'Factories', $class);
+        $factory = str_replace('Models', 'Factories', $class) . 'Factory';
 
-        return static::$class.'Factory';
+        return $factory::new();
     }
 
     /**

--- a/src/Scaffold/Console/CreateFactory.php
+++ b/src/Scaffold/Console/CreateFactory.php
@@ -1,0 +1,46 @@
+<?php namespace October\Rain\Scaffold\Console;
+
+use October\Rain\Scaffold\GeneratorCommandBase;
+
+/**
+ * CreateFactory
+ */
+class CreateFactory extends GeneratorCommandBase
+{
+    /**
+     * @var string signature for the command
+     */
+    protected $signature = 'create:factory
+        {namespace : App or Plugin Namespace. <info>(eg: Acme.Blog)</info>}
+        {name : The name of the job class to generate. <info>(eg: PostFactory)</info>}
+        {--o|overwrite : Overwrite existing files with generated ones}';
+
+    /**
+     * @var string description of the console command
+     */
+    protected $description = 'Creates a new factory class.';
+
+    /**
+     * @var string typeLabel of class being generated
+     */
+    protected $typeLabel = 'Factory';
+
+    /**
+     * makeStubs makes all stubs
+     */
+    public function makeStubs()
+    {
+        $this->makeStub('factory/factory.stub', 'factories/{{studly_name}}.php');
+    }
+
+    /**
+     * prepareVars prepares variables for stubs
+     */
+    protected function prepareVars(): array
+    {
+        return [
+            'name' => $this->argument('name'),
+            'namespace' => $this->argument('namespace'),
+        ];
+    }
+}

--- a/src/Scaffold/Console/CreateSeeder.php
+++ b/src/Scaffold/Console/CreateSeeder.php
@@ -1,0 +1,46 @@
+<?php namespace October\Rain\Scaffold\Console;
+
+use October\Rain\Scaffold\GeneratorCommandBase;
+
+/**
+ * CreateSeeder
+ */
+class CreateSeeder extends GeneratorCommandBase
+{
+    /**
+     * @var string signature for the command
+     */
+    protected $signature = 'create:seeder
+        {namespace : App or Plugin Namespace. <info>(eg: Acme.Blog)</info>}
+        {name : The name of the job class to generate. <info>(eg: PostSeeder)</info>}
+        {--o|overwrite : Overwrite existing files with generated ones}';
+
+    /**
+     * @var string description of the console command
+     */
+    protected $description = 'Creates a new seeder class.';
+
+    /**
+     * @var string typeLabel of class being generated
+     */
+    protected $typeLabel = 'Seeder';
+
+    /**
+     * makeStubs makes all stubs
+     */
+    public function makeStubs()
+    {
+        $this->makeStub('seeders/seeder.stub', 'seeder/{{studly_name}}.php');
+    }
+
+    /**
+     * prepareVars prepares variables for stubs
+     */
+    protected function prepareVars(): array
+    {
+        return [
+            'name' => $this->argument('name'),
+            'namespace' => $this->argument('namespace'),
+        ];
+    }
+}

--- a/src/Scaffold/Console/CreateSeeder.php
+++ b/src/Scaffold/Console/CreateSeeder.php
@@ -30,7 +30,7 @@ class CreateSeeder extends GeneratorCommandBase
      */
     public function makeStubs()
     {
-        $this->makeStub('seeders/seeder.stub', 'seeder/{{studly_name}}.php');
+        $this->makeStub('seeder/seeder.stub', 'seeders/{{studly_name}}.php');
     }
 
     /**

--- a/src/Scaffold/Console/factory/factory.stub
+++ b/src/Scaffold/Console/factory/factory.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace {{namespace_php}}\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class {{studly_name}} extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/Scaffold/Console/seeder/seeder.stub
+++ b/src/Scaffold/Console/seeder/seeder.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace {{namespace_php}}\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class {{studly_name}} extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}

--- a/src/Scaffold/ScaffoldServiceProvider.php
+++ b/src/Scaffold/ScaffoldServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace October\Rain\Scaffold;
 
 use October\Rain\Scaffold\Console\CreateCommand;
+use October\Rain\Scaffold\Console\CreateFactory;
 use October\Rain\Scaffold\Console\CreatePlugin;
 use October\Rain\Scaffold\Console\CreateModel;
 use October\Rain\Scaffold\Console\CreateMigration;
@@ -10,6 +11,7 @@ use October\Rain\Scaffold\Console\CreateFormWidget;
 use October\Rain\Scaffold\Console\CreateReportWidget;
 use October\Rain\Scaffold\Console\CreateFilterWidget;
 use October\Rain\Scaffold\Console\CreateContentField;
+use October\Rain\Scaffold\Console\CreateSeeder;
 use October\Rain\Scaffold\Console\CreateTest;
 use October\Rain\Scaffold\Console\CreateJob;
 use Illuminate\Contracts\Support\DeferrableProvider;
@@ -41,6 +43,8 @@ class ScaffoldServiceProvider extends ServiceProvider implements DeferrableProvi
         $this->app->singleton('command.create.command', CreateCommand::class);
         $this->app->singleton('command.create.test', CreateTest::class);
         $this->app->singleton('command.create.job', CreateJob::class);
+        $this->app->singleton('command.create.factory', CreateFactory::class);
+        $this->app->singleton('command.create.seeder', CreateSeeder::class);
 
         $this->commands('command.create.plugin');
         $this->commands('command.create.model');
@@ -54,6 +58,8 @@ class ScaffoldServiceProvider extends ServiceProvider implements DeferrableProvi
         $this->commands('command.create.command');
         $this->commands('command.create.test');
         $this->commands('command.create.job');
+        $this->commands('command.create.factory');
+        $this->commands('command.create.seeder');
     }
 
     /**
@@ -73,7 +79,10 @@ class ScaffoldServiceProvider extends ServiceProvider implements DeferrableProvi
             'command.create.filterwidget',
             'command.create.contentfield',
             'command.create.command',
-            'command.create.job'
+            'command.create.test',
+            'command.create.job',
+            'command.create.factory',
+            'command.create.seeder',
         ];
     }
 }


### PR DESCRIPTION
Adds
- php artisan create:seeder
- php artisan create:factory
- eloquent trait HasFactory to initialize factory on eloquent model

Missing validation:
- checks if seeders and factories have correct suffix

Needs to be added in october repo:
- php artisan plugin:seed