### PR TITLE
fix(ErrorHandler): replace array_first with foreach in isNotFoundExce…

### DIFF
--- a/src/Exception/ErrorHandler.php
+++ b/src/Exception/ErrorHandler.php
@@ -85,9 +85,12 @@ class ErrorHandler
      */
     protected function isNotFoundException($exception)
     {
-        return array_first($this->notFoundExceptions, function($type) use ($exception) {
-            return $exception instanceof $type;
-        });
+        foreach ($this->notFoundExceptions as $type) {
+            if ($exception instanceof $type) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
…ption

On newer stacks (Laravel 12.23+/PHP 8.5 polyfill), global array_first no longer accepts a callback, making isNotFoundException() always true and forcing 404 for all exceptions. Replace with a plain foreach to restore correct detection.