### PR TITLE
Add Laravel 12 quiet methods and createOrFirst to relations

### DIFF
--- a/src/Database/Concerns/HasNicerPagination.php
+++ b/src/Database/Concerns/HasNicerPagination.php
@@ -52,4 +52,28 @@ trait HasNicerPagination
     {
         return $this->simplePaginate($perPage, ['*'], $pageName);
     }
+
+    /**
+     * cursorPaginateAtPage paginates using a cursor by passing the cursor directly.
+     *
+     * @param  int  $perPage
+     * @param  \Illuminate\Pagination\Cursor|string|null  $cursor
+     * @return \Illuminate\Contracts\Pagination\CursorPaginator
+     */
+    public function cursorPaginateAtPage($perPage, $cursor)
+    {
+        return $this->cursorPaginate($perPage, ['*'], 'cursor', $cursor);
+    }
+
+    /**
+     * cursorPaginateCustom paginates using a cursor with a custom cursor name.
+     *
+     * @param  int  $perPage
+     * @param  string $cursorName
+     * @return \Illuminate\Contracts\Pagination\CursorPaginator
+     */
+    public function cursorPaginateCustom($perPage, $cursorName)
+    {
+        return $this->cursorPaginate($perPage, ['*'], $cursorName);
+    }
 }

--- a/src/Database/Relations/AttachOneOrMany.php
+++ b/src/Database/Relations/AttachOneOrMany.php
@@ -139,6 +139,38 @@ trait AttachOneOrMany
     }
 
     /**
+     * saveQuietly saves the supplied related model without raising any events.
+     */
+    public function saveQuietly(Model $model, $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($model, $sessionKey) {
+            return $this->save($model, $sessionKey);
+        });
+    }
+
+    /**
+     * saveMany saves multiple models with deferred binding support.
+     */
+    public function saveMany($models, $sessionKey = null)
+    {
+        foreach ($models as $model) {
+            $this->save($model, $sessionKey);
+        }
+
+        return $models;
+    }
+
+    /**
+     * saveManyQuietly saves multiple models without raising any events.
+     */
+    public function saveManyQuietly($models, $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($models, $sessionKey) {
+            return $this->saveMany($models, $sessionKey);
+        });
+    }
+
+    /**
      * create a new instance of this related model
      */
     public function create(array $attributes = [], $sessionKey = null)
@@ -160,6 +192,40 @@ trait AttachOneOrMany
         }
 
         return $model;
