### PR TITLE
Add lazy loading prevention support to Model

### DIFF
--- a/src/Database/Concerns/HasAttributes.php
+++ b/src/Database/Concerns/HasAttributes.php
@@ -75,13 +75,35 @@ trait HasAttributes
             return $this->getAttributeValue($key);
         }
 
+        return $this->getRelationValue($key);
+    }
+
+    /**
+     * getRelationValue gets a relationship value from a method.
+     * Overridden from {@link Eloquent} to implement recognition of the relation
+     * using October Rain's property-based relation definitions.
+     * @param string $key
+     * @return mixed
+     */
+    public function getRelationValue($key)
+    {
         if ($this->relationLoaded($key)) {
             return $this->relations[$key];
         }
 
-        if ($this->hasRelation($key)) {
-            return $this->getRelationshipFromMethod($key);
+        if (!$this->hasRelation($key)) {
+            return;
         }
+
+        if ($this->attemptToAutoloadRelation($key)) {
+            return $this->relations[$key];
+        }
+
+        if ($this->preventsLazyLoading) {
+            $this->handleLazyLoadingViolation($key);
+        }
+
+        return $this->getRelationshipFromMethod($key);
     }
 
     /**


### PR DESCRIPTION
Override getRelationValue() to integrate with Laravel's lazy loading prevention system while using October Rain's property-based relation definitions (hasRelation instead of isRelation).

Supports:
- Model::preventLazyLoading()
- $model->withRelationshipAutoloading()
- Model::handleLazyLoadingViolationUsing()
- attemptToAutoloadRelation() for automatic eager loading