### PR TITLE
Add morphToMany to be able to use with relation sort

### DIFF
--- a/src/Database/Traits/SortableRelation.php
+++ b/src/Database/Traits/SortableRelation.php
@@ -62,7 +62,7 @@ trait SortableRelation
      */
     protected function defineSortableRelations()
     {
-        $interactsWithPivot = ['belongsToMany'];
+        $interactsWithPivot = ['belongsToMany', 'morphToMany'];
         $sortableRelations = [];
 
         foreach ($interactsWithPivot as $type) {


### PR DESCRIPTION
This pull request makes a small update to the `defineSortableRelations` method in `src/Database/Traits/SortableRelation.php` to improve support for relation types. The change adds `morphToMany` to the list of relation types that interact with pivot tables.

* Added `morphToMany` to the `$interactsWithPivot` array to ensure sortable relations work correctly for both `belongsToMany` and `morphToMany` relationships.