### PR TITLE
Correctly pass connection to Grammar class

### DIFF
--- a/src/Database/Connections/MySqlConnection.php
+++ b/src/Database/Connections/MySqlConnection.php
@@ -31,7 +31,12 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        $grammar = new QueryGrammar;
+        if (method_exists($grammar, 'setConnection')) {
+            $grammar->setConnection($this);
+        }
+        
+        return $this->withTablePrefix($grammar);
     }
 
     /**
@@ -55,7 +60,12 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar);
+        $grammar = new SchemaGrammar;
+        if (method_exists($grammar, 'setConnection')) {
+            $grammar->setConnection($this);
+        }
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**


### PR DESCRIPTION
This fixes issue with running ddRawSql methods on query

` RuntimeException  The database driver's grammar implementation does not support escaping values.`

Not sure if this needs to be done for every connection driver just tested MYSQL and it works.