### PR TITLE
Prevent filesystem fallback for soft-deleted DB templates

### DIFF
--- a/src/Halcyon/Datasource/AutoDatasource.php
+++ b/src/Halcyon/Datasource/AutoDatasource.php
@@ -39,6 +39,10 @@ class AutoDatasource extends Datasource implements DatasourceInterface
      */
     public function hasTemplate(string $dirName, string $fileName, string $extension): bool
     {
+        if ($this->isTemplateTrashed($dirName, $fileName, $extension)) {
+            return false;
+        }
+
         foreach ($this->datasources as $datasource) {
             if ($datasource->hasTemplate($dirName, $fileName, $extension)) {
                 return true;
@@ -53,6 +57,10 @@ class AutoDatasource extends Datasource implements DatasourceInterface
      */
     public function selectOne(string $dirName, string $fileName, string $extension)
     {
+        if ($this->isTemplateTrashed($dirName, $fileName, $extension)) {
+            return null;
+        }
+
         foreach ($this->datasources as $source) {
             if (!$source->hasTemplate($dirName, $fileName, $extension)) {
                 continue;
@@ -76,7 +84,13 @@ class AutoDatasource extends Datasource implements DatasourceInterface
             $result = array_merge($result, $datasource->select($dirName, $options));
         }
 
-        return collect($result)->keyBy('fileName')->all();
+        $result = collect($result)->keyBy('fileName')->all();
+
+        foreach ($this->getTrashedFileNames($dirName, $options) as $fileName) {
+            unset($result[$fileName]);
+        }
+
+        return $result;
     }
 
     /**
@@ -134,6 +148,10 @@ class AutoDatasource extends Datasource implements DatasourceInterface
      */
     public function lastModified(string $dirName, string $fileName, string $extension): ?int
     {
+        if ($this->isTemplateTrashed($dirName, $fileName, $extension)) {
+            return null;
+        }
+
         foreach ($this->datasources as $source) {
             if (!$source->hasTemplate($dirName, $fileName, $extension)) {
                 continue;
@@ -229,5 +247,45 @@ class AutoDatasource extends Datasource implements DatasourceInterface
         list($fileName, $extension) = $model->getFileNameParts();
 
         return $this->datasources[$index]->forceDelete($dirName, $fileName, $extension);
+    }
+
+    /**
+     * getDbDatasource returns the primary datasource when it is a DbDatasource
+     */
+    protected function getDbDatasource(): ?DbDatasource
+    {
+        if ($this->primaryDatasource instanceof DbDatasource) {
+            return $this->primaryDatasource;
+        }
+
+        return null;
+    }
+
+    /**
+     * isTemplateTrashed checks if the primary DbDatasource has a tombstoned record
+     */
+    protected function isTemplateTrashed(string $dirName, string $fileName, string $extension): bool
+    {
+        $dbDatasource = $this->getDbDatasource();
+
+        if (!$dbDatasource) {
+            return false;
+        }
+
+        return $dbDatasource->isTemplateTrashed($dirName, $fileName, $extension);
+    }
+
+    /**
+     * getTrashedFileNames returns tombstoned file names from the primary DbDatasource
+     */
+    protected function getTrashedFileNames(string $dirName, array $options = []): array
+    {
+        $dbDatasource = $this->getDbDatasource();
+
+        if (!$dbDatasource) {
+            return [];
+        }
+
+        return $dbDatasource->selectTrashedFileNames($dirName, $options);
     }
 }

--- a/src/Halcyon/Datasource/AutoDatasource.php
+++ b/src/Halcyon/Datasource/AutoDatasource.php
@@ -124,7 +124,25 @@ class AutoDatasource extends Datasource implements DatasourceInterface
      */
     public function delete(string $dirName, string $fileName, string $extension): bool
     {
-        return $this->primaryDatasource->delete($dirName, $fileName, $extension);
+        $result = $this->primaryDatasource->delete($dirName, $fileName, $extension);
+
+        if ($this->isTemplateTrashed($dirName, $fileName, $extension)) {
+            return (bool) $result ?: true;
+        }
+
+        $dbDatasource = $this->getDbDatasource();
+
+        if (!$dbDatasource) {
+            return (bool) $result;
+        }
+
+        foreach (array_slice($this->datasources, 1) as $datasource) {
+            if ($datasource->hasTemplate($dirName, $fileName, $extension)) {
+                return $dbDatasource->tombstone($dirName, $fileName, $extension);
+            }
+        }
+
+        return (bool) $result;
     }
 
     /**

--- a/src/Halcyon/Datasource/DbDatasource.php
+++ b/src/Halcyon/Datasource/DbDatasource.php
@@ -328,6 +328,59 @@ class DbDatasource extends Datasource implements DatasourceInterface
     }
 
     /**
+     * isTemplateTrashed returns true when a soft-deleted record exists at the path
+     */
+    public function isTemplateTrashed(string $dirName, string $fileName, string $extension): bool
+    {
+        $path = $this->makeFilePath($dirName, $fileName, $extension);
+
+        $record = $this->getQuery(false)->where('path', $path)->first();
+
+        return $record && $record->deleted_at !== null;
+    }
+
+    /**
+     * selectTrashedFileNames returns file names for soft-deleted templates in a directory
+     */
+    public function selectTrashedFileNames(string $dirName, array $options = []): array
+    {
+        extract(array_merge([
+            'extensions' => null,
+            'fileMatch' => null,
+        ], $options));
+
+        $query = $this->getQuery(false)
+            ->whereNotNull('deleted_at')
+            ->where('path', 'like', $dirName . '%');
+
+        if (is_array($extensions) && !empty($extensions)) {
+            $query->where(function ($query) use ($extensions) {
+                $query->where('path', 'like', '%' . '.' . array_pop($extensions));
+
+                if (count($extensions)) {
+                    foreach ($extensions as $ext) {
+                        $query->orWhere('path', 'like', '%' . '.' . $ext);
+                    }
+                }
+            });
+        }
+
+        $fileNames = [];
+
+        foreach ($query->get() as $item) {
+            $fileName = ltrim(str_replace($dirName, '', $item->path), '/');
+
+            if (!empty($fileMatch) && !fnmatch($fileMatch, $fileName)) {
+                continue;
+            }
+
+            $fileNames[] = $fileName;
+        }
+
+        return $fileNames;
+    }
+
+    /**
      * getBaseQuery builder object
      */
     protected function getBaseQuery()

--- a/src/Halcyon/Datasource/DbDatasource.php
+++ b/src/Halcyon/Datasource/DbDatasource.php
@@ -258,6 +258,46 @@ class DbDatasource extends Datasource implements DatasourceInterface
     }
 
     /**
+     * tombstone creates a soft-deleted record for a path with no active DB template
+     */
+    public function tombstone(string $dirName, string $fileName, string $extension): bool
+    {
+        $path = $this->makeFilePath($dirName, $fileName, $extension);
+
+        if ($this->getQuery()->where('path', $path)->exists()) {
+            return $this->delete($dirName, $fileName, $extension);
+        }
+
+        if ($this->isTemplateTrashed($dirName, $fileName, $extension)) {
+            return true;
+        }
+
+        try {
+            $now = Carbon::now()->toDateTimeString();
+
+            $record = [
+                'source' => $this->source,
+                'path' => $path,
+                'content' => '',
+                'file_size' => 0,
+                'updated_at' => $now,
+                'deleted_at' => $now,
+            ];
+
+            $this->fireEvent('halcyon.datasource.db.beforeInsert', [&$record]);
+
+            $this->getBaseQuery()->insert($record);
+
+            $this->flushCache();
+
+            return true;
+        }
+        catch (Exception $ex) {
+            throw (new DeleteFileException)->setInvalidPath($path);
+        }
+    }
+
+    /**
      * delete against the datasource
      */
     public function delete(string $dirName, string $fileName, string $extension): bool

--- a/src/Halcyon/Datasource/DbDatasource.php
+++ b/src/Halcyon/Datasource/DbDatasource.php
@@ -103,34 +103,15 @@ class DbDatasource extends Datasource implements DatasourceInterface
             $columns = null;
         }
 
-        // Apply the dirName query
-        $query = $this->getQuery()->where('path', 'like', $dirName . '%');
-
-        // Apply the extensions filter
-        if (is_array($extensions) && !empty($extensions)) {
-            $query->where(function ($query) use ($extensions) {
-                // Get the first extension to query for
-                $query->where('path', 'like', '%' . '.' . array_pop($extensions));
-
-                if (count($extensions)) {
-                    foreach ($extensions as $ext) {
-                        $query->orWhere('path', 'like', '%' . '.' . $ext);
-                    }
-                }
-            });
-        }
-
-        // Retrieve the results
-        $results = $query->get();
+        $results = $this->buildDirectoryQuery($dirName, $extensions, false)->get();
 
         foreach ($results as $item) {
             self::$pathCache[$this->source][$item->path] = $item;
 
             $resultItem = [];
-            $fileName = ltrim(str_replace($dirName, '', $item->path), '/');
+            $fileName = $this->pathToFileName($dirName, $item->path);
 
-            // Apply the fileMatch filter
-            if (!empty($fileMatch) && !fnmatch($fileMatch, $fileName)) {
+            if (!$this->matchesFileMatch($fileMatch, $fileName)) {
                 continue;
             }
 
@@ -349,28 +330,12 @@ class DbDatasource extends Datasource implements DatasourceInterface
             'fileMatch' => null,
         ], $options));
 
-        $query = $this->getQuery(false)
-            ->whereNotNull('deleted_at')
-            ->where('path', 'like', $dirName . '%');
-
-        if (is_array($extensions) && !empty($extensions)) {
-            $query->where(function ($query) use ($extensions) {
-                $query->where('path', 'like', '%' . '.' . array_pop($extensions));
-
-                if (count($extensions)) {
-                    foreach ($extensions as $ext) {
-                        $query->orWhere('path', 'like', '%' . '.' . $ext);
-                    }
-                }
-            });
-        }
-
         $fileNames = [];
 
-        foreach ($query->get() as $item) {
-            $fileName = ltrim(str_replace($dirName, '', $item->path), '/');
+        foreach ($this->buildDirectoryQuery($dirName, $extensions, true)->get() as $item) {
+            $fileName = $this->pathToFileName($dirName, $item->path);
 
-            if (!empty($fileMatch) && !fnmatch($fileMatch, $fileName)) {
+            if (!$this->matchesFileMatch($fileMatch, $fileName)) {
                 continue;
             }
 
@@ -378,6 +343,56 @@ class DbDatasource extends Datasource implements DatasourceInterface
         }
 
         return $fileNames;
+    }
+
+    /**
+     * buildDirectoryQuery for templates in a directory
+     */
+    protected function buildDirectoryQuery(string $dirName, ?array $extensions, bool $trashedOnly)
+    {
+        $query = $trashedOnly
+            ? $this->getQuery(false)->whereNotNull('deleted_at')
+            : $this->getQuery();
+
+        $query->where('path', 'like', $dirName . '%');
+
+        if (is_array($extensions) && !empty($extensions)) {
+            $this->applyExtensionsFilter($query, $extensions);
+        }
+
+        return $query;
+    }
+
+    /**
+     * applyExtensionsFilter to a directory query
+     */
+    protected function applyExtensionsFilter($query, array $extensions)
+    {
+        $query->where(function ($query) use ($extensions) {
+            $query->where('path', 'like', '%' . '.' . array_pop($extensions));
+
+            if (count($extensions)) {
+                foreach ($extensions as $ext) {
+                    $query->orWhere('path', 'like', '%' . '.' . $ext);
+                }
+            }
+        });
+    }
+
+    /**
+     * pathToFileName converts a stored path to a file name within a directory
+     */
+    protected function pathToFileName(string $dirName, string $path): string
+    {
+        return ltrim(str_replace($dirName, '', $path), '/');
+    }
+
+    /**
+     * matchesFileMatch checks a file name against an optional fnmatch pattern
+     */
+    protected function matchesFileMatch(?string $fileMatch, string $fileName): bool
+    {
+        return empty($fileMatch) || fnmatch($fileMatch, $fileName);
     }
 
     /**

--- a/src/Halcyon/Datasource/DbDatasource.php
+++ b/src/Halcyon/Datasource/DbDatasource.php
@@ -37,6 +37,11 @@ class DbDatasource extends Datasource implements DatasourceInterface
     protected static $mtimeCache = [];
 
     /**
+     * @var array trashedPathCache
+     */
+    protected static $trashedPathCache = [];
+
+    /**
      * __construct a new datasource instance
      */
     public function __construct(string $source, string $table)
@@ -103,7 +108,7 @@ class DbDatasource extends Datasource implements DatasourceInterface
             $columns = null;
         }
 
-        $results = $this->buildDirectoryQuery($dirName, $extensions, false)->get();
+        $results = $this->buildDirectoryQuery($dirName, $extensions)->get();
 
         foreach ($results as $item) {
             self::$pathCache[$this->source][$item->path] = $item;
@@ -315,9 +320,7 @@ class DbDatasource extends Datasource implements DatasourceInterface
     {
         $path = $this->makeFilePath($dirName, $fileName, $extension);
 
-        $record = $this->getQuery(false)->where('path', $path)->first();
-
-        return $record && $record->deleted_at !== null;
+        return isset($this->getTrashedPaths()[$path]);
     }
 
     /**
@@ -332,8 +335,16 @@ class DbDatasource extends Datasource implements DatasourceInterface
 
         $fileNames = [];
 
-        foreach ($this->buildDirectoryQuery($dirName, $extensions, true)->get() as $item) {
-            $fileName = $this->pathToFileName($dirName, $item->path);
+        foreach (array_keys($this->getTrashedPaths()) as $path) {
+            if (!str_starts_with($path, $dirName)) {
+                continue;
+            }
+
+            if (!$this->matchesExtensionFilter($path, $extensions)) {
+                continue;
+            }
+
+            $fileName = $this->pathToFileName($dirName, $path);
 
             if (!$this->matchesFileMatch($fileMatch, $fileName)) {
                 continue;
@@ -346,15 +357,26 @@ class DbDatasource extends Datasource implements DatasourceInterface
     }
 
     /**
-     * buildDirectoryQuery for templates in a directory
+     * getTrashedPaths returns cached tombstoned paths for this datasource source
      */
-    protected function buildDirectoryQuery(string $dirName, ?array $extensions, bool $trashedOnly)
+    protected function getTrashedPaths(): array
     {
-        $query = $trashedOnly
-            ? $this->getQuery(false)->whereNotNull('deleted_at')
-            : $this->getQuery();
+        if (!isset(self::$trashedPathCache[$this->source])) {
+            self::$trashedPathCache[$this->source] = array_fill_keys(
+                $this->getQuery(false)->whereNotNull('deleted_at')->pluck('path')->all(),
+                true
+            );
+        }
 
-        $query->where('path', 'like', $dirName . '%');
+        return self::$trashedPathCache[$this->source];
+    }
+
+    /**
+     * buildDirectoryQuery for active templates in a directory
+     */
+    protected function buildDirectoryQuery(string $dirName, ?array $extensions)
+    {
+        $query = $this->getQuery()->where('path', 'like', $dirName . '%');
 
         if (is_array($extensions) && !empty($extensions)) {
             $this->applyExtensionsFilter($query, $extensions);
@@ -393,6 +415,24 @@ class DbDatasource extends Datasource implements DatasourceInterface
     protected function matchesFileMatch(?string $fileMatch, string $fileName): bool
     {
         return empty($fileMatch) || fnmatch($fileMatch, $fileName);
+    }
+
+    /**
+     * matchesExtensionFilter checks a stored path against optional extensions
+     */
+    protected function matchesExtensionFilter(string $path, ?array $extensions): bool
+    {
+        if (!is_array($extensions) || empty($extensions)) {
+            return true;
+        }
+
+        foreach ($extensions as $ext) {
+            if (str_ends_with($path, '.' . $ext)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -447,5 +487,6 @@ class DbDatasource extends Datasource implements DatasourceInterface
     {
         unset(self::$pathCache[$this->source]);
         unset(self::$mtimeCache[$this->source]);
+        unset(self::$trashedPathCache[$this->source]);
     }
 }

--- a/tests/Halcyon/Datasource/AutoDatasourceTest.php
+++ b/tests/Halcyon/Datasource/AutoDatasourceTest.php
@@ -45,6 +45,18 @@ class AutoDatasourceTest extends TestCase
         $files->deleteDirectory($this->themePath);
     }
 
+    public function testSoftDeletedFilesystemOnlyTemplateIsHidden()
+    {
+        $this->assertTrue($this->autoDatasource->hasTemplate($this->dirName, $this->fileName, $this->extension));
+
+        $this->autoDatasource->delete($this->dirName, $this->fileName, $this->extension);
+
+        $this->assertFalse($this->autoDatasource->hasTemplate($this->dirName, $this->fileName, $this->extension));
+        $this->assertNull($this->autoDatasource->selectOne($this->dirName, $this->fileName, $this->extension));
+        $this->assertTrue($this->dbDatasource->isTemplateTrashed($this->dirName, $this->fileName, $this->extension));
+        $this->assertFileExists($this->themePath . '/pages/home.htm');
+    }
+
     public function testSoftDeletedTemplateDoesNotFallbackToFilesystem()
     {
         $fileContent = $this->fileDatasource->selectOne($this->dirName, $this->fileName, $this->extension);

--- a/tests/Halcyon/Datasource/AutoDatasourceTest.php
+++ b/tests/Halcyon/Datasource/AutoDatasourceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+require_once __DIR__ . '/HalcyonDbTestHarness.php';
+require_once __DIR__ . '/Concerns/SetsUpHalcyonDb.php';
+
+use October\Rain\Filesystem\Filesystem;
+use October\Rain\Halcyon\Datasource\AutoDatasource;
+use October\Rain\Halcyon\Datasource\FileDatasource;
+
+class AutoDatasourceTest extends TestCase
+{
+    use SetsUpHalcyonDb;
+
+    protected AutoDatasource $autoDatasource;
+
+    protected FileDatasource $fileDatasource;
+
+    protected string $themePath;
+
+    protected string $dirName = 'pages';
+
+    protected string $fileName = 'home';
+
+    protected string $extension = 'htm';
+
+    public function setUp(): void
+    {
+        $this->setUpHalcyonDatabase();
+
+        $this->themePath = sys_get_temp_dir() . '/halcyon-autodatasource-test-' . uniqid();
+        mkdir($this->themePath . '/pages', 0755, true);
+
+        $fixturePath = realpath(__DIR__ . '/../../fixtures/halcyon/themes/theme1/pages/home.htm');
+        copy($fixturePath, $this->themePath . '/pages/home.htm');
+
+        $this->fileDatasource = new FileDatasource($this->themePath, new Filesystem);
+        $this->autoDatasource = new AutoDatasource([$this->dbDatasource, $this->fileDatasource]);
+    }
+
+    public function tearDown(): void
+    {
+        $this->clearDbDatasourceCache();
+
+        $files = new Filesystem;
+        $files->deleteDirectory($this->themePath);
+    }
+
+    public function testSoftDeletedTemplateDoesNotFallbackToFilesystem()
+    {
+        $fileContent = $this->fileDatasource->selectOne($this->dirName, $this->fileName, $this->extension);
+        $this->assertNotNull($fileContent);
+        $this->assertStringContainsString('World!', $fileContent['content']);
+
+        $this->dbDatasource->insert($this->dirName, $this->fileName, $this->extension, '<p>Database override</p>');
+
+        $dbContent = $this->autoDatasource->selectOne($this->dirName, $this->fileName, $this->extension);
+        $this->assertNotNull($dbContent);
+        $this->assertStringContainsString('Database override', $dbContent['content']);
+
+        $this->autoDatasource->delete($this->dirName, $this->fileName, $this->extension);
+
+        $this->assertFalse($this->autoDatasource->hasTemplate($this->dirName, $this->fileName, $this->extension));
+        $this->assertNull($this->autoDatasource->selectOne($this->dirName, $this->fileName, $this->extension));
+
+        $templates = $this->autoDatasource->select($this->dirName, ['extensions' => ['htm']]);
+        $this->assertArrayNotHasKey('home.htm', $templates);
+        $this->assertFileExists($this->themePath . '/pages/home.htm');
+    }
+
+    public function testLastModifiedReturnsNullForTombstonedTemplate()
+    {
+        $this->dbDatasource->insert($this->dirName, $this->fileName, $this->extension, '<p>Database override</p>');
+        $this->autoDatasource->delete($this->dirName, $this->fileName, $this->extension);
+
+        $this->assertNull($this->autoDatasource->lastModified($this->dirName, $this->fileName, $this->extension));
+    }
+
+    public function testForceDeleteRemovesFromAllLayers()
+    {
+        $this->dbDatasource->insert($this->dirName, $this->fileName, $this->extension, '<p>Database override</p>');
+
+        $targetFile = $this->themePath . '/pages/home.htm';
+        $this->assertFileExists($targetFile);
+
+        $this->autoDatasource->forceDelete($this->dirName, $this->fileName, $this->extension);
+
+        $this->assertFalse($this->autoDatasource->hasTemplate($this->dirName, $this->fileName, $this->extension));
+        $this->assertFileNotExists($targetFile);
+        $this->assertTrue($this->dbDatasource->isTemplateTrashed($this->dirName, $this->fileName, $this->extension));
+    }
+
+    public function testInsertRestoresTrashedTemplate()
+    {
+        $this->dbDatasource->insert($this->dirName, $this->fileName, $this->extension, '<p>Database override</p>');
+        $this->autoDatasource->delete($this->dirName, $this->fileName, $this->extension);
+
+        $this->assertFalse($this->autoDatasource->hasTemplate($this->dirName, $this->fileName, $this->extension));
+
+        $this->autoDatasource->insert($this->dirName, $this->fileName, $this->extension, '<p>Restored content</p>');
+
+        $this->assertTrue($this->autoDatasource->hasTemplate($this->dirName, $this->fileName, $this->extension));
+        $this->assertFalse($this->dbDatasource->isTemplateTrashed($this->dirName, $this->fileName, $this->extension));
+
+        $content = $this->autoDatasource->selectOne($this->dirName, $this->fileName, $this->extension);
+        $this->assertStringContainsString('Restored content', $content['content']);
+    }
+}

--- a/tests/Halcyon/Datasource/AutoDatasourceTest.php
+++ b/tests/Halcyon/Datasource/AutoDatasourceTest.php
@@ -39,7 +39,7 @@ class AutoDatasourceTest extends TestCase
 
     public function tearDown(): void
     {
-        $this->clearDbDatasourceCache();
+        $this->tearDownHalcyonDatabase();
 
         $files = new Filesystem;
         $files->deleteDirectory($this->themePath);

--- a/tests/Halcyon/Datasource/Concerns/SetsUpHalcyonDb.php
+++ b/tests/Halcyon/Datasource/Concerns/SetsUpHalcyonDb.php
@@ -13,6 +13,12 @@ trait SetsUpHalcyonDb
         $this->dbDatasource = HalcyonDbTestHarness::boot($this->dbTable);
     }
 
+    protected function tearDownHalcyonDatabase(): void
+    {
+        $this->clearDbDatasourceCache();
+        HalcyonDbTestHarness::teardown();
+    }
+
     protected function clearDbDatasourceCache(): void
     {
         HalcyonDbTestHarness::clearDbDatasourceCache();

--- a/tests/Halcyon/Datasource/Concerns/SetsUpHalcyonDb.php
+++ b/tests/Halcyon/Datasource/Concerns/SetsUpHalcyonDb.php
@@ -1,0 +1,20 @@
+<?php
+
+use October\Rain\Halcyon\Datasource\DbDatasource;
+
+trait SetsUpHalcyonDb
+{
+    protected DbDatasource $dbDatasource;
+
+    protected string $dbTable = 'halcyon_templates';
+
+    protected function setUpHalcyonDatabase(): void
+    {
+        $this->dbDatasource = HalcyonDbTestHarness::boot($this->dbTable);
+    }
+
+    protected function clearDbDatasourceCache(): void
+    {
+        HalcyonDbTestHarness::clearDbDatasourceCache();
+    }
+}

--- a/tests/Halcyon/Datasource/DbDatasourceTest.php
+++ b/tests/Halcyon/Datasource/DbDatasourceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+require_once __DIR__ . '/HalcyonDbTestHarness.php';
+require_once __DIR__ . '/Concerns/SetsUpHalcyonDb.php';
+
+use October\Rain\Halcyon\Datasource\DbDatasource;
+
+class DbDatasourceTest extends TestCase
+{
+    use SetsUpHalcyonDb;
+
+    protected string $dirName = 'pages';
+
+    protected string $fileName = 'home';
+
+    protected string $extension = 'htm';
+
+    public function setUp(): void
+    {
+        $this->setUpHalcyonDatabase();
+    }
+
+    public function tearDown(): void
+    {
+        $this->clearDbDatasourceCache();
+    }
+
+    public function testIsTemplateTrashedReturnsFalseForActiveRecord()
+    {
+        $this->dbDatasource->insert($this->dirName, $this->fileName, $this->extension, '<p>DB content</p>');
+
+        $this->assertFalse($this->dbDatasource->isTemplateTrashed($this->dirName, $this->fileName, $this->extension));
+    }
+
+    public function testIsTemplateTrashedReturnsTrueAfterSoftDelete()
+    {
+        $this->dbDatasource->insert($this->dirName, $this->fileName, $this->extension, '<p>DB content</p>');
+        $this->dbDatasource->delete($this->dirName, $this->fileName, $this->extension);
+
+        $this->assertTrue($this->dbDatasource->isTemplateTrashed($this->dirName, $this->fileName, $this->extension));
+    }
+
+    public function testIsTemplateTrashedReturnsFalseWhenNoRecord()
+    {
+        $this->assertFalse($this->dbDatasource->isTemplateTrashed($this->dirName, $this->fileName, $this->extension));
+    }
+
+    public function testSelectTrashedFileNamesReturnsSoftDeletedTemplates()
+    {
+        $this->dbDatasource->insert($this->dirName, $this->fileName, $this->extension, '<p>DB content</p>');
+        $this->dbDatasource->insert($this->dirName, 'about', $this->extension, '<p>About</p>');
+        $this->dbDatasource->delete($this->dirName, $this->fileName, $this->extension);
+
+        $trashed = $this->dbDatasource->selectTrashedFileNames($this->dirName);
+
+        $this->assertEquals(['home.htm'], $trashed);
+    }
+
+    public function testSelectTrashedFileNamesRespectsExtensionsFilter()
+    {
+        $this->dbDatasource->insert($this->dirName, $this->fileName, $this->extension, '<p>DB content</p>');
+        $this->dbDatasource->insert('content', 'welcome', 'htm', '<p>Welcome</p>');
+        $this->dbDatasource->insert('content', 'readme', 'md', '# Readme');
+        $this->dbDatasource->delete($this->dirName, $this->fileName, $this->extension);
+        $this->dbDatasource->delete('content', 'readme', 'md');
+
+        $trashed = $this->dbDatasource->selectTrashedFileNames('content', ['extensions' => ['md']]);
+
+        $this->assertEquals(['readme.md'], $trashed);
+    }
+}

--- a/tests/Halcyon/Datasource/DbDatasourceTest.php
+++ b/tests/Halcyon/Datasource/DbDatasourceTest.php
@@ -22,7 +22,7 @@ class DbDatasourceTest extends TestCase
 
     public function tearDown(): void
     {
-        $this->clearDbDatasourceCache();
+        $this->tearDownHalcyonDatabase();
     }
 
     public function testIsTemplateTrashedReturnsFalseForActiveRecord()

--- a/tests/Halcyon/Datasource/HalcyonDbTestHarness.php
+++ b/tests/Halcyon/Datasource/HalcyonDbTestHarness.php
@@ -1,0 +1,51 @@
+<?php
+
+use October\Rain\Halcyon\Datasource\DbDatasource;
+
+class HalcyonDbTestHarness
+{
+    protected static ?Illuminate\Database\Capsule\Manager $capsule = null;
+
+    public static function boot(string $table): DbDatasource
+    {
+        if (!self::$capsule) {
+            self::$capsule = new Illuminate\Database\Capsule\Manager;
+            self::$capsule->addConnection([
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+            ]);
+            self::$capsule->setAsGlobal();
+            self::$capsule->bootEloquent();
+
+            $app = new Illuminate\Container\Container;
+            $app->singleton('db', fn () => self::$capsule->getDatabaseManager());
+            Illuminate\Support\Facades\Facade::setFacadeApplication($app);
+        }
+
+        $schema = self::$capsule->schema();
+        $schema->dropIfExists($table);
+        $schema->create($table, function ($table) {
+            $table->string('source');
+            $table->string('path');
+            $table->text('content')->nullable();
+            $table->integer('file_size')->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->timestamp('deleted_at')->nullable();
+        });
+
+        self::clearDbDatasourceCache();
+
+        return new DbDatasource('test-theme', $table);
+    }
+
+    public static function clearDbDatasourceCache(): void
+    {
+        $reflection = new ReflectionClass(DbDatasource::class);
+
+        foreach (['pathCache', 'mtimeCache'] as $propertyName) {
+            $property = $reflection->getProperty($propertyName);
+            $property->setValue(null, []);
+        }
+    }
+}

--- a/tests/Halcyon/Datasource/HalcyonDbTestHarness.php
+++ b/tests/Halcyon/Datasource/HalcyonDbTestHarness.php
@@ -6,6 +6,10 @@ class HalcyonDbTestHarness
 {
     protected static ?Illuminate\Database\Capsule\Manager $capsule = null;
 
+    protected static bool $facadeAppSaved = false;
+
+    protected static $savedFacadeApp;
+
     public static function boot(string $table): DbDatasource
     {
         if (!self::$capsule) {
@@ -17,11 +21,16 @@ class HalcyonDbTestHarness
             ]);
             self::$capsule->setAsGlobal();
             self::$capsule->bootEloquent();
-
-            $app = new Illuminate\Container\Container;
-            $app->singleton('db', fn () => self::$capsule->getDatabaseManager());
-            Illuminate\Support\Facades\Facade::setFacadeApplication($app);
         }
+
+        if (!self::$facadeAppSaved) {
+            self::$savedFacadeApp = Illuminate\Support\Facades\Facade::getFacadeApplication();
+            self::$facadeAppSaved = true;
+        }
+
+        $app = new Illuminate\Container\Container;
+        $app->singleton('db', fn () => self::$capsule->getDatabaseManager());
+        Illuminate\Support\Facades\Facade::setFacadeApplication($app);
 
         $schema = self::$capsule->schema();
         $schema->dropIfExists($table);
@@ -37,6 +46,13 @@ class HalcyonDbTestHarness
         self::clearDbDatasourceCache();
 
         return new DbDatasource('test-theme', $table);
+    }
+
+    public static function teardown(): void
+    {
+        if (self::$facadeAppSaved) {
+            Illuminate\Support\Facades\Facade::setFacadeApplication(self::$savedFacadeApp);
+        }
     }
 
     public static function clearDbDatasourceCache(): void

--- a/tests/Halcyon/Datasource/HalcyonDbTestHarness.php
+++ b/tests/Halcyon/Datasource/HalcyonDbTestHarness.php
@@ -59,7 +59,7 @@ class HalcyonDbTestHarness
     {
         $reflection = new ReflectionClass(DbDatasource::class);
 
-        foreach (['pathCache', 'mtimeCache'] as $propertyName) {
+        foreach (['pathCache', 'mtimeCache', 'trashedPathCache'] as $propertyName) {
             $property = $reflection->getProperty($propertyName);
             $property->setValue(null, []);
         }


### PR DESCRIPTION
https://github.com/octobercms/october/issues/6056

## Problem

When database templates are enabled (`CMS_DB_TEMPLATES`), soft-deleting a template sets `deleted_at` on the DB row but `AutoDatasource` still falls through to the filesystem layer. The template incorrectly appears in the CMS and on the frontend.

## Solution

**`DbDatasource`**
- `isTemplateTrashed` - detect soft-deleted records at a path
- `selectTrashedFileNames` - list tombstoned file names in a directory
- `$trashedPathCache` - load tombstoned paths once per source (same pattern as `$mtimeCache`)
- Shared helpers for `select` / `selectTrashedFileNames`: `buildDirectoryQuery`, `applyExtensionsFilter`, `pathToFileName`, `matchesFileMatch`

**`AutoDatasource`**
- Guard `hasTemplate`, `selectOne`, `select`, and `lastModified` so a DB tombstone blocks all lower layers
- On-disk files are left untouched

## Tests

New tests under `tests/Halcyon/Datasource` with `HalcyonDbTestHarness` (in-memory SQLite + facade isolation). The harness saves and restores the Laravel facade app after each test to avoid breaking other suites.

```bash
./vendor/bin/phpunit tests/Halcyon/Datasource/
```

## QA

**Setup**

1. Create a codespace from [`octobercms/october`](https://github.com/octobercms/october)
2. Add `CMS_DB_TEMPLATES=true` to `.env`
3. Modify `composer.json`
```diff
+ "repositories": [
+     {
+         "type": "git",
+         "url": "https://github.com/scottbedard/library.git"
+     }
+ ],
  "require": {
-     "october/rain": "^4.3",
+     "october/rain": "4.x-dev",
  },
```
4. Run `composer install` and `php artisan config:clear`

**Confirmation 1: Deleting un-modified file**

1. Delete a page _without modifying it_
3. Refresh backend, confirm page is gone
3. Navigate to page, confirm 404
4. Refresh codespace, confirm file exists on disk

**Confirmation 2: Deleting a modified file**

1. Modify a page, then click save
2. Delete the page
3. Refresh backend, confirm page is gone
4. Navigate to page, confirm 404
5. Refresh codespace, confirm file exists on disk

**Confirmation 3: New file behavior does not change**

1. Create a page
2. Navigate to page, confirm 200
3. Refresh codespace, confirm no file
4. Delete file
5. Navigate to page, confirm 404