### PR TITLE
Remove PHP 8+ polyfills and use native string functions

### DIFF
--- a/init/functions.php
+++ b/init/functions.php
@@ -563,19 +563,6 @@ if (!function_exists('camel_case')) {
     }
 }
 
-if (!function_exists('ends_with')) {
-    /**
-     * ends_with determines if a given string ends with a given substring
-     * @param  string  $haystack
-     * @param  string|array  $needles
-     * @return bool
-     */
-    function ends_with($haystack, $needles)
-    {
-        return Str::endsWith($haystack, $needles);
-    }
-}
-
 if (!function_exists('kebab_case')) {
     /**
      * kebab_case converts a string to kebab case
@@ -598,19 +585,6 @@ if (!function_exists('snake_case')) {
     function snake_case($value, $delimiter = '_')
     {
         return Str::snake($value, $delimiter);
-    }
-}
-
-if (!function_exists('starts_with')) {
-    /**
-     * starts_with determines if a given string starts with a given substring
-     * @param  string  $haystack
-     * @param  string|array  $needles
-     * @return bool
-     */
-    function starts_with($haystack, $needles)
-    {
-        return Str::startsWith($haystack, $needles);
     }
 }
 

--- a/src/Auth/Models/Role.php
+++ b/src/Auth/Models/Role.php
@@ -77,7 +77,7 @@ class Role extends Model
             // Now, let's check if the permission ends in a wildcard "*" symbol.
             // If it does, we'll check through all the merged permissions to see
             // if a permission exists which matches the wildcard.
