### PR TITLE
Remove attribute access events for performance

### DIFF
--- a/src/Database/Concerns/HasAttributes.php
+++ b/src/Database/Concerns/HasAttributes.php
@@ -19,13 +19,6 @@ trait HasAttributes
     {
         $attributes = $this->getArrayableAttributes();
 
-        // Before Event
-        foreach ($attributes as $key => $value) {
-            if (($eventValue = $this->fireEvent('model.beforeGetAttribute', [$key], true)) !== null) {
-                $attributes[$key] = $eventValue;
-            }
-        }
-
         // Dates
         $attributes = $this->addDateAttributesToArray($attributes);
 
@@ -48,13 +41,6 @@ trait HasAttributes
         $attributes = $this->addJsonableAttributesToArray(
             $attributes, $mutatedAttributes
         );
-
-        // After Event
-        foreach ($attributes as $key => $value) {
-            if (($eventValue = $this->fireEvent('model.getAttribute', [$key, $value], true)) !== null) {
-                $attributes[$key] = $eventValue;
-            }
-        }
 
         return $attributes;
     }
@@ -114,23 +100,6 @@ trait HasAttributes
      */
     public function getAttributeValue($key)
     {
-        /**
-         * @event model.beforeGetAttribute
-         * Called before the model attribute is retrieved
-         *
-         * Example usage:
-         *
-         *     $model->bindEvent('model.beforeGetAttribute', function ((string) $key) use (\October\Rain\Database\Model $model) {
-         *         if ($key === 'not-for-you-to-look-at') {
-         *             return 'you are not allowed here';
-         *         }
-         *     });
-         *
-         */
-        if (($attr = $this->fireEvent('model.beforeGetAttribute', [$key], true)) !== null) {
-            return $attr;
-        }
-
         $attr = parent::getAttributeValue($key);
 
         // Return valid json (boolean, array) if valid, otherwise
@@ -140,23 +109,6 @@ trait HasAttributes
             if (json_last_error() === JSON_ERROR_NONE) {
                 $attr = $_attr;
             }
-        }
-
-        /**
-         * @event model.getAttribute
-         * Called after the model attribute is retrieved
-         *
-         * Example usage:
-         *
-         *     $model->bindEvent('model.getAttribute', function ((string) $key, $value) use (\October\Rain\Database\Model $model) {
-         *         if ($key === 'not-for-you-to-look-at') {
-         *             return "Totally not $value";
-         *         }
-         *     });
-         *
-         */
-        if (($_attr = $this->fireEvent('model.getAttribute', [$key, $attr], true)) !== null) {
-            return $_attr;
         }
 
         return $attr;
@@ -190,23 +142,6 @@ trait HasAttributes
             return $this->setRelationSimpleValue($key, $value);
         }
 
-        /**
-         * @event model.beforeSetAttribute
-         * Called before the model attribute is set
-         *
-         * Example usage:
-         *
-         *     $model->bindEvent('model.beforeSetAttribute', function ((string) $key, $value) use (\October\Rain\Database\Model $model) {
-         *         if ($key === 'do-not-touch') {
-         *             return "$value has been touched";
-         *         }
-         *     });
-         *
-         */
-        if (($_value = $this->fireEvent('model.beforeSetAttribute', [$key, $value], true)) !== null) {
-            $value = $_value;
-        }
-
         // Jsonable
         if ($this->isJsonable($key) && (!empty($value) || is_array($value))) {
             $value = json_encode($value, JSON_UNESCAPED_UNICODE);
@@ -217,24 +152,7 @@ trait HasAttributes
             $value = trim($value);
         }
 
-        $result = parent::setAttribute($key, $value);
-
-        /**
-         * @event model.setAttribute
-         * Called after the model attribute is set
-         *
-         * Example usage:
-         *
-         *     $model->bindEvent('model.setAttribute', function ((string) $key, $value) use (\October\Rain\Database\Model $model) {
-         *         if ($key === 'do-not-touch') {
-         *             \Log::info("{$key} has been touched and set to {$value}!")
-         *         }
-         *     });
-         *
-         */
-        $this->fireEvent('model.setAttribute', [$key, $value]);
-
-        return $result;
+        return parent::setAttribute($key, $value);
     }
 
     /**

--- a/src/Database/Traits/Encryptable.php
+++ b/src/Database/Traits/Encryptable.php
@@ -6,6 +6,9 @@ use Exception;
 /**
  * Encryptable database trait
  *
+ * @deprecated Use Laravel's built-in 'encrypted' cast instead:
+ *             protected $casts = ['secret' => 'encrypted'];
+ *
  * @package october\database
  * @author Alexey Bobkov, Samuel Georges
  */
