### PR TITLE
Use October\...\HandleExceptions in Console\Kernel

### DIFF
--- a/src/Foundation/Console/Kernel.php
+++ b/src/Foundation/Console/Kernel.php
@@ -14,7 +14,7 @@ class Kernel extends ConsoleKernel
     protected $bootstrappers = [
         \Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables::class,
         \October\Rain\Foundation\Bootstrap\LoadConfiguration::class,
-        \Illuminate\Foundation\Bootstrap\HandleExceptions::class,
+        \October\Rain\Foundation\Bootstrap\HandleExceptions::class,
         \Illuminate\Foundation\Bootstrap\RegisterFacades::class,
         \Illuminate\Foundation\Bootstrap\SetRequestForConsole::class,
         \October\Rain\Foundation\Bootstrap\RegisterOctober::class,


### PR DESCRIPTION
We encountered an issue with de new deprecation logging feature. Through configuration this feature is switched off by default but we noticed that deprecations were still logged as warnings when running console command.

Turns out that the new `HandleExceptions` class was not registered in the Console\Kernel. 

This change is already implemented in the Http\Kernel which was added in https://github.com/octobercms/library/commit/ed6aa00a590f232fac38fd5bb8406f1ca9149afe