### PR TITLE
Add MariaDB driver and error detector singletons from Laravel 12

### DIFF
--- a/src/Database/Connections/MariaDbConnection.php
+++ b/src/Database/Connections/MariaDbConnection.php
@@ -1,0 +1,11 @@
+<?php namespace October\Rain\Database\Connections;
+
+use Illuminate\Database\MariaDbConnection as MariaDbConnectionBase;
+
+/**
+ * MariaDbConnection implements connection extension
+ */
+class MariaDbConnection extends MariaDbConnectionBase
+{
+    use \October\Rain\Database\Connections\ExtendsConnection;
+}

--- a/src/Database/Connectors/ConnectionFactory.php
+++ b/src/Database/Connectors/ConnectionFactory.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Arr;
 use Illuminate\Database\Connectors\ConnectionFactory as ConnectionFactoryBase;
 use October\Rain\Database\Connections\Connection;
+use October\Rain\Database\Connections\MariaDbConnection;
 use October\Rain\Database\Connections\MySqlConnection;
 use October\Rain\Database\Connections\SQLiteConnection;
 use October\Rain\Database\Connections\PostgresConnection;
@@ -57,6 +58,8 @@ class ConnectionFactory extends ConnectionFactoryBase
         switch ($driver) {
             case 'mysql':
                 return new MySqlConnection($connection, $database, $prefix, $config);
+            case 'mariadb':
+                return new MariaDbConnection($connection, $database, $prefix, $config);
             case 'pgsql':
                 return new PostgresConnection($connection, $database, $prefix, $config);
             case 'sqlite':

--- a/src/Database/DatabaseServiceProvider.php
+++ b/src/Database/DatabaseServiceProvider.php
@@ -6,6 +6,10 @@ use October\Rain\Database\Connectors\ConnectionFactory;
 use Illuminate\Database\DatabaseServiceProvider as DatabaseServiceProviderBase;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\DatabaseTransactionsManager;
+use Illuminate\Database\ConcurrencyErrorDetector;
+use Illuminate\Database\LostConnectionDetector;
+use Illuminate\Contracts\Database\ConcurrencyErrorDetector as ConcurrencyErrorDetectorContract;
+use Illuminate\Contracts\Database\LostConnectionDetector as LostConnectionDetectorContract;
 
 /**
  * DatabaseServiceProvider
@@ -18,7 +22,6 @@ class DatabaseServiceProvider extends DatabaseServiceProviderBase
     public function register()
     {
         Model::clearBootedModels();
-        Model::flushEventListeners();
 
         $this->registerConnectionServices();
         $this->registerFakerGenerator();
@@ -81,6 +84,10 @@ class DatabaseServiceProvider extends DatabaseServiceProviderBase
         $this->app->singleton('db.updater', function ($app) {
             return new Updater;
         });
+
+        $this->app->singleton(ConcurrencyErrorDetectorContract::class, ConcurrencyErrorDetector::class);
+
+        $this->app->singleton(LostConnectionDetectorContract::class, LostConnectionDetector::class);
     }
 
     /**


### PR DESCRIPTION
- Add MariaDbConnection class as separate driver (not MySQL variant)
- Update ConnectionFactory to support 'mariadb' driver
- Register ConcurrencyErrorDetector singleton for deadlock detection
- Register LostConnectionDetector singleton for reconnection logic
- Remove unnecessary Model::flushEventListeners() call (reduces overhead)

The error detectors are used internally by Laravel for:
- ConcurrencyErrorDetector: Detecting deadlocks and serialization failures to enable automatic transaction retries
- LostConnectionDetector: Detecting lost database connections to trigger reconnection