@@ -34,27 +37,43 @@ trait Encryptable
                 static::class
             ));
         }
+    }
 
-        // Encrypt required fields when necessary
-        $this->bindEvent('model.beforeSetAttribute', function ($key, $value) {
-            if (
-                in_array($key, $this->getEncryptableAttributes()) &&
-                $value !== null &&
-                $value !== ''
-            ) {
-                return $this->makeEncryptableValue($key, $value);
-            }
-        });
+    /**
+     * setAttribute overrides the base method to encrypt encryptable attributes.
+     * @param string $key
+     * @param mixed $value
+     * @return mixed
+     */
+    public function setAttribute($key, $value)
+    {
+        if (
+            in_array($key, $this->getEncryptableAttributes()) &&
+            $value !== null &&
+            $value !== ''
+        ) {
+            $value = $this->makeEncryptableValue($key, $value);
+        }
 
-        $this->bindEvent('model.beforeGetAttribute', function ($key) {
-            if (
-                in_array($key, $this->getEncryptableAttributes()) &&
-                array_get($this->attributes, $key) !== null &&
-                array_get($this->attributes, $key) !== ''
-            ) {
-                return $this->getEncryptableValue($key);
-            }
-        });
+        return parent::setAttribute($key, $value);
+    }
+
+    /**
+     * getAttributeValue overrides the base method to decrypt encryptable attributes.
+     * @param string $key
+     * @return mixed
+     */
+    public function getAttributeValue($key)
+    {
+        if (
+            in_array($key, $this->getEncryptableAttributes()) &&
+            array_get($this->attributes, $key) !== null &&
+            array_get($this->attributes, $key) !== ''
+        ) {
+            return $this->getEncryptableValue($key);
+        }
+
+        return parent::getAttributeValue($key);
     }
 
     /**

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -639,11 +639,6 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
      */
     public function getAttribute($key)
     {
-        // Before Event
-        if (($attr = $this->fireEvent('model.beforeGetAttribute', [$key], true)) !== null) {
-            return $attr;
-        }
-
         $value = $this->getAttributeFromArray($key);
 
         // If the attribute has a get mutator, we will call that then return what
@@ -651,11 +646,6 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
         // retrieval from the model to a form that is more useful for usage.
         if ($this->hasGetMutator($key)) {
             return $this->mutateAttribute($key, $value);
-        }
-
-        // After Event
-        if (($_attr = $this->fireEvent('model.getAttribute', [$key, $value], true)) !== null) {
-            return $_attr;
         }
 
         return $value;
@@ -715,28 +705,16 @@ class Model extends Extendable implements ArrayAccess, Arrayable, Jsonable, Json
      */
     public function setAttribute($key, $value)
     {
-        // Before Event
-        if (($_value = $this->fireEvent('model.beforeSetAttribute', [$key, $value], true)) !== null) {
-            $value = $_value;
-        }
-
         // First we will check for the presence of a mutator for the set operation
         // which simply lets the developers tweak the attribute as it is set on
         // the model, such as "json_encoding" an listing of data for storage.
         if ($this->hasSetMutator($key)) {
             $method = 'set'.Str::studly($key).'Attribute';
-            // If we return the returned value of the mutator call straight away, that will disable the firing of
-            // 'model.setAttribute' event, and then no third party plugins will be able to implement any kind of
-            // post processing logic when an attribute is set with explicit mutators. Returning from the mutator
-            // call will also break method chaining as intended by returning `$this` at the end of this method.
             $this->{$method}($value);
         }
         else {
             $this->attributes[$key] = $value;
         }
-
-        // After Event
-        $this->fireEvent('model.setAttribute', [$key, $value]);
 
         return $this;
     }


### PR DESCRIPTION
Remove model.beforeGetAttribute, model.getAttribute, model.beforeSetAttribute, and model.setAttribute events from Database and Halcyon models.

These events fired on every attribute access/mutation, causing significant overhead (e.g., 50 users × 15 attributes × 2 events = 1,500 event fires for a simple list). Laravel does not fire events for attribute access.

Breaking change: Code relying on these events will need refactoring.