### PR TITLE
rtrim() on AssetFactory.php

### DIFF
--- a/src/Assetic/Factory/AssetFactory.php
+++ b/src/Assetic/Factory/AssetFactory.php
@@ -51,7 +51,7 @@ class AssetFactory
      */
     public function __construct($root, $debug = false)
     {
-        $this->root = rtrim($root, '/');
+        $this->root = $root ? rtrim($root, '/') : '';
         $this->debug = $debug;
         $this->output = 'assetic/*';
     }


### PR DESCRIPTION
rtrim(): Passing null to parameter #1 ($string) of type string is deprecated in PHP 8.3