### PR TITLE
Replace legacy array helper functions with Arr class methods

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -6,6 +6,7 @@ use Cache;
 use Storage;
 use Response;
 use File as FileHelper;
+use Illuminate\Support\Arr;
 use October\Rain\Database\Model;
 use October\Rain\Resize\Resizer;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -327,7 +328,7 @@ class File extends Model
      */
     public function outputThumb($width, $height, $options = [], $returnResponse = true)
     {
-        $disposition = array_get($options, 'disposition', 'inline');
+        $disposition = Arr::get($options, 'disposition', 'inline');
         $options = $this->getDefaultThumbOptions($options);
 
         // Generate thumb if not existing already

--- a/src/Database/Models/DeferredBinding.php
+++ b/src/Database/Models/DeferredBinding.php
@@ -2,6 +2,7 @@
 
 use Event;
 use Carbon\Carbon;
+use Illuminate\Support\Arr;
 use October\Rain\Database\Model;
 use Throwable;
 
@@ -209,12 +210,12 @@ class DeferredBinding extends Model
             }
 
             $options = $masterObject->getRelationDefinition($this->master_field);
-            if (!array_get($options, 'delete', false)) {
+            if (!Arr::get($options, 'delete', false)) {
                 return;
             }
 
             // Only delete it if the relationship is null
-            $foreignKey = array_get($options, 'key', $masterObject->getForeignKey());
+            $foreignKey = Arr::get($options, 'key', $masterObject->getForeignKey());
             if ($foreignKey && !$relatedObj->$foreignKey) {
                 $relatedObj->delete();
             }

--- a/src/Database/Relations/AttachOneOrMany.php
+++ b/src/Database/Relations/AttachOneOrMany.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
 use October\Rain\Database\Attach\File as FileModel;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -368,7 +369,7 @@ trait AttachOneOrMany
 
             $options = $this->parent->getRelationDefinition($this->relationName);
 
-            if (array_get($options, 'delete', false)) {
+            if (Arr::get($options, 'delete', false)) {
                 $model->delete();
             }
             else {
@@ -477,7 +478,7 @@ trait AttachOneOrMany
     {
         $options = $this->parent->getRelationDefinition($this->relationName);
 
-        if (array_get($options, 'delete', false)) {
+        if (Arr::get($options, 'delete', false)) {
             $this->delete();
         }
         else {

--- a/src/Database/Relations/DefinedConstraints.php
+++ b/src/Database/Relations/DefinedConstraints.php
@@ -1,6 +1,7 @@
 <?php namespace October\Rain\Database\Relations;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany as BelongsToManyBase;
+use Illuminate\Support\Arr;
 
 /**
  * DefinedConstraints handles the constraints and filters defined by a relation
@@ -33,28 +34,28 @@ trait DefinedConstraints
         }
 
         // Default models (belongsTo, hasOne, hasOneThrough, morphOne)
-        if ($defaultData = array_get($args, 'default')) {
+        if ($defaultData = Arr::get($args, 'default')) {
             $relation->withDefault($defaultData);
         }
 
         // Pivot data (belongsToMany, morphToMany, morphByMany)
-        if ($pivotData = array_get($args, 'pivot')) {
+        if ($pivotData = Arr::get($args, 'pivot')) {
             $relation->withPivot($pivotData);
         }
 
         // Pivot incrementing key (belongsToMany, morphToMany, morphByMany)
-        if ($pivotKey = array_get($args, 'pivotKey')) {
+        if ($pivotKey = Arr::get($args, 'pivotKey')) {
             $relation->withPivot($pivotKey);
         }
 
         // Pivot timestamps (belongsToMany, morphToMany, morphByMany)
-        if (array_get($args, 'timestamps')) {
+        if (Arr::get($args, 'timestamps')) {
             $relation->withTimestamps();
         }
 
         // Count "helper" relation
         // @deprecated use Laravel withCount() method instead
-        if (array_get($args, 'count')) {
+        if (Arr::get($args, 'count')) {
             if ($relation instanceof BelongsToManyBase) {
                 $relation->countMode = true;
                 $keyName = $relation->getQualifiedForeignPivotKeyName();
@@ -79,14 +80,14 @@ trait DefinedConstraints
         }
 
         // Conditions
-        if ($conditions = array_get($args, 'conditions')) {
+        if ($conditions = Arr::get($args, 'conditions')) {
             $query->whereRaw($conditions);
         }
 
         // Sort order
         // @deprecated count is deprecated
-        $hasCountArg = array_get($args, 'count') !== null;
-        if (($orderBy = array_get($args, 'order')) && !$hasCountArg) {
+        $hasCountArg = Arr::get($args, 'count') !== null;
+        if (($orderBy = Arr::get($args, 'order')) && !$hasCountArg) {
             if (!is_array($orderBy)) {
                 $orderBy = [$orderBy];
             }
@@ -105,7 +106,7 @@ trait DefinedConstraints
         }
 
         // Scope
-        if ($scope = array_get($args, 'scope')) {
+        if ($scope = Arr::get($args, 'scope')) {
             if (is_string($scope)) {
                 $query->$scope($this->parent);
             }

--- a/src/Database/Relations/HasOneOrMany.php
+++ b/src/Database/Relations/HasOneOrMany.php
@@ -1,6 +1,7 @@
 <?php namespace October\Rain\Database\Relations;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 /**
  * HasOneOrMany
@@ -253,7 +254,7 @@ trait HasOneOrMany
             $options = $this->parent->getRelationDefinition($this->relationName);
 
             // Delete or orphan the model
-            if (array_get($options, 'delete', false)) {
+            if (Arr::get($options, 'delete', false)) {
                 $model->delete();
             }
             else {
@@ -304,7 +305,7 @@ trait HasOneOrMany
     {
         $options = $this->parent->getRelationDefinition($this->relationName);
 
-        if (array_get($options, 'delete', false)) {
+        if (Arr::get($options, 'delete', false)) {
             $this->delete();
         }
         else {

--- a/src/Database/Relations/MorphOneOrMany.php
+++ b/src/Database/Relations/MorphOneOrMany.php
@@ -1,6 +1,7 @@
 <?php namespace October\Rain\Database\Relations;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 /**
  * MorphOneOrMany
@@ -244,7 +245,7 @@ trait MorphOneOrMany
             $options = $this->parent->getRelationDefinition($this->relationName);
 
             // Delete or orphan the model
-            if (array_get($options, 'delete', false)) {
+            if (Arr::get($options, 'delete', false)) {
                 $model->delete();
             }
             else {
@@ -298,7 +299,7 @@ trait MorphOneOrMany
     {
         $options = $this->parent->getRelationDefinition($this->relationName);
 
-        if (array_get($options, 'delete', false)) {
+        if (Arr::get($options, 'delete', false)) {
             $this->delete();
         }
         else {

--- a/src/Database/Traits/Encryptable.php
+++ b/src/Database/Traits/Encryptable.php
@@ -2,6 +2,7 @@
 
 use Crypt;
 use Exception;
+use Illuminate\Support\Arr;
 
 /**
  * Encryptable database trait
@@ -49,8 +50,8 @@ trait Encryptable
         $this->bindEvent('model.beforeGetAttribute', function ($key) {
             if (
                 in_array($key, $this->getEncryptableAttributes()) &&
-                array_get($this->attributes, $key) !== null &&
-                array_get($this->attributes, $key) !== ''
+                Arr::get($this->attributes, $key) !== null &&
+                Arr::get($this->attributes, $key) !== ''
             ) {
                 return $this->getEncryptableValue($key);
             }

--- a/src/Database/Traits/Multisite.php
+++ b/src/Database/Traits/Multisite.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Database\Traits;
 
+use Illuminate\Support\Arr;
 use Site;
 use October\Rain\Database\Scopes\MultisiteScope;
 use Exception;
@@ -331,7 +332,7 @@ trait Multisite
             return $default;
         }
 
-        return array_get($this->propagatableSync, $key, $default);
+        return Arr::get($this->propagatableSync, $key, $default);
     }
 
     /**

--- a/src/Database/Traits/Revisionable.php
+++ b/src/Database/Traits/Revisionable.php
@@ -4,6 +4,7 @@ use Db;
 use Exception;
 use DateTime;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
+use Illuminate\Support\Arr;
 
 /**
  * Revisionable trait tracks changes to specific attributes
@@ -79,7 +80,7 @@ trait Revisionable
 
             $toSave[] = [
                 'field' => $attribute,
-                'old_value' => array_get($this->original, $attribute),
+                'old_value' => Arr::get($this->original, $attribute),
                 'new_value' => $value,
                 'revisionable_type' => $relationObject->getMorphClass(),
                 'revisionable_id' => $this->getKey(),

--- a/src/Database/Traits/SimpleTree.php
+++ b/src/Database/Traits/SimpleTree.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Database\Traits;
 
+use Illuminate\Support\Arr;
 use October\Rain\Database\Collection;
 use October\Rain\Database\TreeCollection;
 use Exception;
@@ -228,7 +229,7 @@ trait SimpleTree
                 }
 
                 // Add the children
-                $childItems = array_get($map, $item->{$idName}, []);
+                $childItems = Arr::get($map, $item->{$idName}, []);
                 if (count($childItems) > 0) {
                     $result = $result + $buildCollection($childItems, $map, $depth + 1);
                 }

--- a/src/Database/Traits/SoftDelete.php
+++ b/src/Database/Traits/SoftDelete.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Illuminate\Database\Eloquent\Collection as CollectionBase;
+use Illuminate\Support\Arr;
 use October\Rain\Database\Scopes\SoftDeleteScope;
 
 /**
@@ -129,7 +130,7 @@ trait SoftDelete
         $definitions = $this->getRelationDefinitions();
         foreach ($definitions as $type => $relations) {
             foreach ($relations as $name => $options) {
-                if (!array_get($options, 'softDelete', false)) {
+                if (!Arr::get($options, 'softDelete', false)) {
                     continue;
                 }
 
@@ -213,7 +214,7 @@ trait SoftDelete
         $definitions = $this->getRelationDefinitions();
         foreach ($definitions as $type => $relations) {
             foreach ($relations as $name => $options) {
-                if (!array_get($options, 'softDelete', false)) {
+                if (!Arr::get($options, 'softDelete', false)) {
                     continue;
                 }
 

--- a/src/Halcyon/Builder.php
+++ b/src/Halcyon/Builder.php
@@ -1,6 +1,7 @@
 <?php namespace October\Rain\Halcyon;
 
 use Carbon\Carbon;
+use Illuminate\Support\Arr;
 use October\Rain\Halcyon\Exception\InvalidDirectoryNameException;
 use October\Rain\Halcyon\Exception\InvalidExtensionException;
 use October\Rain\Halcyon\Exception\MissingFileNameException;
@@ -645,7 +646,7 @@ class Builder
             return false;
         }
 
-        $mtime = $result ? array_get(reset($result), 'mtime') : null;
+        $mtime = $result ? Arr::get(reset($result), 'mtime') : null;
 
         list($name, $extension) = $this->selectSingle;
 

--- a/src/Halcyon/Datasource/AutoDatasource.php
+++ b/src/Halcyon/Datasource/AutoDatasource.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Halcyon\Datasource;
 
+use Illuminate\Support\Arr;
 use October\Rain\Halcyon\Model;
 use October\Rain\Halcyon\Processors\Processor;
 
@@ -28,7 +29,7 @@ class AutoDatasource extends Datasource implements DatasourceInterface
     {
         $this->datasources = $datasources;
 
-        $this->primaryDatasource = array_first($datasources);
+        $this->primaryDatasource = Arr::first($datasources);
 
         $this->postProcessor = new Processor;
     }

--- a/src/Halcyon/Processors/Processor.php
+++ b/src/Halcyon/Processors/Processor.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Halcyon\Processors;
 
+use Illuminate\Support\Arr;
 use October\Rain\Halcyon\Builder;
 
 /**
@@ -24,7 +25,7 @@ class Processor
             return null;
         }
 
-        $fileName = array_get($result, 'fileName');
+        $fileName = Arr::get($result, 'fileName');
 
         return [$fileName => $this->parseTemplateContent($query, $result, $fileName)];
     }
@@ -45,7 +46,7 @@ class Processor
         $items = [];
 
         foreach ($results as $result) {
-            $fileName = array_get($result, 'fileName');
+            $fileName = Arr::get($result, 'fileName');
             $items[$fileName] = $this->parseTemplateContent($query, $result, $fileName);
         }
 
@@ -64,14 +65,14 @@ class Processor
             'isCompoundObject' => $query->getModel()->isCompoundObject()
         ];
 
-        $content = array_get($result, 'content');
+        $content = Arr::get($result, 'content');
 
         $processed = SectionParser::parse($content, $options);
 
         return [
             'fileName' => $fileName,
             'content' => $content,
-            'mtime' => array_get($result, 'mtime'),
+            'mtime' => Arr::get($result, 'mtime'),
             'markup' => $processed['markup'],
             'code' => $processed['code']
         ] + $processed['settings'];

--- a/src/Halcyon/Traits/Validation.php
+++ b/src/Halcyon/Traits/Validation.php
@@ -1,9 +1,10 @@
 <?php namespace October\Rain\Halcyon\Traits;
 
-use Validator;
+use Illuminate\Support\Arr;
 use Illuminate\Support\MessageBag;
-use October\Rain\Support\Facades\Input;
 use October\Rain\Halcyon\Exception\ModelException;
+use October\Rain\Support\Facades\Input;
+use Validator;
 use Exception;
 
 trait Validation
@@ -57,7 +58,7 @@ trait Validation
                 // If forcing the save event, the beforeValidate/afterValidate
                 // events should still fire for consistency. So validate an
                 // empty set of rules and messages.
-                $force = array_get($options, 'force', false);
+                $force = Arr::get($options, 'force', false);
                 if ($force) {
                     $valid = $model->validate([], []);
                 }

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Session\Store as Session;
 use Illuminate\Routing\UrlGenerator as UrlGeneratorBase;
+use Illuminate\Support\Arr;
 
 /**
  * FormBuilder
@@ -114,9 +115,9 @@ class FormBuilder
      */
     public function open(array $options = [])
     {
-        $method = strtoupper(array_get($options, 'method', 'post'));
-        $request = array_get($options, 'request');
-        $model = array_get($options, 'model');
+        $method = strtoupper(Arr::get($options, 'method', 'post'));
+        $request = Arr::get($options, 'request');
+        $model = Arr::get($options, 'model');
 
         if ($model) {
             $this->model = $model;
@@ -125,7 +126,7 @@ class FormBuilder
         $append = $this->requestHandler($request);
 
         if ($method !== 'GET') {
-            $append .= $this->sessionKey(array_get($options, 'sessionKey'));
+            $append .= $this->sessionKey(Arr::get($options, 'sessionKey'));
         }
 
         $attributes = [];
@@ -153,7 +154,7 @@ class FormBuilder
         // is used to spoof requests for this PUT, PATCH, etc. methods on forms.
         $attributes = array_merge(
             $attributes,
-            array_except($options, $this->reserved)
+            Arr::except($options, $this->reserved)
         );
 
         // Finally, we will concatenate all of the attributes into a single string so
@@ -178,7 +179,7 @@ class FormBuilder
 
         $attributes = array_merge([
             'data-request' => $handler
-        ], array_except($options, $this->reservedAjax));
+        ], Arr::except($options, $this->reservedAjax));
 
         $ajaxAttributes = array_diff_key($options, $attributes);
         foreach ($ajaxAttributes as $property => $value) {
@@ -436,9 +437,9 @@ class FormBuilder
         // If the "size" attribute was not specified, we will just look for the regular
         // columns and rows attributes, using sane defaults if these do not exist on
         // the attributes array. We'll then return this entire options array back.
-        $cols = array_get($options, 'cols', 50);
+        $cols = Arr::get($options, 'cols', 50);
 
-        $rows = array_get($options, 'rows', 10);
+        $rows = Arr::get($options, 'rows', 10);
 
         return array_merge($options, compact('cols', 'rows'));
     }
@@ -978,7 +979,7 @@ class FormBuilder
             return object_get($this->model, $this->transformKey($name));
         }
         elseif (is_array($this->model)) {
-            return array_get($this->model, $this->transformKey($name));
+            return Arr::get($this->model, $this->transformKey($name));
         }
     }
 

--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -7,6 +7,7 @@ use Config;
 use Illuminate\Mail\Mailer as MailerBase;
 use Illuminate\Mail\SentMessage;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 /**
@@ -386,11 +387,11 @@ class Mailer extends MailerBase
                     $result[$address] = $name;
                 }
                 elseif (is_array($person)) {
-                    if (!$address = array_get($person, 'email', array_get($person, 'address'))) {
+                    if (!$address = Arr::get($person, 'email', Arr::get($person, 'address'))) {
                         continue;
                     }
 
-                    $result[$address] = array_get($person, 'name');
+                    $result[$address] = Arr::get($person, 'name');
                 }
             }
         }
@@ -457,7 +458,7 @@ class Mailer extends MailerBase
             $customSubject = $message->getSymfonyMessage()->getSubject();
             if (
                 empty($customSubject) &&
-                ($subject = array_get($result['settings'], 'subject'))
+                ($subject = Arr::get($result['settings'], 'subject'))
             ) {
                 $message->subject($subject);
             }

--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Network;
 
+use Illuminate\Support\Arr;
 use October\Rain\Exception\ApplicationException;
 
 /**
@@ -351,7 +352,7 @@ class Http
                 $this->redirectCount = $this->maxRedirects;
             }
             if (in_array($this->code, [301, 302])) {
-                $this->url = array_get($this->info, 'redirect_url');
+                $this->url = Arr::get($this->info, 'redirect_url');
                 if (!empty($this->url) && $this->redirectCount > 0) {
                     $this->redirectCount -= 1;
                     return $this->send();

--- a/src/Parse/Syntax/FieldParser.php
+++ b/src/Parse/Syntax/FieldParser.php
@@ -1,6 +1,7 @@
 <?php namespace October\Rain\Parse\Syntax;
 
 use Exception;
+use Illuminate\Support\Arr;
 
 /**
  * FieldParser for dynamic syntax parser
@@ -67,7 +68,7 @@ class FieldParser
     public function __construct($template = null, $options = [])
     {
         if ($template) {
-            $this->tagPrefix = array_get($options, 'tagPrefix', '');
+            $this->tagPrefix = Arr::get($options, 'tagPrefix', '');
             $this->template = $template;
             $this->processTemplate($template);
         }
@@ -170,7 +171,7 @@ class FieldParser
 
             if ($params['type'] === 'repeater') {
                 $defaults[$field] = [];
-                $defaults[$field][] = $this->getDefaultParams(array_get($params, 'fields', []));
+                $defaults[$field][] = $this->getDefaultParams(Arr::get($params, 'fields', []));
             }
             else {
                 $defaults[$field] = $params['default'] ?? null;
@@ -253,7 +254,7 @@ class FieldParser
 
             if ($tagName === 'variable') {
                 $params['X_OCTOBER_IS_VARIABLE'] = true;
-                $tagName = array_get($params, 'type', 'text');
+                $tagName = Arr::get($params, 'type', 'text');
             }
 
             $params['type'] = $tagName;

--- a/src/Parse/Syntax/Parser.php
+++ b/src/Parse/Syntax/Parser.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Parse\Syntax;
 
+use Illuminate\Support\Arr;
 use October\Rain\Parse\Bracket as TextParser;
 
 /**
@@ -45,7 +46,7 @@ class Parser
     {
         if ($template) {
             $this->template = $template;
-            $this->varPrefix = array_get($options, 'varPrefix', '');
+            $this->varPrefix = Arr::get($options, 'varPrefix', '');
             $this->fieldParser = new FieldParser($template, $options);
 
             $textFilters = [
@@ -145,7 +146,7 @@ class Parser
     {
         $prefixField = $this->varPrefix.$field;
         $params = $this->fieldParser->getFieldParams($field);
-        $innerFields = array_get($params, 'fields', []);
+        $innerFields = Arr::get($params, 'fields', []);
         $innerTags = $tagDetails['tags'];
         $innerTemplate = $tagDetails['template'];
 
@@ -153,7 +154,7 @@ class Parser
          * Replace all the inner tags
          */
         foreach ($innerTags as $innerField => $tagString) {
-            $innerParams = array_get($innerFields, $innerField, []);
+            $innerParams = Arr::get($innerFields, $innerField, []);
             $tagReplacement = $this->{'eval'.$engine.'ViewField'}($innerField, $innerParams, 'fields');
             $innerTemplate = str_replace($tagString, $tagReplacement, $innerTemplate);
         }
@@ -161,7 +162,7 @@ class Parser
         /*
          * Replace the opening tag
          */
-        $openTag = array_get($tagDetails, 'open', '{repeater}');
+        $openTag = Arr::get($tagDetails, 'open', '{repeater}');
         $openReplacement = $engine === 'Twig' ? '{% for fields in '.$prefixField.' %}' : '{'.$prefixField.'}';
         $openReplacement = $openReplacement . PHP_EOL;
         $innerTemplate = str_replace($openTag, $openReplacement, $innerTemplate);
@@ -169,7 +170,7 @@ class Parser
         /*
          * Replace the closing tag
          */
-        $closeTag = array_get($tagDetails, 'close', '{/repeater}');
+        $closeTag = Arr::get($tagDetails, 'close', '{/repeater}');
         $closeReplacement = $engine === 'Twig' ? '{% endfor %}' : '{/'.$prefixField.'}';
         $closeReplacement = PHP_EOL . $closeReplacement;
         $innerTemplate = str_replace($closeTag, $closeReplacement, $innerTemplate);

--- a/src/Parse/Syntax/SyntaxModelTrait.php
+++ b/src/Parse/Syntax/SyntaxModelTrait.php
@@ -1,5 +1,6 @@
 <?php namespace October\Rain\Parse\Syntax;
 
+use Illuminate\Support\Arr;
 use Request;
 
 /**
@@ -93,8 +94,8 @@ trait SyntaxModelTrait
      */
     protected function getThumbForImage($image, $params = [])
     {
-        $imageWidth = array_get($params, 'imageWidth');
-        $imageHeight = array_get($params, 'imageHeight');
+        $imageWidth = Arr::get($params, 'imageWidth');
+        $imageHeight = Arr::get($params, 'imageHeight');
         if ($imageWidth && $imageHeight) {
             $path = $image->getThumb($imageWidth, $imageHeight, ['mode' => 'crop']);
         }
@@ -135,7 +136,7 @@ trait SyntaxModelTrait
             }
 
             if ($params['type'] === 'repeater') {
-                $params['form']['fields'] = array_get($params, 'fields', []);
+                $params['form']['fields'] = Arr::get($params, 'fields', []);
                 unset($params['fields']);
             }
 


### PR DESCRIPTION
Replaces deprecated global array helper functions with their Illuminate\Support\Arr equivalents across 21 files:
- array_get() → Arr::get()
- array_first() → Arr::first()
- array_except() → Arr::except()

They still exists in codebase just moving that we can deprecate them later.