+    }
+
+    /**
+     * createQuietly creates a new instance without raising any events.
+     */
+    public function createQuietly(array $attributes = [], $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($attributes, $sessionKey) {
+            return $this->create($attributes, $sessionKey);
+        });
+    }
+
+    /**
+     * createMany creates multiple instances of related models.
+     */
+    public function createMany(iterable $records, $sessionKey = null)
+    {
+        $instances = [];
+
+        foreach ($records as $record) {
+            $instances[] = $this->create($record, $sessionKey);
+        }
+
+        return $instances;
+    }
+
+    /**
+     * createManyQuietly creates multiple instances without raising any events.
+     */
+    public function createManyQuietly(iterable $records, $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($records, $sessionKey) {
+            return $this->createMany($records, $sessionKey);
+        });
     }
 
     /**

--- a/src/Database/Relations/BelongsToMany.php
+++ b/src/Database/Relations/BelongsToMany.php
@@ -69,11 +69,94 @@ class BelongsToMany extends BelongsToManyBase
     }
 
     /**
+     * saveQuietly saves the model without raising any events,
+     * with deferred binding support.
+     */
+    public function saveQuietly(Model $model, array $pivotData = [], $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($model, $pivotData, $sessionKey) {
+            return $this->save($model, $pivotData, $sessionKey);
+        });
+    }
+
+    /**
+     * saveMany saves multiple models with deferred binding support.
+     */
+    public function saveMany($models, array $pivotData = [], $sessionKey = null)
+    {
+        foreach ($models as $model) {
+            $this->save($model, $pivotData, $sessionKey);
+        }
+
+        return $models;
+    }
+
+    /**
+     * saveManyQuietly saves multiple models without raising any events,
+     * with deferred binding support.
+     */
+    public function saveManyQuietly($models, array $pivotData = [], $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($models, $pivotData, $sessionKey) {
+            return $this->saveMany($models, $pivotData, $sessionKey);
+        });
+    }
+
+    /**
      * create a new instance of this related model with deferred binding support.
      */
     public function create(array $attributes = [], array $pivotData = [], $sessionKey = null)
     {
         $model = $this->related->create($attributes);
+
+        $this->add($model, $sessionKey, $pivotData);
+
+        return $model;
+    }
+
+    /**
+     * createQuietly creates a new instance without raising any events,
+     * with deferred binding support.
+     */
+    public function createQuietly(array $attributes = [], array $pivotData = [], $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($attributes, $pivotData, $sessionKey) {
+            return $this->create($attributes, $pivotData, $sessionKey);
+        });
+    }
+
+    /**
+     * createMany creates multiple related models with deferred binding support.
+     */
+    public function createMany(iterable $records, array $pivotData = [], $sessionKey = null)
+    {
+        $instances = $this->related->newCollection();
+
+        foreach ($records as $record) {
+            $instances->push($this->create($record, $pivotData, $sessionKey));
+        }
+
+        return $instances;
+    }
+
+    /**
+     * createManyQuietly creates multiple models without raising any events,
+     * with deferred binding support.
+     */
+    public function createManyQuietly(iterable $records, array $pivotData = [], $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($records, $pivotData, $sessionKey) {
+            return $this->createMany($records, $pivotData, $sessionKey);
+        });
+    }
+
+    /**
+     * createOrFirst attempts to create the record, or if a unique constraint
+     * violation occurs, finds the existing record.
+     */
+    public function createOrFirst(array $attributes = [], array $values = [], array $pivotData = [], $sessionKey = null)
+    {
+        $model = $this->related->createOrFirst($attributes, $values);
 
         $this->add($model, $sessionKey, $pivotData);
 
@@ -286,6 +369,26 @@ class BelongsToMany extends BelongsToManyBase
         $this->query->addSelect($this->shouldSelect($columns));
 
         $paginator = $this->query->simplePaginate($perPage, $currentPage, $columns);
+
+        $this->hydratePivotRelation($paginator->items());
+
+        return $paginator;
+    }
+
+    /**
+     * cursorPaginate using a cursor paginator.
+     *
+     * @param  int|null  $perPage
+     * @param  array  $columns
+     * @param  string  $cursorName
+     * @param  \Illuminate\Pagination\Cursor|string|null  $cursor
+     * @return \Illuminate\Contracts\Pagination\CursorPaginator
+     */
+    public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null)
+    {
+        $this->query->addSelect($this->shouldSelect($columns));
+
+        $paginator = $this->query->cursorPaginate($perPage, $columns, $cursorName, $cursor);
 
         $this->hydratePivotRelation($paginator->items());
 

--- a/src/Database/Relations/HasOneOrMany.php
+++ b/src/Database/Relations/HasOneOrMany.php
@@ -31,6 +31,17 @@ trait HasOneOrMany
     }
 
     /**
+     * saveQuietly saves the supplied related model without raising any events,
+     * with deferred binding support.
+     */
+    public function saveQuietly(Model $model, $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($model, $sessionKey) {
+            return $this->save($model, $sessionKey);
+        });
+    }
+
+    /**
      * saveMany is an alias for the addMany() method
      * @param  array  $models
      * @return array
@@ -43,11 +54,92 @@ trait HasOneOrMany
     }
 
     /**
+     * saveManyQuietly saves multiple models without raising any events,
+     * with deferred binding support.
+     */
+    public function saveManyQuietly($models, $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($models, $sessionKey) {
+            return $this->saveMany($models, $sessionKey);
+        });
+    }
+
+    /**
      * create a new instance of this related model with deferred binding support
      */
     public function create(array $attributes = [], $sessionKey = null)
     {
         $model = parent::create($attributes);
+
+        if ($sessionKey !== null) {
+            $this->add($model, $sessionKey);
+        }
+
+        return $model;
+    }
+
+    /**
+     * createQuietly creates a new instance without raising any events,
+     * with deferred binding support.
+     */
+    public function createQuietly(array $attributes = [], $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($attributes, $sessionKey) {
+            return $this->create($attributes, $sessionKey);
+        });
+    }
+
+    /**
+     * forceCreateQuietly creates a new instance bypassing mass assignment
+     * without raising any events, with deferred binding support.
+     */
+    public function forceCreateQuietly(array $attributes = [], $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($attributes, $sessionKey) {
+            $model = parent::forceCreate($attributes);
+
+            if ($sessionKey !== null) {
+                $this->add($model, $sessionKey);
+            }
+
+            return $model;
+        });
+    }
+
+    /**
+     * createMany creates multiple related models with deferred binding support.
+     */
+    public function createMany(iterable $records, $sessionKey = null)
+    {
+        $instances = parent::createMany($records);
+
+        if ($sessionKey !== null) {
+            foreach ($instances as $model) {
+                $this->add($model, $sessionKey);
+            }
+        }
+
+        return $instances;
+    }
+
+    /**
+     * createManyQuietly creates multiple models without raising any events,
+     * with deferred binding support.
+     */
+    public function createManyQuietly(iterable $records, $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($records, $sessionKey) {
+            return $this->createMany($records, $sessionKey);
+        });
+    }
+
+    /**
+     * createOrFirst attempts to create the record, or if a unique constraint
+     * violation occurs, finds the existing record.
+     */
+    public function createOrFirst(array $attributes = [], array $values = [], $sessionKey = null)
+    {
+        $model = parent::createOrFirst($attributes, $values);
 
         if ($sessionKey !== null) {
             $this->add($model, $sessionKey);

--- a/src/Database/Relations/MorphOneOrMany.php
+++ b/src/Database/Relations/MorphOneOrMany.php
@@ -32,11 +32,115 @@ trait MorphOneOrMany
     }
 
     /**
+     * saveQuietly saves the supplied related model without raising any events,
+     * with deferred binding support.
+     */
+    public function saveQuietly(Model $model, $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($model, $sessionKey) {
+            return $this->save($model, $sessionKey);
+        });
+    }
+
+    /**
+     * saveMany saves multiple models with deferred binding support.
+     */
+    public function saveMany($models, $sessionKey = null)
+    {
+        foreach ($models as $model) {
+            $this->save($model, $sessionKey);
+        }
+
+        return $models;
+    }
+
+    /**
+     * saveManyQuietly saves multiple models without raising any events,
+     * with deferred binding support.
+     */
+    public function saveManyQuietly($models, $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($models, $sessionKey) {
+            return $this->saveMany($models, $sessionKey);
+        });
+    }
+
+    /**
      * create a new instance of this related model with deferred binding support.
      */
     public function create(array $attributes = [], $sessionKey = null)
     {
         $model = parent::create($attributes);
+
+        if ($sessionKey !== null) {
+            $this->add($model, $sessionKey);
+        }
+
+        return $model;
+    }
+
+    /**
+     * createQuietly creates a new instance without raising any events,
+     * with deferred binding support.
+     */
+    public function createQuietly(array $attributes = [], $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($attributes, $sessionKey) {
+            return $this->create($attributes, $sessionKey);
+        });
+    }
+
+    /**
+     * forceCreateQuietly creates a new instance bypassing mass assignment
+     * without raising any events, with deferred binding support.
+     */
+    public function forceCreateQuietly(array $attributes = [], $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($attributes, $sessionKey) {
+            $model = parent::forceCreate($attributes);
+
+            if ($sessionKey !== null) {
+                $this->add($model, $sessionKey);
+            }
+
+            return $model;
+        });
+    }
+
+    /**
+     * createMany creates multiple related models with deferred binding support.
+     */
+    public function createMany(iterable $records, $sessionKey = null)
+    {
+        $instances = parent::createMany($records);
+
+        if ($sessionKey !== null) {
+            foreach ($instances as $model) {
+                $this->add($model, $sessionKey);
+            }
+        }
+
+        return $instances;
+    }
+
+    /**
+     * createManyQuietly creates multiple models without raising any events,
+     * with deferred binding support.
+     */
+    public function createManyQuietly(iterable $records, $sessionKey = null)
+    {
+        return Model::withoutEvents(function () use ($records, $sessionKey) {
+            return $this->createMany($records, $sessionKey);
+        });
+    }
+
+    /**
+     * createOrFirst attempts to create the record, or if a unique constraint
+     * violation occurs, finds the existing record.
+     */
+    public function createOrFirst(array $attributes = [], array $values = [], $sessionKey = null)
+    {
+        $model = parent::createOrFirst($attributes, $values);
 
         if ($sessionKey !== null) {
             $this->add($model, $sessionKey);


### PR DESCRIPTION
Sync missing relation methods from Laravel 12:
- saveQuietly, saveManyQuietly for saving without events
- createQuietly, createManyQuietly for creating without events
- forceCreateQuietly for bypassing mass assignment without events
- createOrFirst for atomic create-or-find operations
- createMany with deferred binding support
- cursorPaginate for BelongsToMany with pivot hydration
- cursorPaginateAtPage and cursorPaginateCustom helpers

All methods support October's deferred binding via sessionKey parameter.