### PR TITLE
Add filesystem.localToPublic event

### DIFF
--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Filesystem;
 
+use Event;
 use ReflectionClass;
 use FilesystemIterator;
 use Illuminate\Filesystem\Filesystem as FilesystemBase;
@@ -103,6 +104,20 @@ class Filesystem extends FilesystemBase
      */
     public function localToPublic($path)
     {
+        /**
+         * @event filesystem.localToPublic
+         * Allow custom logic for converting local to public paths on non-standard installations.
+         *
+         * Example usage
+         *
+         *     Event::listen('filesystem.localToPublic', function ($path) {
+         *         return '/custom/public/path';
+         *     });
+         */
+        if (($event = Event::fire('filesystem.localToPublic', [$path], true)) !== null) {
+            return $event;
+        }
+        
         // Check real paths
         $basePath = base_path();
         if (strpos($path, $basePath) === 0) {


### PR DESCRIPTION
Would you consider adding this event to the core? We have a special case where we are using symlinks to include core OctoberCMS files into the project to isolate each project under its own cPanel account while still beeing able to update all projects with a single deploy. Currently such a special situation is sometimes not handeled correctly by the ``localToPublic`` helper (null is returned).

![image](https://github.com/octobercms/library/assets/6329543/5c2d87a8-605c-4a62-b699-e25b358ec564)

By adding this event we could allow developers to implement custom logic for converting local to public paths and solve special cases such as this.