### PR TITLE
Add StorageFileDatasource for database-tracked theme file storage

### DIFF
--- a/src/Halcyon/Datasource/AutoDatasource.php
+++ b/src/Halcyon/Datasource/AutoDatasource.php
@@ -130,7 +130,7 @@ class AutoDatasource extends Datasource implements DatasourceInterface
             return (bool) $result ?: true;
         }
 
-        $dbDatasource = $this->getDbDatasource();
+        $dbDatasource = $this->getSoftDeleteDatasource();
 
         if (!$dbDatasource) {
             return (bool) $result;
@@ -268,6 +268,80 @@ class AutoDatasource extends Datasource implements DatasourceInterface
     }
 
     /**
+     * hasTemplateAtIndex checks if a template exists at a specific datasource index
+     */
+    public function hasTemplateAtIndex(int $index, string $dirName, string $fileName, string $extension): bool
+    {
+        if (!$this->hasIndex($index)) {
+            return false;
+        }
+
+        return $this->datasources[$index]->hasTemplate($dirName, $fileName, $extension);
+    }
+
+    /**
+     * resolveLocalPath returns the first matching local path from datasources
+     */
+    public function resolveLocalPath(string $dirName, string $fileName, string $extension): ?string
+    {
+        if ($this->isTemplateTrashed($dirName, $fileName, $extension)) {
+            return null;
+        }
+
+        foreach ($this->datasources as $source) {
+            if (!$source->hasTemplate($dirName, $fileName, $extension)) {
+                continue;
+            }
+
+            if ($source instanceof ResolvableDatasourceInterface) {
+                $localPath = $source->resolveLocalPath($dirName, $fileName, $extension);
+                if ($localPath) {
+                    return $localPath;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * resolvePublicUrl returns the first matching public URL from datasources
+     */
+    public function resolvePublicUrl(string $dirName, string $fileName, string $extension, array $context = []): ?string
+    {
+        if ($this->isTemplateTrashed($dirName, $fileName, $extension)) {
+            return null;
+        }
+
+        foreach ($this->datasources as $source) {
+            if (!$source->hasTemplate($dirName, $fileName, $extension)) {
+                continue;
+            }
+
+            if ($source instanceof ResolvableDatasourceInterface) {
+                $publicUrl = $source->resolvePublicUrl($dirName, $fileName, $extension, $context);
+                if ($publicUrl) {
+                    return $publicUrl;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * getSoftDeleteDatasource returns the primary datasource when it supports soft deletes
+     */
+    protected function getSoftDeleteDatasource(): ?SoftDeleteDatasourceInterface
+    {
+        if ($this->primaryDatasource instanceof SoftDeleteDatasourceInterface) {
+            return $this->primaryDatasource;
+        }
+
+        return null;
+    }
+
+    /**
      * getDbDatasource returns the primary datasource when it is a DbDatasource
      */
     protected function getDbDatasource(): ?DbDatasource
@@ -284,7 +358,7 @@ class AutoDatasource extends Datasource implements DatasourceInterface
      */
     protected function isTemplateTrashed(string $dirName, string $fileName, string $extension): bool
     {
-        $dbDatasource = $this->getDbDatasource();
+        $dbDatasource = $this->getSoftDeleteDatasource();
 
         if (!$dbDatasource) {
             return false;
@@ -294,11 +368,11 @@ class AutoDatasource extends Datasource implements DatasourceInterface
     }
 
     /**
-     * getTrashedFileNames returns tombstoned file names from the primary DbDatasource
+     * getTrashedFileNames returns tombstoned file names from the primary datasource
      */
     protected function getTrashedFileNames(string $dirName, array $options = []): array
     {
-        $dbDatasource = $this->getDbDatasource();
+        $dbDatasource = $this->getSoftDeleteDatasource();
 
         if (!$dbDatasource) {
             return [];

--- a/src/Halcyon/Datasource/AutoDatasource.php
+++ b/src/Halcyon/Datasource/AutoDatasource.php
@@ -66,7 +66,10 @@ class AutoDatasource extends Datasource implements DatasourceInterface
                 continue;
             }
 
-            return $source->selectOne($dirName, $fileName, $extension);
+            $result = $source->selectOne($dirName, $fileName, $extension);
+            if ($result !== null) {
+                return $result;
+            }
         }
 
         return null;
@@ -175,7 +178,10 @@ class AutoDatasource extends Datasource implements DatasourceInterface
                 continue;
             }
 
-            return $source->lastModified($dirName, $fileName, $extension);
+            $mtime = $source->lastModified($dirName, $fileName, $extension);
+            if ($mtime !== null) {
+                return $mtime;
+            }
         }
 
         return null;

--- a/src/Halcyon/Datasource/FileDatasource.php
+++ b/src/Halcyon/Datasource/FileDatasource.php
@@ -16,7 +16,7 @@ use Exception;
  * @package october\halcyon
  * @author Alexey Bobkov, Samuel Georges
  */
-class FileDatasource extends Datasource implements DatasourceInterface
+class FileDatasource extends Datasource implements DatasourceInterface, ResolvableDatasourceInterface
 {
     /**
      * @var string basePath is a local path to find the datasource
@@ -287,5 +287,23 @@ class FileDatasource extends Datasource implements DatasourceInterface
     public function makeCacheKey(string $name = ''): string
     {
         return crc32($this->basePath . $name);
+    }
+
+    /**
+     * resolveLocalPath returns the absolute local path for a template, if available
+     */
+    public function resolveLocalPath(string $dirName, string $fileName, string $extension): ?string
+    {
+        $path = $this->makeFilePath($dirName, $fileName, $extension);
+
+        return $this->files->isFile($path) ? $path : null;
+    }
+
+    /**
+     * resolvePublicUrl returns a public URL for a template, if available
+     */
+    public function resolvePublicUrl(string $dirName, string $fileName, string $extension, array $context = []): ?string
+    {
+        return null;
     }
 }

--- a/src/Halcyon/Datasource/ResolvableDatasourceInterface.php
+++ b/src/Halcyon/Datasource/ResolvableDatasourceInterface.php
@@ -1,0 +1,20 @@
+<?php namespace October\Rain\Halcyon\Datasource;
+
+/**
+ * ResolvableDatasourceInterface for datasources that can resolve file locations
+ *
+ * @package october\halcyon
+ * @author Alexey Bobkov, Samuel Georges
+ */
+interface ResolvableDatasourceInterface extends DatasourceInterface
+{
+    /**
+     * resolveLocalPath returns the absolute local path for a template, if available
+     */
+    public function resolveLocalPath(string $dirName, string $fileName, string $extension): ?string;
+
+    /**
+     * resolvePublicUrl returns a public URL for a template, if available
+     */
+    public function resolvePublicUrl(string $dirName, string $fileName, string $extension, array $context = []): ?string;
+}

--- a/src/Halcyon/Datasource/SoftDeleteDatasourceInterface.php
+++ b/src/Halcyon/Datasource/SoftDeleteDatasourceInterface.php
@@ -1,0 +1,25 @@
+<?php namespace October\Rain\Halcyon\Datasource;
+
+/**
+ * SoftDeleteDatasourceInterface for datasources that support tombstoning
+ *
+ * @package october\halcyon
+ * @author Alexey Bobkov, Samuel Georges
+ */
+interface SoftDeleteDatasourceInterface extends DatasourceInterface
+{
+    /**
+     * isTemplateTrashed returns true when a soft-deleted record exists at the path
+     */
+    public function isTemplateTrashed(string $dirName, string $fileName, string $extension): bool;
+
+    /**
+     * selectTrashedFileNames returns file names for soft-deleted templates in a directory
+     */
+    public function selectTrashedFileNames(string $dirName, array $options = []): array;
+
+    /**
+     * tombstone creates a soft-deleted record for a path with no active record
+     */
+    public function tombstone(string $dirName, string $fileName, string $extension): bool;
+}

--- a/src/Halcyon/Datasource/StorageFileDatasource.php
+++ b/src/Halcyon/Datasource/StorageFileDatasource.php
@@ -69,7 +69,13 @@ class StorageFileDatasource extends Datasource implements SoftDeleteDatasourceIn
      */
     public function hasTemplate(string $dirName, string $fileName, string $extension): bool
     {
-        return (bool) $this->lastModified($dirName, $fileName, $extension);
+        $path = $this->makeFilePath($dirName, $fileName, $extension);
+
+        if (!$this->hasActiveRecord($path)) {
+            return false;
+        }
+
+        return $this->files->isFile($this->makeDiskPathFromPath($path));
     }
 
     /**
@@ -90,7 +96,7 @@ class StorageFileDatasource extends Datasource implements SoftDeleteDatasourceIn
             return null;
         }
 
-        $diskPath = $this->makeDiskPath($dirName, $fileName, $extension);
+        $diskPath = $this->makeDiskPathFromPath($path);
 
         if (!$this->files->isFile($diskPath)) {
             return null;
@@ -137,7 +143,11 @@ class StorageFileDatasource extends Datasource implements SoftDeleteDatasourceIn
                 continue;
             }
 
-            $diskPath = $this->storagePath . '/' . $item->path;
+            $diskPath = $this->makeDiskPathFromPath($item->path);
+
+            if (!$this->files->isFile($diskPath)) {
+                continue;
+            }
 
             if ($columns === null) {
                 $resultItem = [
@@ -391,7 +401,7 @@ class StorageFileDatasource extends Datasource implements SoftDeleteDatasourceIn
         $fileNames = [];
 
         foreach (array_keys($this->getTrashedPaths()) as $path) {
-            if (!str_starts_with($path, $dirName)) {
+            if (!$this->pathInDirectory($dirName, $path)) {
                 continue;
             }
 
@@ -461,7 +471,11 @@ class StorageFileDatasource extends Datasource implements SoftDeleteDatasourceIn
      */
     protected function buildDirectoryQuery(string $dirName, ?array $extensions)
     {
-        $query = $this->getQuery()->where('path', 'like', $dirName . '%');
+        $query = $this->getQuery();
+
+        if ($dirName !== '') {
+            $query->where('path', 'like', $dirName . '/%');
+        }
 
         if (is_array($extensions) && !empty($extensions)) {
             $this->applyExtensionsFilter($query, $extensions);
@@ -484,6 +498,34 @@ class StorageFileDatasource extends Datasource implements SoftDeleteDatasourceIn
                 }
             }
         });
+    }
+
+    /**
+     * hasActiveRecord checks if an active metadata record exists for a path
+     */
+    protected function hasActiveRecord(string $path): bool
+    {
+        if (isset(self::$pathCache[$this->source][$path])) {
+            return true;
+        }
+
+        if (!isset(self::$mtimeCache[$this->source])) {
+            self::$mtimeCache[$this->source] = $this->getQuery()->pluck('updated_at', 'path')->all();
+        }
+
+        return isset(self::$mtimeCache[$this->source][$path]);
+    }
+
+    /**
+     * pathInDirectory checks if a stored path belongs to a directory
+     */
+    protected function pathInDirectory(string $dirName, string $path): bool
+    {
+        if ($dirName === '') {
+            return true;
+        }
+
+        return $path === $dirName || str_starts_with($path, $dirName . '/');
     }
 
     /**

--- a/src/Halcyon/Datasource/StorageFileDatasource.php
+++ b/src/Halcyon/Datasource/StorageFileDatasource.php
@@ -1,6 +1,7 @@
 <?php namespace October\Rain\Halcyon\Datasource;
 
 use Db;
+use October\Rain\Filesystem\Filesystem;
 use October\Rain\Halcyon\Processors\Processor;
 use October\Rain\Halcyon\Exception\CreateFileException;
 use October\Rain\Halcyon\Exception\DeleteFileException;
@@ -9,12 +10,12 @@ use Carbon\Carbon;
 use Exception;
 
 /**
- * DbDatasource looks at the database for templates
+ * StorageFileDatasource stores file content on disk and metadata in the database
  *
  * @package october\halcyon
  * @author Alexey Bobkov, Samuel Georges
  */
-class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
+class StorageFileDatasource extends Datasource implements SoftDeleteDatasourceInterface, ResolvableDatasourceInterface
 {
     /**
      * @var string source identifier for this datasource instance
@@ -25,6 +26,16 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
      * @var string table name of the datasource
      */
     protected $table;
+
+    /**
+     * @var string storagePath is the local root path for stored files
+     */
+    protected $storagePath;
+
+    /**
+     * @var Filesystem files
+     */
+    protected $files;
 
     /**
      * @var array pathCache
@@ -44,12 +55,12 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
     /**
      * __construct a new datasource instance
      */
-    public function __construct(string $source, string $table)
+    public function __construct(string $source, string $table, string $storagePath, Filesystem $files)
     {
         $this->source = $source;
-
         $this->table = $table;
-
+        $this->storagePath = rtrim($storagePath, '/\\');
+        $this->files = $files;
         $this->postProcessor = new Processor;
     }
 
@@ -76,22 +87,28 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
         }
 
         if (!$result) {
-            return $result;
+            return null;
+        }
+
+        $diskPath = $this->makeDiskPath($dirName, $fileName, $extension);
+
+        if (!$this->files->isFile($diskPath)) {
+            return null;
         }
 
         return [
             'fileName' => $fileName . '.' . $extension,
-            'content' => $result->content,
+            'content' => $this->files->get($diskPath),
             'mtime' => Carbon::parse($result->updated_at)->timestamp,
             'record' => $result
         ];
     }
 
     /**
-     * select returns all templates, with availableoptions:
+     * select returns all templates, with available options:
      *
      * - columns: only return specific columns, eg: ['fileName', 'mtime', 'content']
-     * - extensions: extensions to search for, eg: ['htm', 'md', 'twig']
+     * - extensions: extensions to search for, eg: ['css', 'png']
      * - fileMatch: pattern to match the filename against using the fnmatch function, eg: *gr[ae]y
      */
     public function select(string $dirName, array $options = []): array
@@ -120,11 +137,12 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
                 continue;
             }
 
-            // Apply the columns filter on the data returned
+            $diskPath = $this->storagePath . '/' . $item->path;
+
             if ($columns === null) {
                 $resultItem = [
                     'fileName' => $fileName,
-                    'content' => $item->content,
+                    'content' => $this->files->isFile($diskPath) ? $this->files->get($diskPath) : '',
                     'mtime' => Carbon::parse($item->updated_at)->timestamp,
                     'record' => $item,
                 ];
@@ -134,8 +152,8 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
                     $resultItem['fileName'] = $fileName;
                 }
 
-                if (in_array('content', $columns)) {
-                    $resultItem['content'] = $item->content;
+                if (in_array('content', $columns) && $this->files->isFile($diskPath)) {
+                    $resultItem['content'] = $this->files->get($diskPath);
                 }
 
                 if (in_array('mtime', $columns)) {
@@ -164,40 +182,32 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
             throw (new FileExistsException())->setInvalidPath($path);
         }
 
-        // Update a trashed record
         if ($this->getQuery(false)->where('path', $path)->first()) {
             return $this->update($dirName, $fileName, $extension, $content);
         }
 
         try {
+            $diskPath = $this->makeDiskPath($dirName, $fileName, $extension);
+            $this->ensureDirectoryExists(dirname($diskPath));
+            $this->files->put($diskPath, $content);
+
+            $fileSize = strlen($content);
             $record = [
                 'source' => $this->source,
                 'path' => $path,
-                'content' => $content,
-                'file_size' => mb_strlen($content, '8bit'),
+                'content' => null,
+                'file_size' => $fileSize,
                 'updated_at' => Carbon::now()->toDateTimeString(),
                 'deleted_at' => null,
             ];
 
-            /**
-             * @event halcyon.datasource.db.beforeInsert
-             * Provides an opportunity to modify records before being inserted into the DB
-             *
-             * Example usage:
-             *
-             *     $datasource->bindEvent('halcyon.datasource.db.beforeInsert', function ((array) &$record) {
-             *         // Attach a site id to every record in a multi-tenant application
-             *         $record['site_id'] = SiteManager::getSite()->id;
-             *     });
-             *
-             */
-            $this->fireEvent('halcyon.datasource.db.beforeInsert', [&$record]);
+            $this->fireEvent('halcyon.datasource.storage.beforeInsert', [&$record]);
 
             $this->getBaseQuery()->insert($record);
 
             $this->flushCache();
 
-            return $record['file_size'];
+            return $fileSize;
         }
         catch (Exception $ex) {
             throw (new CreateFileException)->setInvalidPath($path);
@@ -211,7 +221,6 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
     {
         $path = $this->makeFilePath($dirName, $fileName, $extension);
 
-        // Check if this file has been renamed
         if ($oldFileName !== null) {
             $fileName = $oldFileName;
         }
@@ -222,29 +231,25 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
         $oldPath = $this->makeFilePath($dirName, $fileName, $extension);
 
         try {
-            $fileSize = mb_strlen($content, '8bit');
+            $diskPath = $this->makeDiskPathFromPath($path);
+            $this->ensureDirectoryExists(dirname($diskPath));
+            $this->files->put($diskPath, $content);
+
+            if ($oldPath !== $path && $this->files->isFile($oldDiskPath = $this->makeDiskPathFromPath($oldPath))) {
+                $this->files->delete($oldDiskPath);
+            }
+
+            $fileSize = strlen($content);
 
             $data = [
                 'path' => $path,
-                'content' => $content,
+                'content' => null,
                 'file_size' => $fileSize,
                 'updated_at' => Carbon::now()->toDateTimeString(),
                 'deleted_at' => null
             ];
 
-            /**
-             * @event halcyon.datasource.db.beforeUpdate
-             * Provides an opportunity to modify records before being updated into the DB
-             *
-             * Example usage:
-             *
-             *     $datasource->bindEvent('halcyon.datasource.db.beforeUpdate', function ((array) &$data) {
-             *         // Attach a site id to every record in a multi-tenant application
-             *         $data['site_id'] = SiteManager::getSite()->id;
-             *     });
-             *
-             */
-            $this->fireEvent('halcyon.datasource.db.beforeUpdate', [&$data]);
+            $this->fireEvent('halcyon.datasource.storage.beforeUpdate', [&$data]);
 
             $this->getQuery(false)->where('path', $oldPath)->update($data);
 
@@ -258,7 +263,7 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
     }
 
     /**
-     * tombstone creates a soft-deleted record for a path with no active DB template
+     * tombstone creates a soft-deleted record for a path with no active record
      */
     public function tombstone(string $dirName, string $fileName, string $extension): bool
     {
@@ -278,13 +283,13 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
             $record = [
                 'source' => $this->source,
                 'path' => $path,
-                'content' => '',
+                'content' => null,
                 'file_size' => 0,
                 'updated_at' => $now,
                 'deleted_at' => $now,
             ];
 
-            $this->fireEvent('halcyon.datasource.db.beforeInsert', [&$record]);
+            $this->fireEvent('halcyon.datasource.storage.beforeInsert', [&$record]);
 
             $this->getBaseQuery()->insert($record);
 
@@ -307,10 +312,20 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
             $recordQuery = $this->getQuery()->where('path', $path);
 
             if ($this->forceDeleting) {
+                $diskPath = $this->makeDiskPathFromPath($path);
+                if ($this->files->isFile($diskPath)) {
+                    $this->files->delete($diskPath);
+                }
+
                 $result = $recordQuery->delete();
             }
             else {
                 $result = $recordQuery->update(['deleted_at' => Carbon::now()->toDateTimeString()]);
+
+                $diskPath = $this->makeDiskPathFromPath($path);
+                if ($this->files->isFile($diskPath)) {
+                    $this->files->delete($diskPath);
+                }
             }
 
             $this->flushCache();
@@ -397,6 +412,36 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
     }
 
     /**
+     * resolveLocalPath returns the absolute local path for a template, if available
+     */
+    public function resolveLocalPath(string $dirName, string $fileName, string $extension): ?string
+    {
+        if (!$this->hasTemplate($dirName, $fileName, $extension)) {
+            return null;
+        }
+
+        return $this->makeDiskPath($dirName, $fileName, $extension);
+    }
+
+    /**
+     * resolvePublicUrl returns a public URL for a template, if available
+     */
+    public function resolvePublicUrl(string $dirName, string $fileName, string $extension, array $context = []): ?string
+    {
+        if (!$this->hasTemplate($dirName, $fileName, $extension)) {
+            return null;
+        }
+
+        $publicUrl = $context['publicUrl'] ?? null;
+        if ($publicUrl) {
+            $path = $this->makeFilePath($dirName, $fileName, $extension);
+            return rtrim($publicUrl, '/') . '/' . ltrim($path, '/');
+        }
+
+        return null;
+    }
+
+    /**
      * getTrashedPaths returns cached tombstoned paths for this datasource source
      */
     protected function getTrashedPaths(): array
@@ -466,13 +511,9 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
             return true;
         }
 
-        foreach ($extensions as $ext) {
-            if (str_ends_with($path, '.' . $ext)) {
-                return true;
-            }
-        }
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
 
-        return false;
+        return in_array($extension, $extensions);
     }
 
     /**
@@ -490,35 +531,49 @@ class DbDatasource extends Datasource implements SoftDeleteDatasourceInterface
     {
         $query = $this->getBaseQuery();
         $query->where('source', $this->source);
-        $query->whereNotNull('content');
+        $query->whereNull('content');
 
         if ($withTrashed) {
             $query->whereNull('deleted_at');
         }
 
-        /**
-         * @event halcyon.datasource.db.extendQuery
-         * Provides an opportunity to modify the query object used by the Halycon DbDatasource
-         *
-         * Example usage:
-         *
-         *     $datasource->bindEvent('halcyon.datasource.db.extendQuery', function ((QueryBuilder) $query, (bool) $withTrashed) {
-         *         // Apply a site filter in a multi-tenant application
-         *         $query->where('site_id', SiteManager::getSite()->id);
-         *     });
-         *
-         */
-        $this->fireEvent('halcyon.datasource.db.extendQuery', [$query, $withTrashed]);
+        $this->fireEvent('halcyon.datasource.storage.extendQuery', [$query, $withTrashed]);
 
         return $query;
     }
 
     /**
-     * makeFilePath helper to make file path
+     * makeFilePath helper to make file path relative to the theme root
      */
     protected function makeFilePath(string $dirName, string $fileName, string $extension): string
     {
         return $dirName . '/' . $fileName . '.' . $extension;
+    }
+
+    /**
+     * makeDiskPath returns the absolute disk path for a template
+     */
+    protected function makeDiskPath(string $dirName, string $fileName, string $extension): string
+    {
+        return $this->makeDiskPathFromPath($this->makeFilePath($dirName, $fileName, $extension));
+    }
+
+    /**
+     * makeDiskPathFromPath returns the absolute disk path from a relative path
+     */
+    protected function makeDiskPathFromPath(string $path): string
+    {
+        return $this->storagePath . '/' . $path;
+    }
+
+    /**
+     * ensureDirectoryExists for a given path
+     */
+    protected function ensureDirectoryExists(string $path): void
+    {
+        if (!$this->files->isDirectory($path)) {
+            $this->files->makeDirectory($path, 0755, true, true);
+        }
     }
 
     /**

--- a/src/Halcyon/Datasource/StorageFileDatasource.php
+++ b/src/Halcyon/Datasource/StorageFileDatasource.php
@@ -619,12 +619,30 @@ class StorageFileDatasource extends Datasource implements SoftDeleteDatasourceIn
     }
 
     /**
-     * flushCache
+     * flushStorageCache clears cached paths, mtimes, and trashed paths for this source
      */
-    protected function flushCache()
+    public function flushStorageCache(): void
     {
         unset(self::$pathCache[$this->source]);
         unset(self::$mtimeCache[$this->source]);
         unset(self::$trashedPathCache[$this->source]);
+    }
+
+    /**
+     * flushAllStorageCaches clears all cached paths across every source
+     */
+    public static function flushAllStorageCaches(): void
+    {
+        self::$pathCache = [];
+        self::$mtimeCache = [];
+        self::$trashedPathCache = [];
+    }
+
+    /**
+     * flushCache
+     */
+    protected function flushCache()
+    {
+        $this->flushStorageCache();
     }
 }

--- a/tests/Halcyon/Datasource/HalcyonDbTestHarness.php
+++ b/tests/Halcyon/Datasource/HalcyonDbTestHarness.php
@@ -97,11 +97,6 @@ class HalcyonDbTestHarness
 
     public static function clearStorageFileDatasourceCache(): void
     {
-        $reflection = new ReflectionClass(StorageFileDatasource::class);
-
-        foreach (['pathCache', 'mtimeCache', 'trashedPathCache'] as $propertyName) {
-            $property = $reflection->getProperty($propertyName);
-            $property->setValue(null, []);
-        }
+        StorageFileDatasource::flushAllStorageCaches();
     }
 }

