### PR TITLE
Update PHP requirement to 8.1 and remove strftime() deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "^8.1",
         "composer/composer": "^2.0.0",
         "composer/installers": "^1 || ^2",
         "larajax/larajax": "^2.0",

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -558,15 +558,16 @@ class FormBuilder
      * @param  string  $name
      * @param  string  $selected
      * @param  array   $options
-     * @param  string  $format
+     * @param  string  $format DateTime format string (default: 'F' for full month name)
      * @return string
      */
-    public function selectMonth($name, $selected = null, $options = [], $format = '%B')
+    public function selectMonth($name, $selected = null, $options = [], $format = 'F')
     {
         $months = [];
 
         foreach (range(1, 12) as $month) {
-            $months[$month] = strftime($format, mktime(0, 0, 0, $month, 1));
+            $date = new \DateTime("2024-{$month}-01");
+            $months[$month] = $date->format($format);
         }
 
         return $this->select($name, $months, $selected, $options);


### PR DESCRIPTION
- Bumps minimum PHP version from 8.0.2 to 8.1
- Replaces deprecated strftime() in FormBuilder::selectMonth() with DateTime::format()
- Changes default format parameter from strftime '%B' to DateTime 'F' (both output full month name)