### PR TITLE
Add missing getCachedEventsPath() override

### DIFF
--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -467,6 +467,16 @@ class Application extends ApplicationBase
     }
 
     /**
+     * Get the path to the events cache file.
+     *
+     * @return string
+     */
+    public function getCachedEventsPath()
+    {
+        return $this->normalizeCachePath('APP_EVENTS_CACHE', 'framework/events.php');
+    }
+
+    /**
      * getNamespace returns the application namespace.
      * @return string
      * @throws \RuntimeException


### PR DESCRIPTION
## Summary

All `getCached*Path()` methods in `Application.php` are overridden to resolve cache files under `storage/framework/`, but `getCachedEventsPath()` was not overridden.

This causes Laravel's `EventCacheCommand` to resolve the events cache path to `storage/cache/events.php` (via the default `cache/events.php`), but `storage/cache/` does not exist — resulting in a crash during `php artisan optimize`:

```
ErrorException: file_put_contents(…/storage/cache/events.php): Failed to open stream: No such file or directory
```

## Fix

Add `getCachedEventsPath()` override consistent with all other overrides (`getCachedConfigPath`, `getCachedRoutesPath`, `getCachedServicesPath`, `getCachedPackagesPath`, `getCachedClassesPath`), pointing to `framework/events.php`.