### PR TITLE
Update tests to match php 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        phpVersions: ['8.2', '8.3', '8.4']
+        phpVersions: ['8.2', '8.3', '8.4', '8.5']
       fail-fast: false
     name: PHP ${{ matrix.phpVersions }}
     steps:

--- a/src/Halcyon/Exception/ModelException.php
+++ b/src/Halcyon/Exception/ModelException.php
@@ -2,6 +2,8 @@
 
 use October\Rain\Halcyon\Model;
 use October\Rain\Exception\ValidationException;
+use Illuminate\Support\MessageBag;
+use Exception;
 
 /**
  * ModelException used when validation fails, contains the invalid model for easy analysis
@@ -17,13 +19,38 @@ class ModelException extends ValidationException
     protected $model;
 
     /**
+     * @var MessageBag validationErrors
+     */
+    protected $validationErrors;
+
+    /**
      * __construct receives the invalid model
      */
     public function __construct(Model $model)
     {
         $this->model = $model;
-        $this->errors = $model->errors();
+        $this->validationErrors = $model->errors();
+
+        // Bypass parent constructor to avoid Validator facade dependency
+        Exception::__construct($this->validationErrors->first());
+
         $this->evalErrors();
+    }
+
+    /**
+     * errors returns validation errors
+     */
+    public function errors(): array
+    {
+        return $this->validationErrors->messages();
+    }
+
+    /**
+     * getErrors returns the message bag instance
+     */
+    public function getErrors(): MessageBag
+    {
+        return $this->validationErrors;
     }
 
     /**

--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -444,7 +444,7 @@ class HtmlBuilder
                 break;
             }
 
-            if ($tag[0] === '&' || ord($tag) >= 0x80) {
+            if ($tag[0] === '&' || ord($tag[0]) >= 0x80) {
                 $result .= $tag;
                 $printedLength++;
             }

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -45,7 +45,7 @@ class Translator extends TranslatorBase
 
         // Laravel notes that with JSON translations, there is no usage of a fallback language.
         // The key is the translation. Here we extend the technology to add fallback support.
-        if ($fallback && $line === null) {
+        if ($fallback && $line === null && $this->fallback !== null) {
             $this->load('*', '*', $this->fallback);
             $line = $this->loaded['*']['*'][$this->fallback][$key] ?? null;
         }

--- a/tests/Html/HtmlBuilderTest.php
+++ b/tests/Html/HtmlBuilderTest.php
@@ -21,15 +21,17 @@ class HtmlBuilderTest extends TestCase
         $result = with(new HtmlBuilder)->limit("<p>The quick brown fox jumped over the lazy dog</p><p>The quick brown fox jumped over the lazy dog</p>", 50);
         $this->assertEquals('<p>The quick brown fox jumped over the lazy dog</p><p>The qu...</p>', $result);
 
-        $result = with(new HtmlBuilder)->limit(trim("
+        $input = str_replace("\r\n", "\n", trim("
             <p>The quick brown fox jumped over the lazy dog</p>
             <p>The quick brown fox jumped over the lazy dog</p>
-        "), 60);
+        "));
+        $result = with(new HtmlBuilder)->limit($input, 60);
 
-        $this->assertEquals(trim('
+        $expected = str_replace("\r\n", "\n", trim('
             <p>The quick brown fox jumped over the lazy dog</p>
             <p>The...</p>
-        '), $result);
+        '));
+        $this->assertEquals($expected, $result);
     }
 
     public function testClean()

--- a/tests/Mail/MailerTest.php
+++ b/tests/Mail/MailerTest.php
@@ -95,7 +95,6 @@ class MailerTest extends TestCase
         $className = get_class($object);
         $class = new ReflectionClass($className);
         $method = $class->getMethod($name);
-        $method->setAccessible(true);
         return $method->invokeArgs($object, $params);
     }
 

--- a/tests/Parse/MarkdownTest.php
+++ b/tests/Parse/MarkdownTest.php
@@ -97,7 +97,7 @@ $expected = '<p>&lt;table</p>
         $normal = $parser->parse($text);
 
         // Only accepting one node per line
-        $this->assertEquals($expected, $normal);
+        $this->assertEquals(str_replace("\r\n", "\n", $expected), $normal);
     }
 
     public function testParseMultilineHtml()
@@ -149,6 +149,6 @@ HTML;
 
         $normal = $parser->parse($text);
 
-        $this->assertEquals($expected, $normal);
+        $this->assertEquals(str_replace("\r\n", "\n", $expected), $normal);
     }
 }

--- a/tests/Parse/SyntaxFieldParserTest.php
+++ b/tests/Parse/SyntaxFieldParserTest.php
@@ -322,7 +322,6 @@ class SyntaxFieldParserTest extends TestCase
         $className = get_class($object);
         $class = new ReflectionClass($className);
         $method = $class->getMethod($name);
-        $method->setAccessible(true);
         return $method->invokeArgs($object, $params);
     }
 
@@ -331,7 +330,6 @@ class SyntaxFieldParserTest extends TestCase
         $className = get_class($object);
         $class = new ReflectionClass($className);
         $property = $class->getProperty($name);
-        $property->setAccessible(true);
         return $property->getValue($object);
     }
 
@@ -340,7 +338,6 @@ class SyntaxFieldParserTest extends TestCase
         $className = get_class($object);
         $class = new ReflectionClass($className);
         $property = $class->getProperty($name);
-        $property->setAccessible(true);
         return $property->setValue($object, $value);
     }
 }

--- a/tests/Scaffold/ScaffoldBaseTest.php
+++ b/tests/Scaffold/ScaffoldBaseTest.php
@@ -25,7 +25,6 @@ class ScaffoldBaseTest extends TestCase
         $className = get_class($object);
         $class = new ReflectionClass($className);
         $method = $class->getMethod($name);
-        $method->setAccessible(true);
         return $method->invokeArgs($object, $params);
     }
 
@@ -34,7 +33,6 @@ class ScaffoldBaseTest extends TestCase
         $className = get_class($object);
         $class = new ReflectionClass($className);
         $property = $class->getProperty($name);
-        $property->setAccessible(true);
         return $property->getValue($object);
     }
 
@@ -43,7 +41,6 @@ class ScaffoldBaseTest extends TestCase
         $className = get_class($object);
         $class = new ReflectionClass($className);
         $property = $class->getProperty($name);
-        $property->setAccessible(true);
         return $property->setValue($object, $value);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,7 +20,6 @@ class TestCase extends PHPUnit\Framework\TestCase
         $className = get_class($object);
         $class = new ReflectionClass($className);
         $method = $class->getMethod($name);
-        $method->setAccessible(true);
         return $method->invokeArgs($object, $params);
     }
 


### PR DESCRIPTION
  Summary

  - Add PHP 8.5 compatibility fixes for deprecated features
  - Add PHP 8.5 to GitHub Actions test matrix

  Changes

  Deprecation Fixes:
  - src/Html/HtmlBuilder.php - Fix ord() deprecation on multi-byte strings
  - src/Translation/Translator.php - Fix null array offset deprecation
  - src/Halcyon/Exception/ModelException.php - Override errors() and getErrors() to avoid facade dependency in validation context

  Test Fixes (PHP 8.5 compatibility):
  - Remove deprecated setAccessible() calls (no effect since PHP 8.1)
  - Normalize line endings in test assertions for cross-platform compatibility

  CI:
  - Add PHP 8.5 to test matrix in .github/workflows/tests.yml