### PR TITLE
Guard loadViewsFrom() with is_dir() check in ModuleServiceProvider

### DIFF
--- a/src/Support/ModuleServiceProvider.php
+++ b/src/Support/ModuleServiceProvider.php
@@ -30,7 +30,10 @@ abstract class ModuleServiceProvider extends ServiceProviderBase implements Octo
         }
 
         // Register view path
-        $this->loadViewsFrom($modulePath . '/views', $module);
+        $viewsPath = $modulePath . '/views';
+        if (is_dir($viewsPath)) {
+            $this->loadViewsFrom($viewsPath, $module);
+        }
 
         // Load translator
         $this->loadTranslationsFrom($modulePath . '/lang', $module);


### PR DESCRIPTION
## Summary

`ModuleServiceProvider::register()` unconditionally calls `loadViewsFrom()` for all modules, but not all modules have a `views/` directory (e.g., `media`, `dashboard`). This causes Symfony's Finder to throw an exception during `php artisan optimize`.

The config path registration on line 28 already has an `is_dir()` guard — this PR adds the same guard for views.

## Fix

```php
// Before
$this->loadViewsFrom($modulePath . '/views', $module);

// After
$viewsPath = $modulePath . '/views';
if (is_dir($viewsPath)) {
    $this->loadViewsFrom($viewsPath, $module);
}
```