### PR TITLE
Fixed injection of FlashBag class

### DIFF
--- a/src/Flash/FlashServiceProvider.php
+++ b/src/Flash/FlashServiceProvider.php
@@ -22,6 +22,6 @@ class FlashServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function provides()
     {
-        return ['flash'];
+        return ['flash', FlashBag::class];
     }
 }


### PR DESCRIPTION
During the OC4 upgrade of one of our projects, we detected that flash messages were not being displayed correctly after a redirect. This turned out to be caused by the `FlashBag` instance being constructed twice — once from `modules/cms/twig/Extension.php` for the `{% flash %}` tag in the theme, and once from within one of our plugins. Each time the `FlashBag` class is constructed however, the messages are pulled from the session and cleared thereafter, resulting in an empty list of flash messages.

**Cause**
With the introduction of OC4, the class
https://github.com/octobercms/library/blob/3.x/src/Foundation/Providers/AppDeferSupportServiceProvider.php
was removed.

In previous versions of OC, when any class from the list below was resolved, the providers in `AppDeferSupportServiceProvider` were loaded, including the `FlashServiceProvider`. Since the `FlashBag` is bound as a singleton in this provider, it ensured that the class would not be constructed more than once (upon injection), and thus the session would not be cleared multiple times.

Now that this class is no longer present (which is a good change), it's important that all deferred `ServiceProviders` correctly list all of their services in the `provides` method. This is currently not the case for the `FlashServiceProvider`, as only the string 'flash' is listed, and not the class string of the `FlashBag` class. This causes the `FlashServiceProvider` not to be registered when the `FlashBag` class is injected or resolved using the class string instead of the string `flash`.

This PR fixes this issue by adding the FlashBag class string to the list.

N.B: When testing locally, I had to run `composer dump-autoload` after the change to regenerate the manifest file.

The list of previously service load-triggering classes:
```
mail.manager' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'mailer' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Mail\\Markdown' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'html' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'form' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'block' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'flash' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'parse.markdown' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'parse.yaml' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'parse.twig' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'parse.ini' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'assetic' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'resizer' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'validator' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'validation.presence' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Contracts\\Validation\\UncompromisedVerifier' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'translator' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'translation.loader' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'auth.password' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'auth.password.broker' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Cache\\Console\\ClearCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Cache\\Console\\ForgetCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'October\\Rain\\Foundation\\Console\\ClearCompiledCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\ConfigCacheCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\ConfigClearCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Database\\Console\\WipeCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\DownCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\EnvironmentCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\EventCacheCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\EventClearCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\EventListCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\KeyGenerateCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\OptimizeCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\OptimizeClearCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\PackageDiscoverCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\ClearCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\ListFailedCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\FlushFailedCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\ForgetFailedCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\ListenCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\MonitorCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\PruneBatchesCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\PruneFailedJobsCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\RestartCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\RetryCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\RetryBatchCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Queue\\Console\\WorkCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'October\\Rain\\Foundation\\Console\\RouteCacheCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\RouteClearCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'October\\Rain\\Foundation\\Console\\RouteListCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Console\\Scheduling\\ScheduleFinishCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Console\\Scheduling\\ScheduleListCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Console\\Scheduling\\ScheduleRunCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Console\\Scheduling\\ScheduleClearCacheCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Console\\Scheduling\\ScheduleTestCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Console\\Scheduling\\ScheduleWorkCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Database\\Console\\Seeds\\SeedCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\StorageLinkCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\UpCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\ViewCacheCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\ViewClearCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'October\\Rain\\Foundation\\Console\\ProjectSetCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'October\\Rain\\Foundation\\Console\\ServeCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Foundation\\Console\\VendorPublishCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'migrator' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'migration.repository' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'migration.creator' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Database\\Console\\Migrations\\MigrateCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Database\\Console\\Migrations\\FreshCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Database\\Console\\Migrations\\InstallCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Database\\Console\\Migrations\\RefreshCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Database\\Console\\Migrations\\ResetCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Database\\Console\\Migrations\\RollbackCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Database\\Console\\Migrations\\StatusCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'Illuminate\\Database\\Console\\Migrations\\MigrateMakeCommand' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.plugin' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.model' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.migration' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.controller' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.component' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.formwidget' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.reportwidget' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.filterwidget' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.contentfield' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.command' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.test' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.job' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.factory' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'command.create.seeder' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
'composer' => 'October\\Rain\\Foundation\\Providers\\AppDeferSupportServiceProvider',
``` 