### PR TITLE
Why is the VerifyCsrfToken middleware commented out in this code?

### DIFF
--- a/src/Foundation/Http/Kernel.php
+++ b/src/Foundation/Http/Kernel.php
@@ -60,7 +60,7 @@ class Kernel extends HttpKernel
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            // \App\Http\Middleware\VerifyCsrfToken::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
         'api' => [


### PR DESCRIPTION
Why is the VerifyCsrfToken middleware commented out in this code?
Is this a typo?