--- a/tests/Halcyon/Datasource/HalcyonDbTestHarness.php
+++ b/tests/Halcyon/Datasource/HalcyonDbTestHarness.php
@@ -1,6 +1,7 @@
 <?php
 
 use October\Rain\Halcyon\Datasource\DbDatasource;
+use October\Rain\Halcyon\Datasource\StorageFileDatasource;
 
 class HalcyonDbTestHarness
 {
@@ -11,6 +12,50 @@ class HalcyonDbTestHarness
     protected static $savedFacadeApp;
 
     public static function boot(string $table): DbDatasource
+    {
+        self::bootCapsule();
+
+        $schema = self::$capsule->schema();
+        $schema->dropIfExists($table);
+        $schema->create($table, function ($table) {
+            $table->string('source');
+            $table->string('path');
+            $table->text('content')->nullable();
+            $table->integer('file_size')->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->timestamp('deleted_at')->nullable();
+        });
+
+        self::clearDbDatasourceCache();
+
+        return new DbDatasource('test-theme', $table);
+    }
+
+    /**
+     * bootStorageFilesTable creates a storage files table for testing
+     */
+    public static function bootStorageFilesTable(string $table): void
+    {
+        self::bootCapsule();
+
+        $schema = self::$capsule->schema();
+        $schema->dropIfExists($table);
+        $schema->create($table, function ($table) {
+            $table->string('source');
+            $table->string('path');
+            $table->text('content')->nullable();
+            $table->integer('file_size')->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->timestamp('deleted_at')->nullable();
+        });
+
+        self::clearStorageFileDatasourceCache();
+    }
+
+    /**
+     * bootCapsule for database tests
+     */
+    protected static function bootCapsule(): void
     {
         if (!self::$capsule) {
             self::$capsule = new Illuminate\Database\Capsule\Manager;
@@ -31,21 +76,6 @@ class HalcyonDbTestHarness
         $app = new Illuminate\Container\Container;
         $app->singleton('db', fn () => self::$capsule->getDatabaseManager());
         Illuminate\Support\Facades\Facade::setFacadeApplication($app);
-
-        $schema = self::$capsule->schema();
-        $schema->dropIfExists($table);
-        $schema->create($table, function ($table) {
-            $table->string('source');
-            $table->string('path');
-            $table->text('content')->nullable();
-            $table->integer('file_size')->nullable();
-            $table->timestamp('updated_at')->nullable();
-            $table->timestamp('deleted_at')->nullable();
-        });
-
-        self::clearDbDatasourceCache();
-
-        return new DbDatasource('test-theme', $table);
     }
 
     public static function teardown(): void
@@ -58,6 +88,16 @@ class HalcyonDbTestHarness
     public static function clearDbDatasourceCache(): void
     {
         $reflection = new ReflectionClass(DbDatasource::class);
+
+        foreach (['pathCache', 'mtimeCache', 'trashedPathCache'] as $propertyName) {
+            $property = $reflection->getProperty($propertyName);
+            $property->setValue(null, []);
+        }
+    }
+
+    public static function clearStorageFileDatasourceCache(): void
+    {
+        $reflection = new ReflectionClass(StorageFileDatasource::class);
 
         foreach (['pathCache', 'mtimeCache', 'trashedPathCache'] as $propertyName) {
             $property = $reflection->getProperty($propertyName);

--- a/tests/Halcyon/Datasource/StorageFileDatasourceTest.php
+++ b/tests/Halcyon/Datasource/StorageFileDatasourceTest.php
@@ -113,4 +113,39 @@ class StorageFileDatasourceTest extends TestCase
         $localPath = $this->autoDatasource->resolveLocalPath($this->dirName, $this->fileName, $this->extension);
         $this->assertSame($this->storagePath . '/assets/images/logo.png', $localPath);
     }
+
+    public function testOrphanMetadataFallsBackToFilesystem()
+    {
+        $this->storageDatasource->insert($this->dirName, $this->fileName, $this->extension, 'storage-content');
+        unlink($this->storagePath . '/assets/images/logo.png');
+
+        $filesystemContent = 'filesystem-content';
+        file_put_contents($this->themePath . '/assets/images/logo.png', $filesystemContent);
+
+        $this->assertFalse($this->storageDatasource->hasTemplate($this->dirName, $this->fileName, $this->extension));
+
+        $result = $this->autoDatasource->selectOne($this->dirName, $this->fileName, $this->extension);
+        $this->assertNotNull($result);
+        $this->assertSame($filesystemContent, $result['content']);
+    }
+
+    public function testSelectExcludesOrphanMetadata()
+    {
+        $this->storageDatasource->insert($this->dirName, $this->fileName, $this->extension, 'storage-content');
+        unlink($this->storagePath . '/assets/images/logo.png');
+
+        $results = $this->storageDatasource->select($this->dirName);
+        $this->assertSame([], $results);
+    }
+
+    public function testDirectoryListingDoesNotMatchPrefixCollision()
+    {
+        $this->storageDatasource->insert('assets', 'logo', 'png', 'logo-content');
+        $this->storageDatasource->insert('assets-backup', 'secret', 'png', 'secret-content');
+
+        $results = $this->storageDatasource->select('assets');
+        $fileNames = array_column($results, 'fileName');
+
+        $this->assertSame(['logo.png'], $fileNames);
+    }
 }

--- a/tests/Halcyon/Datasource/StorageFileDatasourceTest.php
+++ b/tests/Halcyon/Datasource/StorageFileDatasourceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+require_once __DIR__ . '/HalcyonDbTestHarness.php';
+
+use October\Rain\Filesystem\Filesystem;
+use October\Rain\Halcyon\Datasource\AutoDatasource;
+use October\Rain\Halcyon\Datasource\FileDatasource;
+use October\Rain\Halcyon\Datasource\StorageFileDatasource;
+
+class StorageFileDatasourceTest extends TestCase
+{
+    protected StorageFileDatasource $storageDatasource;
+
+    protected FileDatasource $fileDatasource;
+
+    protected AutoDatasource $autoDatasource;
+
+    protected string $themePath;
+
+    protected string $storagePath;
+
+    protected string $table = 'cms_theme_files_test';
+
+    protected string $dirName = 'assets/images';
+
+    protected string $fileName = 'logo';
+
+    protected string $extension = 'png';
+
+    public function setUp(): void
+    {
+        $this->bootStorageDatabase();
+
+        $this->themePath = sys_get_temp_dir() . '/halcyon-storagefile-test-theme-' . uniqid();
+        $this->storagePath = sys_get_temp_dir() . '/halcyon-storagefile-test-storage-' . uniqid();
+        mkdir($this->themePath . '/assets/images', 0755, true);
+        mkdir($this->storagePath, 0755, true);
+
+        $this->storageDatasource = new StorageFileDatasource(
+            'test-theme',
+            $this->table,
+            $this->storagePath,
+            new Filesystem
+        );
+
+        $this->fileDatasource = new FileDatasource($this->themePath, new Filesystem);
+        $this->autoDatasource = new AutoDatasource([$this->storageDatasource, $this->fileDatasource]);
+    }
+
+    public function tearDown(): void
+    {
+        HalcyonDbTestHarness::teardown();
+
+        $files = new Filesystem;
+        $files->deleteDirectory($this->themePath);
+        $files->deleteDirectory($this->storagePath);
+    }
+
+    protected function bootStorageDatabase(): void
+    {
+        HalcyonDbTestHarness::bootStorageFilesTable($this->table);
+    }
+
+    public function testInsertStoresFileOnDiskAndInDatabase()
+    {
+        $content = 'binary-image-data';
+        $this->storageDatasource->insert($this->dirName, $this->fileName, $this->extension, $content);
+
+        $diskPath = $this->storagePath . '/assets/images/logo.png';
+        $this->assertFileExists($diskPath);
+        $this->assertSame($content, file_get_contents($diskPath));
+        $this->assertTrue($this->storageDatasource->hasTemplate($this->dirName, $this->fileName, $this->extension));
+    }
+
+    public function testAutoDatasourcePrefersStorageLayer()
+    {
+        $filesystemContent = 'filesystem-content';
+        $storageContent = 'storage-content';
+
+        file_put_contents($this->themePath . '/assets/images/logo.png', $filesystemContent);
+        $this->storageDatasource->insert($this->dirName, $this->fileName, $this->extension, $storageContent);
+
+        $result = $this->autoDatasource->selectOne($this->dirName, $this->fileName, $this->extension);
+        $this->assertSame($storageContent, $result['content']);
+    }
+
+    public function testAutoDatasourceFallsBackToFilesystem()
+    {
+        $filesystemContent = 'filesystem-content';
+        file_put_contents($this->themePath . '/assets/images/logo.png', $filesystemContent);
+
+        $result = $this->autoDatasource->selectOne($this->dirName, $this->fileName, $this->extension);
+        $this->assertNotNull($result);
+        $this->assertSame($filesystemContent, $result['content']);
+    }
+
+    public function testSoftDeletedFilesystemFileIsHidden()
+    {
+        file_put_contents($this->themePath . '/assets/images/logo.png', 'filesystem-content');
+
+        $this->assertTrue($this->autoDatasource->hasTemplate($this->dirName, $this->fileName, $this->extension));
+
+        $this->autoDatasource->delete($this->dirName, $this->fileName, $this->extension);
+
+        $this->assertFalse($this->autoDatasource->hasTemplate($this->dirName, $this->fileName, $this->extension));
+        $this->assertTrue($this->storageDatasource->isTemplateTrashed($this->dirName, $this->fileName, $this->extension));
+    }
+
+    public function testResolveLocalPathReturnsStoragePath()
+    {
+        $this->storageDatasource->insert($this->dirName, $this->fileName, $this->extension, 'content');
+
+        $localPath = $this->autoDatasource->resolveLocalPath($this->dirName, $this->fileName, $this->extension);
+        $this->assertSame($this->storagePath . '/assets/images/logo.png', $localPath);
+    }
+}


### PR DESCRIPTION
### ⚠️ Work in progress

Issue: https://github.com/octobercms/october/issues/6062

## Summary

Adds a new Halcyon datasource for CMS theme assets (images, CSS, etc.) that stores file **content on disk** while tracking **metadata in the database**. This complements the existing `DbDatasource`, which stores template content in the database, and lets both datasources share one table by distinguishing record types via the nullable `content` column.

Also generalizes soft-delete/tombstone handling and path resolution across datasources, and hardens layered lookup so orphaned metadata or missing disk files do not block fallback to lower-priority sources.

## Motivation

October CMS themes can contain both Twig templates (text, DB-backed) and binary/static assets (disk-backed). The CMS needs:

- Database-backed metadata for assets (soft delete, listing, timestamps)
- Layered resolution: storage layer first, theme filesystem second
- Consistent tombstoning when a file exists only on a secondary datasource

`StorageFileDatasource` fills that gap without duplicating the full `DbDatasource` content-in-DB model.

## Changes

### New: `StorageFileDatasource`

Hybrid datasource that mirrors the `DbDatasource` API but:

- Writes file bytes to a configurable `storagePath` on disk
- Inserts/updates rows in a shared table with `content = null`, `file_size`, and timestamps
- Soft-deletes by setting `deleted_at` and removing the disk file (unless force-deleting)
- Supports `tombstone()` for paths with no active record (same pattern as `DbDatasource`)
- Caches paths, mtimes, and trashed paths per source (same pattern as `DbDatasource`)

Existence checks require **both** an active DB record and a file on disk (`hasTemplate`, `selectOne`, `select`), so stale metadata alone does not count as present.

### New interfaces

| Interface | Purpose |
|-----------|---------|
| `SoftDeleteDatasourceInterface` | `isTemplateTrashed`, `selectTrashedFileNames`, `tombstone` |
| `ResolvableDatasourceInterface` | `resolveLocalPath`, `resolvePublicUrl` |

`DbDatasource` now implements `SoftDeleteDatasourceInterface` instead of being referenced by type alone. `FileDatasource` implements `ResolvableDatasourceInterface` (local path only; no public URL).

### Shared table: templates vs files

Both datasources can use the same table. Queries are scoped by record type:

- **`DbDatasource`** — adds `whereNotNull('content')` (template rows)
- **`StorageFileDatasource`** — adds `whereNull('content')` (file metadata rows)

### `AutoDatasource` extensions

- **`selectOne` / `lastModified`** — fall through to the next datasource when the current one returns `null` (enables filesystem fallback when storage metadata is orphaned)
- **`hasTemplateAtIndex`** — check existence at a specific datasource index
- **`resolveLocalPath` / `resolvePublicUrl`** — delegate to the first matching `ResolvableDatasourceInterface`, respecting tombstones
- **`getSoftDeleteDatasource`** — replaces `getDbDatasource()` for trash/tombstone logic so `StorageFileDatasource` participates as the primary soft-delete source

### Hardening

- **`hasTemplate`** aligned with disk-backed `selectOne` (record + file both required)
- **Directory prefix matching** — `pathInDirectory` uses exact segment boundaries so `assets` does not match `assets-backup/...`
- **Orphan metadata** — DB row without disk file is ignored; `AutoDatasource` can fall back to `FileDatasource`
- **`select`** skips entries whose disk file is missing

## Files changed

| File | Change |
|------|--------|
| `src/Halcyon/Datasource/StorageFileDatasource.php` | New hybrid datasource |
| `src/Halcyon/Datasource/SoftDeleteDatasourceInterface.php` | New interface |
| `src/Halcyon/Datasource/ResolvableDatasourceInterface.php` | New interface |
| `src/Halcyon/Datasource/AutoDatasource.php` | Layered fallback, path resolution, soft-delete abstraction |
| `src/Halcyon/Datasource/DbDatasource.php` | Implements `SoftDeleteDatasourceInterface`; `whereNotNull('content')` |
| `src/Halcyon/Datasource/FileDatasource.php` | Implements `ResolvableDatasourceInterface` |
| `tests/Halcyon/Datasource/StorageFileDatasourceTest.php` | New integration tests |
| `tests/Halcyon/Datasource/HalcyonDbTestHarness.php` | Shared capsule boot, storage table helper, cache clearing |

## Basic usage

```php
use October\Rain\Halcyon\Datasource\AutoDatasource;
use October\Rain\Halcyon\Datasource\StorageFileDatasource;
use October\Rain\Halcyon\Datasource\FileDatasource;
use October\Rain\Halcyon\Datasource\DbDatasource;

$auto = new AutoDatasource([
    new DbDatasource('my-theme', 'cms_theme_templates'), // templates: content in DB
    new StorageFileDatasource('my-theme', 'cms_theme_templates', $storageRoot, $files), // assets: content on disk
    new FileDatasource($themePath, $files), // fallback: theme on disk
]);
```

Primary datasource order determines write target and soft-delete authority. Reads walk the stack until a datasource returns a result.
