### PR TITLE
Fix for Laravels Carbon becoming stricter on return types. 

### DIFF
--- a/src/Support/Date.php
+++ b/src/Support/Date.php
@@ -21,7 +21,7 @@ class Date extends DateBase
     /**
      * createFromFormat
      */
-    public static function createFromFormat($format, $time, $timezone = null): ?DateBase
+    public static function createFromFormat($format, $time, $timezone = null): ?static
     {
         if (is_string($time)) {
             $time = static::translateTimeString($time, static::getLocale(), 'en');


### PR DESCRIPTION
Carbon became stricter about return type compatibility I think. The DateBase type that worked before was no longer accepted, but ?static is the proper return type that Carbon expects for late static binding.

Error I recieved:

```
NOTICE: PHP message: PHP Fatal error: Declaration of October\Rain\Support\Date::createFromFormat($format, $time, $timezone = null): ?Carbon\Carbon must be compatible with Carbon\Carbon::createFromFormat($format, $time, $timezone = null): ?static in /var/www/html/vendor/october/rain/src/Support/Date.php on line 24
NOTICE: PHP message: PHP Fatal error: Uncaught Error: Class "October\Rain\Support\Date" not found in /var/www/html/vendor/laravel/framework/src/Illuminate/Support/DateFactory.php:248
```

The fix in my pull request fixed the issue for all of my octobercms sites.
Thanks.  