### PR TITLE
Reconcile ClassLoader base path with the application base path

### DIFF
--- a/src/Foundation/Bootstrap/RegisterOctober.php
+++ b/src/Foundation/Bootstrap/RegisterOctober.php
@@ -97,6 +97,8 @@ class RegisterOctober
     {
         $loader = ClassLoader::instance();
 
+        $loader->basePath = $app->basePath();
+
         $loader->initManifest($app->getCachedClassesPath());
 
         $app->after(function () use ($loader) {


### PR DESCRIPTION
### Problem

`init/autoloader.php` configures the custom class loader with a base path derived from the autoloader file's own location:

```php
ClassLoader::configure(dirname(__DIR__, 4))
```

Because `__DIR__` is resolved through symlinks by PHP, this anchors `ClassLoader::$basePath` to the *physical* location of `vendor/`. When `vendor/` is a symlink (git worktrees, atomic-release deploy schemes that symlink `vendor` or a `current` release directory, and monorepo layouts), the base path points at a different checkout than the one the application was actually booted from.

The class loader resolves every plugin and module class relative to this base path (`isRealFilePath()`, `includeClass()`), so classes are silently loaded from the wrong checkout. Edits in the active checkout are never executed, which is especially damaging under test runners where it produces green suites against stale code.

The `Application` instance already carries the correct base path (set via `Application::configure(basePath: ...)`), but `configureClassLoader()` never propagates it to the loader. It only sets the manifest path.

### Fix

Set `$loader->basePath` from `$app->basePath()` during `configureClassLoader()`, so the loader honors the base path the application was booted with rather than the symlink-resolved vendor location.

### Impact

No behavior change in standard installs where `vendor/` is a real subdirectory (both values are identical). It only corrects setups where `vendor/` is symlinked or the application is booted from a path that differs from `vendor/`'s physical location.