-            if ((strlen($permission) > 1) && ends_with($permission, '*')) {
+            if ((strlen($permission) > 1) && str_ends_with($permission, '*')) {
                 $matched = false;
 
                 foreach ($rolePermissions as $rolePermission => $value) {
@@ -88,7 +88,7 @@ class Role extends Model
                     // exactly match our permission, but starts with it.
                     if (
                         $checkPermission !== $rolePermission &&
-                        starts_with($rolePermission, $checkPermission) &&
+                        str_starts_with($rolePermission, $checkPermission) &&
                         (int) $value === 1
                     ) {
                         $matched = true;
@@ -99,7 +99,7 @@ class Role extends Model
             // Now, let's check if the permission starts in a wildcard "*" symbol.
             // If it does, we'll check through all the merged permissions to see
             // if a permission exists which matches the wildcard.
-            elseif ((strlen($permission) > 1) && starts_with($permission, '*')) {
+            elseif ((strlen($permission) > 1) && str_starts_with($permission, '*')) {
                 $matched = false;
 
                 foreach ($rolePermissions as $rolePermission => $value) {
@@ -110,7 +110,7 @@ class Role extends Model
                     // exactly match our permission, but ends with it.
                     if (
                         $checkPermission !== $rolePermission &&
-                        ends_with($rolePermission, $checkPermission) &&
+                        str_ends_with($rolePermission, $checkPermission) &&
                         (int) $value === 1
                     ) {
                         $matched = true;
@@ -123,7 +123,7 @@ class Role extends Model
 
                 foreach ($rolePermissions as $rolePermission => $value) {
                     // This time check if the rolePermission ends in wildcard "*" symbol.
-                    if ((strlen($rolePermission) > 1) && ends_with($rolePermission, '*')) {
+                    if ((strlen($rolePermission) > 1) && str_ends_with($rolePermission, '*')) {
                         $matched = false;
 
                         // Strip the '*' off the end of the permission.
@@ -133,7 +133,7 @@ class Role extends Model
                         // exactly match our permission, but starts with it.
                         if (
                             $checkGroupPermission !== $permission &&
-                            starts_with($permission, $checkGroupPermission) &&
+                            str_starts_with($permission, $checkGroupPermission) &&
                             (int) $value === 1
                         ) {
                             $matched = true;

--- a/src/Auth/Models/User.php
+++ b/src/Auth/Models/User.php
@@ -542,7 +542,7 @@ class User extends Model implements Authenticatable
             // Now, let's check if the permission ends in a wildcard "*" symbol.
             // If it does, we'll check through all the merged permissions to see
             // if a permission exists which matches the wildcard.
-            if ((strlen($permission) > 1) && ends_with($permission, '*')) {
+            if ((strlen($permission) > 1) && str_ends_with($permission, '*')) {
                 $matched = false;
 
                 foreach ($mergedPermissions as $mergedPermission => $value) {
@@ -553,7 +553,7 @@ class User extends Model implements Authenticatable
                     // exactly match our permission, but starts with it.
                     if (
                         $checkPermission !== $mergedPermission &&
-                        starts_with($mergedPermission, $checkPermission) &&
+                        str_starts_with($mergedPermission, $checkPermission) &&
                         (int) $value === 1
                     ) {
                         $matched = true;
@@ -561,7 +561,7 @@ class User extends Model implements Authenticatable
                     }
                 }
             }
-            elseif ((strlen($permission) > 1) && starts_with($permission, '*')) {
+            elseif ((strlen($permission) > 1) && str_starts_with($permission, '*')) {
                 $matched = false;
 
                 foreach ($mergedPermissions as $mergedPermission => $value) {
@@ -572,7 +572,7 @@ class User extends Model implements Authenticatable
                     // exactly match our permission, but ends with it.
                     if (
                         $checkPermission !== $mergedPermission &&
-                        ends_with($mergedPermission, $checkPermission) &&
+                        str_ends_with($mergedPermission, $checkPermission) &&
                         (int) $value === 1
                     ) {
                         $matched = true;
@@ -585,7 +585,7 @@ class User extends Model implements Authenticatable
 
                 foreach ($mergedPermissions as $mergedPermission => $value) {
                     // This time check if the mergedPermission ends in wildcard "*" symbol.
-                    if ((strlen($mergedPermission) > 1) && ends_with($mergedPermission, '*')) {
+                    if ((strlen($mergedPermission) > 1) && str_ends_with($mergedPermission, '*')) {
                         $matched = false;
 
                         // Strip the '*' off the end of the permission.
@@ -595,7 +595,7 @@ class User extends Model implements Authenticatable
                         // exactly match our permission, but starts with it.
                         if (
                             $checkMergedPermission !== $permission &&
-                            starts_with($permission, $checkMergedPermission) &&
+                            str_starts_with($permission, $checkMergedPermission) &&
                             (int) $value === 1
                         ) {
                             $matched = true;

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -730,7 +730,7 @@ class File extends Model
         $allFiles = $this->storageCmd('files', $directory);
         $collection = [];
         foreach ($allFiles as $file) {
-            if (starts_with(basename($file), $pattern)) {
+            if (str_starts_with(basename($file), $pattern)) {
                 $collection[] = $file;
             }
         }

--- a/src/Foundation/Providers/ExecutionContextProvider.php
+++ b/src/Foundation/Providers/ExecutionContextProvider.php
@@ -39,7 +39,7 @@ class ExecutionContextProvider extends ServiceProvider
 
         $backendUri = $this->normalizeUrl($app['config']->get('backend.uri', 'backend'));
 
-        if (starts_with($requestPath, $backendUri)) {
+        if (str_starts_with($requestPath, $backendUri)) {
             return 'backend';
         }
 

--- a/src/Halcyon/Traits/Validation.php
+++ b/src/Halcyon/Traits/Validation.php
@@ -235,10 +235,10 @@ trait Validation
             // Analyse each rule individually
             foreach ($ruleParts as $key => $rulePart) {
                 // Look for required:create and required:update rules
-                if (starts_with($rulePart, 'required:create') && $this->exists) {
+                if (str_starts_with($rulePart, 'required:create') && $this->exists) {
                     unset($ruleParts[$key]);
                 }
-                elseif (starts_with($rulePart, 'required:update') && !$this->exists) {
+                elseif (str_starts_with($rulePart, 'required:update') && !$this->exists) {
                     unset($ruleParts[$key]);
                 }
             }

--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Html;
 
+use October\Rain\Support\Str;
 use Illuminate\Routing\UrlGenerator;
 
 /**
@@ -585,7 +586,7 @@ class HtmlBuilder
      */
     public function isValidColor(string $value): bool
     {
-        return starts_with($value, [
+        return Str::startsWith($value, [
             '#',
             'var(',
             'rgb(',

--- a/src/Parse/Syntax/SyntaxModelTrait.php
+++ b/src/Parse/Syntax/SyntaxModelTrait.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Parse\Syntax;
 
+use October\Rain\Support\Str;
 use Request;
 
 /**
@@ -102,7 +103,7 @@ trait SyntaxModelTrait
             $path = $image->getPath();
         }
 
-        if (!starts_with($path, ['//', 'http://', 'https://'])) {
+        if (!Str::startsWith($path, ['//', 'http://', 'https://'])) {
             $path = Request::getSchemeAndHttpHost() . $path;
         }
 

--- a/src/Scaffold/Console/CreateFactory.php
+++ b/src/Scaffold/Console/CreateFactory.php
@@ -30,7 +30,7 @@ class CreateFactory extends GeneratorCommandBase
      */
     public function handle()
     {
-        if (!ends_with($this->argument('name'), 'Factory')) {
+        if (!str_ends_with($this->argument('name'), 'Factory')) {
             $this->components->error('Factory classes names must end in "Factory"');
             return;
         }

--- a/src/Scaffold/Console/CreateTest.php
+++ b/src/Scaffold/Console/CreateTest.php
@@ -30,7 +30,7 @@ class CreateTest extends GeneratorCommandBase
      */
     public function handle()
     {
-        if (!ends_with($this->argument('name'), 'Test')) {
+        if (!str_ends_with($this->argument('name'), 'Test')) {
             $this->components->error('Test classes names must end in "Test"');
             return;
         }


### PR DESCRIPTION
- Remove starts_with() and ends_with() helper functions
- Replace with native str_starts_with() and str_ends_with()
- Use Str::startsWith() for array-needle cases (HtmlBuilder, SyntaxModelTrait)