### PR TITLE
Refactor FormBuilder to use Request facade instead of global helpers

### DIFF
--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Html;
 
+use Illuminate\Support\Facades\Request;
 use Illuminate\Session\Store as Session;
 use Illuminate\Routing\UrlGenerator as UrlGeneratorBase;
 
@@ -1051,8 +1052,9 @@ class FormBuilder
             return $this->old($name);
         }
 
-        if (!is_null(input($name, null))) {
-            return input($name);
+        $inputValue = Request::input(Helper::nameToDot($name));
+        if (!is_null($inputValue)) {
+            return $inputValue;
         }
 
         if (isset($this->model)) {
@@ -1082,7 +1084,9 @@ class FormBuilder
     public function sessionKey($sessionKey = null)
     {
         if (!$sessionKey) {
-            $sessionKey = post('_session_key', $this->sessionKey);
+            $sessionKey = Request::getRealMethod() === 'POST'
+                ? Request::post('_session_key', $this->sessionKey)
+                : $this->sessionKey;
         }
 
         return $this->hidden('_session_key', $sessionKey);


### PR DESCRIPTION
Replace deprecated input() and post() global function calls with Request facade methods in FormBuilder for better maintainability.