### PR TITLE
Compile routes for matching and cache the compiled state

### DIFF
--- a/src/Router/README.md
+++ b/src/Router/README.md
@@ -39,3 +39,20 @@ You can also reverse match a route by it's identifier:
 // Returns: /post/2
 $url = $router->url('myRouteId', ['id' => 2]);
 ```
+
+## Compiled route caching
+
+Routes compile automatically on the first match into optimized lookup structures (a hash map for static routes and a combined regex for dynamic routes). The compiled state can be stored and restored to skip compilation entirely, similar to Laravel's route caching:
+
+```php
+// Store the routes with their compiled state
+$cached = $router->toArray();
+
+// Restore later, no recompilation needed
+$router = new Router;
+$router->fromArray($cached);
+
+// Alternatively, save to and load from a PHP file
+$router->saveCompiledRoutes('/path/to/routes.php');
+$router = Router::loadCompiledRoutes('/path/to/routes.php');
+```

--- a/src/Router/RouteCompiler.php
+++ b/src/Router/RouteCompiler.php
@@ -95,7 +95,11 @@ class RouteCompiler
 
         $dynamicRegexes = [];
         foreach ($patterns as $bucket => $branches) {
-            $dynamicRegexes[$bucket] = '#^(?|' . implode('|', $branches) . ')$#i';
+            // The u modifier keeps case-insensitive matching correct for
+            // multibyte (translated) static segments. URLs with invalid
+            // UTF-8 make preg_match fail, the router falls back to
+            // sequential matching for those.
+            $dynamicRegexes[$bucket] = '#^(?|' . implode('|', $branches) . ')$#iu';
         }
 
         return [

--- a/src/Router/RouteCompiler.php
+++ b/src/Router/RouteCompiler.php
@@ -1,0 +1,343 @@
+<?php namespace October\Rain\Router;
+
+/**
+ * RouteCompiler transforms route rules into optimized lookup structures
+ * for faster route matching using static hash maps and combined regexes.
+ *
+ * Uses the same approach as Laravel:
+ * - Static routes: Hash map for O(1) lookup
+ * - Dynamic routes: Combined regex with PCRE (*MARK) verb
+ * - Trailing slash normalization
+ *
+ * @package october\router
+ * @author Alexey Bobkov, Samuel Georges
+ */
+class RouteCompiler
+{
+    /**
+     * @var int COMPILED_VERSION for cache format versioning
+     */
+    const COMPILED_VERSION = 3;
+
+    /**
+     * compile transforms route rules into optimized lookup structures
+     * @param array $routeMap [ruleName => Rule]
+     * @return array Compiled route data
+     */
+    public static function compile(array $routeMap): array
+    {
+        // Sort routes first for consistent ordering
+        uasort($routeMap, [static::class, 'compareRules']);
+
+        // Extract wildcard routes (cannot be combined into regex)
+        [$wildcardRoutes, $remainingRoutes] = static::extractWildcardRoutes($routeMap);
+
+        // Build static route hash map (with trailing slash normalization)
+        [$staticRoutes, $dynamicRoutes] = static::buildStaticRoutes($remainingRoutes);
+
+        // Build combined regex for dynamic routes
+        $dynamicCompiled = static::buildCombinedRegex($dynamicRoutes);
+
+        return [
+            'version' => static::COMPILED_VERSION,
+            'staticRoutes' => $staticRoutes,
+            'dynamicRegex' => $dynamicCompiled['regex'],
+            'dynamicRouteMap' => $dynamicCompiled['routeMap'],
+            'wildcardRules' => array_keys($wildcardRoutes),
+        ];
+    }
+
+    /**
+     * compareRules sorts rules by specificity (static segments, wildcards, dynamic)
+     * @param Rule $a
+     * @param Rule $b
+     * @return int
+     */
+    protected static function compareRules(Rule $a, Rule $b): int
+    {
+        // More static segments = more specific = check first
+        if ($a->staticSegmentCount !== $b->staticSegmentCount) {
+            return $b->staticSegmentCount - $a->staticSegmentCount;
+        }
+
+        // Fewer wildcards = more specific = check first
+        if ($a->wildSegmentCount !== $b->wildSegmentCount) {
+            return $a->wildSegmentCount - $b->wildSegmentCount;
+        }
+
+        // Fewer dynamic segments = more specific = check first
+        return $a->dynamicSegmentCount - $b->dynamicSegmentCount;
+    }
+
+    /**
+     * extractWildcardRoutes separates routes with wildcard segments
+     * @param array $routeMap
+     * @return array [wildcardRoutes, remainingRoutes]
+     */
+    protected static function extractWildcardRoutes(array $routeMap): array
+    {
+        $wildcardRoutes = [];
+        $remainingRoutes = [];
+
+        foreach ($routeMap as $name => $rule) {
+            if ($rule->wildSegmentCount > 0) {
+                $wildcardRoutes[$name] = $rule;
+            }
+            else {
+                $remainingRoutes[$name] = $rule;
+            }
+        }
+
+        return [$wildcardRoutes, $remainingRoutes];
+    }
+
+    /**
+     * buildStaticRoutes extracts fully static routes into hash map
+     * Also handles trailing slash normalization (like Symfony)
+     * @param array $routeMap
+     * @return array [staticRoutes, dynamicRoutes]
+     */
+    protected static function buildStaticRoutes(array $routeMap): array
+    {
+        $staticRoutes = [];
+        $dynamicRoutes = [];
+
+        foreach ($routeMap as $name => $rule) {
+            if ($rule->dynamicSegmentCount === 0) {
+                // Fully static route - use lowercase for case-insensitive matching
+                $url = mb_strtolower(Helper::rebuildUrl($rule->segments));
+                $staticRoutes[$url] = $name;
+
+                // Also register with/without trailing slash for normalization
+                if ($url !== '/') {
+                    $withSlash = rtrim($url, '/') . '/';
+                    $withoutSlash = rtrim($url, '/');
+                    if (!isset($staticRoutes[$withSlash])) {
+                        $staticRoutes[$withSlash] = $name;
+                    }
+                    if (!isset($staticRoutes[$withoutSlash])) {
+                        $staticRoutes[$withoutSlash] = $name;
+                    }
+                }
+            }
+            else {
+                $dynamicRoutes[$name] = $rule;
+            }
+        }
+
+        return [$staticRoutes, $dynamicRoutes];
+    }
+
+    /**
+     * buildCombinedRegex creates a single regex from all dynamic routes
+     * Uses PCRE (*MARK:n) verb like Symfony for efficient route identification
+     * @param array $dynamicRoutes
+     * @param int $startIndex Starting index for route numbering (for chunking)
+     * @return array ['regex' => string|null, 'routeMap' => array]
+     */
+    protected static function buildCombinedRegex(array $dynamicRoutes, int $startIndex = 0): array
+    {
+        if (empty($dynamicRoutes)) {
+            return ['regex' => null, 'routeMap' => []];
+        }
+
+        $patterns = [];
+        $routeMap = [];
+        $index = $startIndex;
+
+        foreach ($dynamicRoutes as $name => $rule) {
+            $routePattern = static::ruleToRegex($rule, $index);
+
+            if ($routePattern !== null) {
+                $patterns[] = $routePattern['pattern'];
+                $routeMap[$index] = [
+                    'ruleName' => $name,
+                    'params' => $routePattern['params'],
+                    'defaults' => $routePattern['defaults'],
+                ];
+                $index++;
+            }
+        }
+
+        if (empty($patterns)) {
+            return ['regex' => null, 'routeMap' => []];
+        }
+
+        // Combine all patterns with alternation
+        // Using 'i' for case-insensitive, 'u' for UTF-8 support
+        $combinedRegex = '#^(?|' . implode('|', $patterns) . ')$#iu';
+
+        return ['regex' => $combinedRegex, 'routeMap' => $routeMap];
+    }
+
+    /**
+     * ruleToRegex converts a Rule to a regex pattern with (*MARK:n) verb
+     * @param Rule $rule
+     * @param int $routeIndex
+     * @return array|null ['pattern' => string, 'params' => array, 'defaults' => array]
+     */
+    protected static function ruleToRegex(Rule $rule, int $routeIndex): ?array
+    {
+        $segments = $rule->segments;
+        $regexParts = [];
+        $params = [];
+        $defaults = [];
+        $hasTrailingOptional = false;
+
+        // Process segments from end to detect trailing optionals
+        $segmentCount = count($segments);
+        $trailingOptionalCount = 0;
+
+        for ($i = $segmentCount - 1; $i >= 0; $i--) {
+            $segment = $segments[$i];
+            if (strpos($segment, ':') === 0 && Helper::segmentIsOptional($segment)) {
+                $trailingOptionalCount++;
+            }
+            else {
+                break;
+            }
+        }
+
+        // Build regex for each segment
+        foreach ($segments as $idx => $segment) {
+            // Static segment
+            if (strpos($segment, ':') !== 0) {
+                $regexParts[] = preg_quote($segment, '#');
+            }
+            // Dynamic segment
+            else {
+                $paramName = Helper::getParameterName($segment);
+                $params[] = $paramName;
+
+                // Get custom regex or use default
+                $customRegex = Helper::getSegmentRegExp($segment);
+                if ($customRegex) {
+                    // Extract inner pattern (remove delimiters and anchors)
+                    $innerPattern = trim($customRegex, '/');
+                    // Strip start/end anchors as they don't apply within combined regex
+                    $innerPattern = preg_replace('/^\^/', '', $innerPattern);
+                    $innerPattern = preg_replace('/\$$/', '', $innerPattern);
+                }
+                else {
+                    $innerPattern = '[^/]+';
+                }
+
+                // Capture group for parameter (unnamed, will use numeric index)
+                $groupPattern = "({$innerPattern})";
+
+                // Handle optional segments
+                $isOptional = Helper::segmentIsOptional($segment);
+                $isTrailingOptional = $isOptional && ($idx >= $segmentCount - $trailingOptionalCount);
+
+                if ($isOptional) {
+                    $default = Helper::getSegmentDefaultValue($segment);
+                    if ($default !== false) {
+                        $defaults[$paramName] = $default;
+                    }
+                    else {
+                        $defaults[$paramName] = null;
+                    }
+                }
+
+                if ($isTrailingOptional) {
+                    // Trailing optional - make the whole segment optional including leading slash
+                    $regexParts[] = "(?:/{$groupPattern})?";
+                    $hasTrailingOptional = true;
+                }
+                else {
+                    $regexParts[] = $groupPattern;
+                }
+            }
+        }
+
+        // Join with slashes, handling trailing optionals specially
+        if ($hasTrailingOptional) {
+            // Find where trailing optionals start
+            $mainParts = [];
+            $optionalParts = [];
+            $inOptional = false;
+
+            foreach ($regexParts as $part) {
+                if (strpos($part, '(?:/') === 0) {
+                    $inOptional = true;
+                }
+
+                if ($inOptional) {
+                    $optionalParts[] = $part;
+                }
+                else {
+                    $mainParts[] = $part;
+                }
+            }
+
+            // Handle case where all segments are optional (e.g., /:page?)
+            if (empty($mainParts)) {
+                // Convert first optional from (?:/X)? to /X? format to match root /
+                if (!empty($optionalParts)) {
+                    $first = array_shift($optionalParts);
+                    // Transform (?:/([^/]+))? to /([^/]+)?
+                    $first = preg_replace('#^\(\?:/(.+)\)\?$#', '/$1?', $first);
+                    $pattern = $first . implode('', $optionalParts);
+                }
+                else {
+                    $pattern = '/';
+                }
+            }
+            else {
+                $pattern = '/' . implode('/', $mainParts) . implode('', $optionalParts);
+            }
+        }
+        else {
+            $pattern = '/' . implode('/', $regexParts);
+        }
+
+        // Add (*MARK:n) verb to identify which route matched (like Symfony)
+        $pattern = $pattern . '(*MARK:' . $routeIndex . ')';
+
+        return [
+            'pattern' => $pattern,
+            'params' => $params,
+            'defaults' => $defaults,
+        ];
+    }
+
+    /**
+     * extractMatchedRoute extracts route index and parameters from regex match
+     * @param array $matches preg_match result
+     * @param array $routeMap compiled route map
+     * @return array|null [routeIndex, parameters]
+     */
+    public static function extractMatchedRoute(array $matches, array $routeMap): ?array
+    {
+        // Get route index from MARK (like Symfony)
+        if (!isset($matches['MARK'])) {
+            return null;
+        }
+
+        $matchedIndex = (int) $matches['MARK'];
+
+        if (!isset($routeMap[$matchedIndex])) {
+            return null;
+        }
+
+        $routeInfo = $routeMap[$matchedIndex];
+        $parameters = [];
+
+        // Extract parameter values from numeric capture groups
+        // Groups start at index 1 (0 is full match)
+        foreach ($routeInfo['params'] as $i => $paramName) {
+            $groupIndex = $i + 1;
+            if (isset($matches[$groupIndex]) && $matches[$groupIndex] !== '') {
+                $parameters[$paramName] = $matches[$groupIndex];
+            }
+            elseif (isset($routeInfo['defaults'][$paramName])) {
+                $parameters[$paramName] = $routeInfo['defaults'][$paramName];
+            }
+            else {
+                $parameters[$paramName] = false;
+            }
+        }
+
+        return [$matchedIndex, $parameters];
+    }
+}

--- a/src/Router/RouteCompiler.php
+++ b/src/Router/RouteCompiler.php
@@ -5,8 +5,9 @@
  * similar to Laravel's cached routes and Symfony's compiled URL matcher.
  *
  * - Fully static routes are collected in a hash map for O(1) lookup.
- * - Dynamic routes are combined into a single regular expression using the
- *   PCRE (*MARK) verb, so one preg_match call identifies the matched route.
+ * - Dynamic routes are combined into regexes bucketed by their first static
+ *   segment, using the PCRE (*MARK) verb so one preg_match call identifies
+ *   the matched route.
  * - Wildcard routes use capture logic that cannot be expressed in the
  *   combined regex, they are matched sequentially by the router.
  *
@@ -69,10 +70,18 @@ class RouteCompiler
                     $staticRoutes[$url] = ['name' => $name, 'position' => $position];
                 }
             }
-            // Dynamic rule, becomes a branch in the combined regex
+            // Dynamic rule, becomes a branch in a combined regex. Rules are
+            // bucketed by their first static segment so matching only scans
+            // routes that share the URL's first segment.
             else {
                 $compiled = static::compileRulePattern($rule);
-                $patterns[] = $compiled['pattern'] . '(*MARK:' . $index . ')';
+
+                $firstSegment = $rule->segments[0] ?? '';
+                $bucket = strpos($firstSegment, ':') !== 0
+                    ? mb_strtolower($firstSegment)
+                    : '';
+
+                $patterns[$bucket][] = $compiled['pattern'] . '(*MARK:' . $index . ')';
                 $dynamicRouteMap[$index] = [
                     'name' => $name,
                     'position' => $position,
@@ -84,12 +93,15 @@ class RouteCompiler
             $position++;
         }
 
+        $dynamicRegexes = [];
+        foreach ($patterns as $bucket => $branches) {
+            $dynamicRegexes[$bucket] = '#^(?|' . implode('|', $branches) . ')$#i';
+        }
+
         return [
             'version' => static::COMPILED_VERSION,
             'staticRoutes' => $staticRoutes,
-            'dynamicRegex' => $patterns
-                ? '#^(?|' . implode('|', $patterns) . ')$#i'
-                : null,
+            'dynamicRegexes' => $dynamicRegexes,
             'dynamicRouteMap' => $dynamicRouteMap,
             'fallbackRules' => $fallbackRules,
         ];

--- a/src/Router/RouteCompiler.php
+++ b/src/Router/RouteCompiler.php
@@ -1,13 +1,22 @@
 <?php namespace October\Rain\Router;
 
 /**
- * RouteCompiler transforms route rules into optimized lookup structures
- * for faster route matching using static hash maps and combined regexes.
+ * RouteCompiler transforms route rules into optimized lookup structures,
+ * similar to Laravel's cached routes and Symfony's compiled URL matcher.
  *
- * Uses the same approach as Laravel:
- * - Static routes: Hash map for O(1) lookup
- * - Dynamic routes: Combined regex with PCRE (*MARK) verb
- * - Trailing slash normalization
+ * - Fully static routes are collected in a hash map for O(1) lookup.
+ * - Dynamic routes are combined into a single regular expression using the
+ *   PCRE (*MARK) verb, so one preg_match call identifies the matched route.
+ * - Wildcard routes use capture logic that cannot be expressed in the
+ *   combined regex, they are matched sequentially by the router.
+ *
+ * Custom segment expressions (:param|^regex$) are intentionally not inlined
+ * in the combined regex. They are validated after the structural match using
+ * the same logic as Rule::resolveUrlSegments, preserving their original
+ * semantics (case sensitivity, substring search, error tolerance).
+ *
+ * The route map must be sorted (see Router::sortRules) before compiling,
+ * positions recorded here refer to offsets in the sorted route map.
  *
  * @package october\router
  * @author Alexey Bobkov, Samuel Georges
@@ -15,329 +24,136 @@
 class RouteCompiler
 {
     /**
-     * @var int COMPILED_VERSION for cache format versioning
+     * @var int COMPILED_VERSION invalidates cached compiled data when the format changes
      */
-    const COMPILED_VERSION = 3;
+    const COMPILED_VERSION = 1;
 
     /**
      * compile transforms route rules into optimized lookup structures
-     * @param array $routeMap [ruleName => Rule]
-     * @return array Compiled route data
+     * @param array $routeMap [ruleName => Rule] in matching (sorted) order
+     * @return array
      */
     public static function compile(array $routeMap): array
     {
-        // Sort routes first for consistent ordering
-        uasort($routeMap, [static::class, 'compareRules']);
+        $staticRoutes = [];
+        $patterns = [];
+        $dynamicRouteMap = [];
+        $fallbackRules = [];
+        $position = 0;
+        $index = 0;
 
-        // Extract wildcard routes (cannot be combined into regex)
-        [$wildcardRoutes, $remainingRoutes] = static::extractWildcardRoutes($routeMap);
+        foreach ($routeMap as $name => $rule) {
+            // Wildcard rules keep the original sequential matching. The
+            // leading static segments are stored so the router can skip the
+            // rule cheaply when they cannot match.
+            if ($rule->wildSegmentCount > 0) {
+                $prefix = [];
+                foreach ($rule->segments as $segment) {
+                    if (strpos($segment, ':') === 0) {
+                        break;
+                    }
+                    $prefix[] = mb_strtolower($segment);
+                }
 
-        // Build static route hash map (with trailing slash normalization)
-        [$staticRoutes, $dynamicRoutes] = static::buildStaticRoutes($remainingRoutes);
+                $fallbackRules[] = [
+                    'name' => $name,
+                    'position' => $position,
+                    'prefix' => $prefix,
+                ];
+            }
+            // Fully static rule, hash map lookup. The first rule wins,
+            // matching sequential behavior.
+            elseif ($rule->dynamicSegmentCount === 0) {
+                $url = mb_strtolower('/' . implode('/', $rule->segments));
+                if (!isset($staticRoutes[$url])) {
+                    $staticRoutes[$url] = ['name' => $name, 'position' => $position];
+                }
+            }
+            // Dynamic rule, becomes a branch in the combined regex
+            else {
+                $compiled = static::compileRulePattern($rule);
+                $patterns[] = $compiled['pattern'] . '(*MARK:' . $index . ')';
+                $dynamicRouteMap[$index] = [
+                    'name' => $name,
+                    'position' => $position,
+                    'params' => $compiled['params'],
+                ];
+                $index++;
+            }
 
-        // Build combined regex for dynamic routes
-        $dynamicCompiled = static::buildCombinedRegex($dynamicRoutes);
+            $position++;
+        }
 
         return [
             'version' => static::COMPILED_VERSION,
             'staticRoutes' => $staticRoutes,
-            'dynamicRegex' => $dynamicCompiled['regex'],
-            'dynamicRouteMap' => $dynamicCompiled['routeMap'],
-            'wildcardRules' => array_keys($wildcardRoutes),
+            'dynamicRegex' => $patterns
+                ? '#^(?|' . implode('|', $patterns) . ')$#i'
+                : null,
+            'dynamicRouteMap' => $dynamicRouteMap,
+            'fallbackRules' => $fallbackRules,
         ];
     }
 
     /**
-     * compareRules sorts rules by specificity (static segments, wildcards, dynamic)
-     * @param Rule $a
-     * @param Rule $b
-     * @return int
-     */
-    protected static function compareRules(Rule $a, Rule $b): int
-    {
-        // More static segments = more specific = check first
-        if ($a->staticSegmentCount !== $b->staticSegmentCount) {
-            return $b->staticSegmentCount - $a->staticSegmentCount;
-        }
-
-        // Fewer wildcards = more specific = check first
-        if ($a->wildSegmentCount !== $b->wildSegmentCount) {
-            return $a->wildSegmentCount - $b->wildSegmentCount;
-        }
-
-        // Fewer dynamic segments = more specific = check first
-        return $a->dynamicSegmentCount - $b->dynamicSegmentCount;
-    }
-
-    /**
-     * extractWildcardRoutes separates routes with wildcard segments
-     * @param array $routeMap
-     * @return array [wildcardRoutes, remainingRoutes]
-     */
-    protected static function extractWildcardRoutes(array $routeMap): array
-    {
-        $wildcardRoutes = [];
-        $remainingRoutes = [];
-
-        foreach ($routeMap as $name => $rule) {
-            if ($rule->wildSegmentCount > 0) {
-                $wildcardRoutes[$name] = $rule;
-            }
-            else {
-                $remainingRoutes[$name] = $rule;
-            }
-        }
-
-        return [$wildcardRoutes, $remainingRoutes];
-    }
-
-    /**
-     * buildStaticRoutes extracts fully static routes into hash map
-     * Also handles trailing slash normalization (like Symfony)
-     * @param array $routeMap
-     * @return array [staticRoutes, dynamicRoutes]
-     */
-    protected static function buildStaticRoutes(array $routeMap): array
-    {
-        $staticRoutes = [];
-        $dynamicRoutes = [];
-
-        foreach ($routeMap as $name => $rule) {
-            if ($rule->dynamicSegmentCount === 0) {
-                // Fully static route - use lowercase for case-insensitive matching
-                $url = mb_strtolower(Helper::rebuildUrl($rule->segments));
-                $staticRoutes[$url] = $name;
-
-                // Also register with/without trailing slash for normalization
-                if ($url !== '/') {
-                    $withSlash = rtrim($url, '/') . '/';
-                    $withoutSlash = rtrim($url, '/');
-                    if (!isset($staticRoutes[$withSlash])) {
-                        $staticRoutes[$withSlash] = $name;
-                    }
-                    if (!isset($staticRoutes[$withoutSlash])) {
-                        $staticRoutes[$withoutSlash] = $name;
-                    }
-                }
-            }
-            else {
-                $dynamicRoutes[$name] = $rule;
-            }
-        }
-
-        return [$staticRoutes, $dynamicRoutes];
-    }
-
-    /**
-     * buildCombinedRegex creates a single regex from all dynamic routes
-     * Uses PCRE (*MARK:n) verb like Symfony for efficient route identification
-     * @param array $dynamicRoutes
-     * @param int $startIndex Starting index for route numbering (for chunking)
-     * @return array ['regex' => string|null, 'routeMap' => array]
-     */
-    protected static function buildCombinedRegex(array $dynamicRoutes, int $startIndex = 0): array
-    {
-        if (empty($dynamicRoutes)) {
-            return ['regex' => null, 'routeMap' => []];
-        }
-
-        $patterns = [];
-        $routeMap = [];
-        $index = $startIndex;
-
-        foreach ($dynamicRoutes as $name => $rule) {
-            $routePattern = static::ruleToRegex($rule, $index);
-
-            if ($routePattern !== null) {
-                $patterns[] = $routePattern['pattern'];
-                $routeMap[$index] = [
-                    'ruleName' => $name,
-                    'params' => $routePattern['params'],
-                    'defaults' => $routePattern['defaults'],
-                ];
-                $index++;
-            }
-        }
-
-        if (empty($patterns)) {
-            return ['regex' => null, 'routeMap' => []];
-        }
-
-        // Combine all patterns with alternation
-        // Using 'i' for case-insensitive, 'u' for UTF-8 support
-        $combinedRegex = '#^(?|' . implode('|', $patterns) . ')$#iu';
-
-        return ['regex' => $combinedRegex, 'routeMap' => $routeMap];
-    }
-
-    /**
-     * ruleToRegex converts a Rule to a regex pattern with (*MARK:n) verb
+     * compileRulePattern converts a rule to a regex branch with parameter metadata.
+     * Segments with custom expressions match as generic segments ([^/]+) and are
+     * validated after the match, so the combined regex never embeds user patterns.
      * @param Rule $rule
-     * @param int $routeIndex
-     * @return array|null ['pattern' => string, 'params' => array, 'defaults' => array]
+     * @return array ['pattern' => string, 'params' => array]
      */
-    protected static function ruleToRegex(Rule $rule, int $routeIndex): ?array
+    protected static function compileRulePattern(Rule $rule): array
     {
         $segments = $rule->segments;
-        $regexParts = [];
-        $params = [];
-        $defaults = [];
-        $hasTrailingOptional = false;
-
-        // Process segments from end to detect trailing optionals
         $segmentCount = count($segments);
-        $trailingOptionalCount = 0;
 
+        // Count trailing optional segments. An optional segment followed by a
+        // required segment is treated as required, same as Rule::resolveUrlSegments.
+        $trailingOptionals = 0;
         for ($i = $segmentCount - 1; $i >= 0; $i--) {
-            $segment = $segments[$i];
-            if (strpos($segment, ':') === 0 && Helper::segmentIsOptional($segment)) {
-                $trailingOptionalCount++;
+            if (strpos($segments[$i], ':') === 0 && Helper::segmentIsOptional($segments[$i])) {
+                $trailingOptionals++;
             }
             else {
                 break;
             }
         }
 
-        // Build regex for each segment
-        foreach ($segments as $idx => $segment) {
+        $pattern = '';
+        $params = [];
+
+        foreach ($segments as $index => $segment) {
             // Static segment
             if (strpos($segment, ':') !== 0) {
-                $regexParts[] = preg_quote($segment, '#');
+                $pattern .= '/' . preg_quote($segment, '#');
+                continue;
             }
+
             // Dynamic segment
-            else {
-                $paramName = Helper::getParameterName($segment);
-                $params[] = $paramName;
+            $isTrailingOptional = $index >= $segmentCount - $trailingOptionals;
+            $regexp = Helper::getSegmentRegExp($segment);
 
-                // Get custom regex or use default
-                $customRegex = Helper::getSegmentRegExp($segment);
-                if ($customRegex) {
-                    // Extract inner pattern (remove delimiters and anchors)
-                    $innerPattern = trim($customRegex, '/');
-                    // Strip start/end anchors as they don't apply within combined regex
-                    $innerPattern = preg_replace('/^\^/', '', $innerPattern);
-                    $innerPattern = preg_replace('/\$$/', '', $innerPattern);
-                }
-                else {
-                    $innerPattern = '[^/]+';
-                }
+            $params[] = [
+                'name' => Helper::getParameterName($segment),
+                'regex' => $regexp !== false ? $regexp : null,
+                'default' => $isTrailingOptional
+                    ? Helper::getSegmentDefaultValue($segment)
+                    : false,
+            ];
 
-                // Capture group for parameter (unnamed, will use numeric index)
-                $groupPattern = "({$innerPattern})";
-
-                // Handle optional segments
-                $isOptional = Helper::segmentIsOptional($segment);
-                $isTrailingOptional = $isOptional && ($idx >= $segmentCount - $trailingOptionalCount);
-
-                if ($isOptional) {
-                    $default = Helper::getSegmentDefaultValue($segment);
-                    if ($default !== false) {
-                        $defaults[$paramName] = $default;
-                    }
-                    else {
-                        $defaults[$paramName] = null;
-                    }
-                }
-
-                if ($isTrailingOptional) {
-                    // Trailing optional - make the whole segment optional including leading slash
-                    $regexParts[] = "(?:/{$groupPattern})?";
-                    $hasTrailingOptional = true;
-                }
-                else {
-                    $regexParts[] = $groupPattern;
-                }
+            if (!$isTrailingOptional) {
+                $pattern .= '/([^/]+)';
             }
-        }
-
-        // Join with slashes, handling trailing optionals specially
-        if ($hasTrailingOptional) {
-            // Find where trailing optionals start
-            $mainParts = [];
-            $optionalParts = [];
-            $inOptional = false;
-
-            foreach ($regexParts as $part) {
-                if (strpos($part, '(?:/') === 0) {
-                    $inOptional = true;
-                }
-
-                if ($inOptional) {
-                    $optionalParts[] = $part;
-                }
-                else {
-                    $mainParts[] = $part;
-                }
-            }
-
-            // Handle case where all segments are optional (e.g., /:page?)
-            if (empty($mainParts)) {
-                // Convert first optional from (?:/X)? to /X? format to match root /
-                if (!empty($optionalParts)) {
-                    $first = array_shift($optionalParts);
-                    // Transform (?:/([^/]+))? to /([^/]+)?
-                    $first = preg_replace('#^\(\?:/(.+)\)\?$#', '/$1?', $first);
-                    $pattern = $first . implode('', $optionalParts);
-                }
-                else {
-                    $pattern = '/';
-                }
+            elseif ($pattern === '') {
+                // Rule starts with an optional segment, it must still match
+                // the root URL (/)
+                $pattern .= '/([^/]+)?';
             }
             else {
-                $pattern = '/' . implode('/', $mainParts) . implode('', $optionalParts);
-            }
-        }
-        else {
-            $pattern = '/' . implode('/', $regexParts);
-        }
-
-        // Add (*MARK:n) verb to identify which route matched (like Symfony)
-        $pattern = $pattern . '(*MARK:' . $routeIndex . ')';
-
-        return [
-            'pattern' => $pattern,
-            'params' => $params,
-            'defaults' => $defaults,
-        ];
-    }
-
-    /**
-     * extractMatchedRoute extracts route index and parameters from regex match
-     * @param array $matches preg_match result
-     * @param array $routeMap compiled route map
-     * @return array|null [routeIndex, parameters]
-     */
-    public static function extractMatchedRoute(array $matches, array $routeMap): ?array
-    {
-        // Get route index from MARK (like Symfony)
-        if (!isset($matches['MARK'])) {
-            return null;
-        }
-
-        $matchedIndex = (int) $matches['MARK'];
-
-        if (!isset($routeMap[$matchedIndex])) {
-            return null;
-        }
-
-        $routeInfo = $routeMap[$matchedIndex];
-        $parameters = [];
-
-        // Extract parameter values from numeric capture groups
-        // Groups start at index 1 (0 is full match)
-        foreach ($routeInfo['params'] as $i => $paramName) {
-            $groupIndex = $i + 1;
-            if (isset($matches[$groupIndex]) && $matches[$groupIndex] !== '') {
-                $parameters[$paramName] = $matches[$groupIndex];
-            }
-            elseif (isset($routeInfo['defaults'][$paramName])) {
-                $parameters[$paramName] = $routeInfo['defaults'][$paramName];
-            }
-            else {
-                $parameters[$paramName] = false;
+                $pattern .= '(?:/([^/]+))?';
             }
         }
 
-        return [$matchedIndex, $parameters];
+        return ['pattern' => $pattern, 'params' => $params];
     }
 }

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -589,10 +589,21 @@ class Router
             return $this;
         }
 
-        $this->staticRoutes = $compiled['staticRoutes'] ?? [];
-        $this->dynamicRegexes = $compiled['dynamicRegexes'] ?? [];
-        $this->dynamicRouteMap = $compiled['dynamicRouteMap'] ?? [];
-        $this->fallbackRules = $compiled['fallbackRules'] ?? [];
+        // Reject torn or corrupted payloads, e.g. from a concurrent cache
+        // write, the routes recompile on the next match instead
+        if (
+            !is_array($compiled['staticRoutes'] ?? null) ||
+            !is_array($compiled['dynamicRegexes'] ?? null) ||
+            !is_array($compiled['dynamicRouteMap'] ?? null) ||
+            !is_array($compiled['fallbackRules'] ?? null)
+        ) {
+            return $this;
+        }
+
+        $this->staticRoutes = $compiled['staticRoutes'];
+        $this->dynamicRegexes = $compiled['dynamicRegexes'];
+        $this->dynamicRouteMap = $compiled['dynamicRouteMap'];
+        $this->fallbackRules = $compiled['fallbackRules'];
         $this->isCompiled = true;
 
         return $this;

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -92,9 +92,11 @@ class Router
 
         $segments = Helper::segmentizeUrl($url, false);
         $plainUrl = '/' . implode('/', $segments);
+        $lowerUrl = mb_strtolower($plainUrl);
+        $lowerSegments = $segments ? explode('/', substr($lowerUrl, 1)) : [];
 
         // Static route lookup
-        $static = $this->staticRoutes[mb_strtolower($plainUrl)] ?? null;
+        $static = $this->staticRoutes[$lowerUrl] ?? null;
         if ($static !== null) {
             $routeRule = $this->ruleObject($static['name']);
             if ($routeRule && $this->acceptRuleMatch($routeRule, [], $url)) {
@@ -112,7 +114,7 @@ class Router
         // are both checked, the earliest sorted match wins.
         $candidate = null;
         if ($this->dynamicRegexes) {
-            $buckets = isset($segments[0]) ? [mb_strtolower($segments[0]), ''] : [''];
+            $buckets = $lowerSegments ? [$lowerSegments[0], ''] : [''];
 
             foreach ($buckets as $bucket) {
                 if (!isset($this->dynamicRegexes[$bucket])) {
@@ -138,35 +140,29 @@ class Router
 
         // Wildcard rules are matched sequentially. Only those that outrank
         // the dynamic candidate in the sorted route map are considered first.
-        if ($this->fallbackRules) {
-            $lowerSegments = $segments
-                ? explode('/', substr(mb_strtolower($plainUrl), 1))
-                : [];
+        foreach ($this->fallbackRules as $fallback) {
+            if ($candidate !== null && $fallback['position'] > $candidate['position']) {
+                break;
+            }
 
-            foreach ($this->fallbackRules as $fallback) {
-                if ($candidate !== null && $fallback['position'] > $candidate['position']) {
-                    break;
+            // The leading static segments must match for the rule to apply
+            foreach ($fallback['prefix'] as $index => $staticSegment) {
+                if (($lowerSegments[$index] ?? null) !== $staticSegment) {
+                    continue 2;
                 }
+            }
 
-                // The leading static segments must match for the rule to apply
-                foreach ($fallback['prefix'] as $index => $staticSegment) {
-                    if (($lowerSegments[$index] ?? null) !== $staticSegment) {
-                        continue 2;
-                    }
-                }
+            $routeRule = $this->ruleObject($fallback['name']);
+            if (!$routeRule) {
+                continue;
+            }
 
-                $routeRule = $this->ruleObject($fallback['name']);
-                if (!$routeRule) {
-                    continue;
-                }
-
-                $parameters = [];
-                if (
-                    $routeRule->resolveUrlSegments($segments, $parameters) &&
-                    $this->acceptRuleMatch($routeRule, $parameters, $url)
-                ) {
-                    return true;
-                }
+            $parameters = [];
+            if (
+                $routeRule->resolveUrlSegments($segments, $parameters) &&
+                $this->acceptRuleMatch($routeRule, $parameters, $url)
+            ) {
+                return true;
             }
         }
 
@@ -649,6 +645,8 @@ class Router
      */
     public function toArray()
     {
+        // Compiling sorts the route map, it must happen before the rules
+        // are exported so their order matches the compiled positions
         $compiled = $this->getCompiledRoutes();
 
         $rules = [];

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -1,7 +1,15 @@
 <?php namespace October\Rain\Router;
 
+use Exception;
+
 /**
  * Router used in October CMS for managing page routes.
+ *
+ * Matching uses compiled lookup structures (see RouteCompiler): a hash map
+ * for static routes, a combined regex for dynamic routes and sequential
+ * matching for wildcard routes. Compilation happens lazily on the first
+ * match and sorts the route map by specificity (see sortRules), the compiled
+ * result can be cached and restored via toArray/fromArray.
  *
  * @package october\router
  * @author Alexey Bobkov, Samuel Georges
@@ -44,26 +52,28 @@ class Router
     protected $dynamicRegex = null;
 
     /**
-     * @var array dynamicRouteMap maps regex group index to route info
+     * @var array dynamicRouteMap maps a combined regex mark to route info
      */
     protected $dynamicRouteMap = [];
 
     /**
-     * @var array wildcardRules ordered list of wildcard route rule names
+     * @var array fallbackRules are rules matched sequentially (wildcard rules),
+     * each with the position they hold in the sorted route map
      */
-    protected $wildcardRules = [];
+    protected $fallbackRules = [];
 
     /**
      * route registers a new route rule
      */
     public function route($name, $route)
     {
-        $this->invalidate();
+        $this->invalidateCompiled();
+
         return $this->routeMap[$name] = Rule::fromPattern($name, $route);
     }
 
     /**
-     * match given URL string using compiled route matching for performance
+     * match given URL string
      * @param string $url Request URL to match for
      * @return bool
      */
@@ -73,161 +83,113 @@ class Router
         $this->matchedRouteRule = null;
         $this->parameters = [];
 
-        // Compile routes on first match if not already compiled
         if (!$this->isCompiled) {
-            $this->compile();
+            $this->compileRules();
         }
 
-        $normalizedUrl = Helper::normalizeUrl($url);
+        $segments = Helper::segmentizeUrl($url, false);
+        $plainUrl = '/' . implode('/', $segments);
 
-        // Tier 1: Try static route lookup (O(1))
-        if ($this->matchStatic($normalizedUrl)) {
-            return true;
+        // Static route lookup
+        $static = $this->staticRoutes[mb_strtolower($plainUrl)] ?? null;
+        if ($static !== null) {
+            $routeRule = $this->routeMap[$static['name']] ?? null;
+            if ($routeRule && $this->acceptRuleMatch($routeRule, [], $url)) {
+                return true;
+            }
+
+            // The condition callback rejected the match, continue with the
+            // rules that follow, like sequential matching does
+            return $this->matchFromPosition($segments, $url, $static['position'] + 1);
         }
 
-        // Tier 2: Try combined regex for dynamic routes (O(1))
-        if ($this->matchDynamic($normalizedUrl)) {
-            return true;
+        // Dynamic route lookup, a single combined regex identifies the
+        // matched route using the (*MARK) verb
+        $candidate = null;
+        if ($this->dynamicRegex !== null) {
+            $result = @preg_match($this->dynamicRegex, $plainUrl, $matches);
+
+            // Regex engine failure (e.g. backtrack limit), fall back to
+            // sequential matching
+            if ($result === false) {
+                return $this->matchFromPosition($segments, $url, 0);
+            }
+
+            if ($result === 1) {
+                $candidate = $this->extractDynamicCandidate($matches);
+            }
         }
 
-        // Tier 3: Try wildcard routes sequentially (O(w))
-        if ($this->matchWildcard($url)) {
-            return true;
+        // Wildcard rules are matched sequentially. Only those that outrank
+        // the dynamic candidate in the sorted route map are considered first.
+        if ($this->fallbackRules) {
+            $lowerSegments = $segments
+                ? explode('/', substr(mb_strtolower($plainUrl), 1))
+                : [];
+
+            foreach ($this->fallbackRules as $fallback) {
+                if ($candidate !== null && $fallback['position'] > $candidate['position']) {
+                    break;
+                }
+
+                // The leading static segments must match for the rule to apply
+                foreach ($fallback['prefix'] as $index => $staticSegment) {
+                    if (($lowerSegments[$index] ?? null) !== $staticSegment) {
+                        continue 2;
+                    }
+                }
+
+                $routeRule = $this->routeMap[$fallback['name']] ?? null;
+                if (!$routeRule) {
+                    continue;
+                }
+
+                $parameters = [];
+                if (
+                    $routeRule->resolveUrlSegments($segments, $parameters) &&
+                    $this->acceptRuleMatch($routeRule, $parameters, $url)
+                ) {
+                    return true;
+                }
+            }
+        }
+
+        if ($candidate !== null) {
+            if ($candidate['valid']) {
+                $routeRule = $this->routeMap[$candidate['name']] ?? null;
+                if ($routeRule && $this->acceptRuleMatch($routeRule, $candidate['parameters'], $url)) {
+                    return true;
+                }
+            }
+
+            // A custom segment expression or condition callback rejected the
+            // candidate, continue with the rules that follow
+            return $this->matchFromPosition($segments, $url, $candidate['position'] + 1);
         }
 
         return false;
     }
 
     /**
-     * matchStatic attempts O(1) static route lookup
-     * @param string $normalizedUrl
-     * @return bool
-     */
-    protected function matchStatic($normalizedUrl)
-    {
-        $urlLower = mb_strtolower($normalizedUrl);
-
-        if (!isset($this->staticRoutes[$urlLower])) {
-            return false;
-        }
-
-        $ruleName = $this->staticRoutes[$urlLower];
-        if (!isset($this->routeMap[$ruleName])) {
-            return false;
-        }
-
-        $routeRule = $this->routeMap[$ruleName];
-        $parameters = [];
-
-        // Check condition callback
-        $callback = $routeRule->condition();
-        if ($callback !== null) {
-            $callbackResult = call_user_func($callback, $parameters, $normalizedUrl);
-            if ($callbackResult === false) {
-                return false;
-            }
-        }
-
-        $this->matchedRouteRule = $routeRule;
-
-        // Run afterMatch callback
-        $matchCallback = $routeRule->afterMatch();
-        if ($matchCallback !== null) {
-            $parameters = call_user_func($matchCallback, $parameters, $normalizedUrl);
-        }
-
-        $this->parameters = $parameters;
-        return true;
-    }
-
-    /**
-     * matchDynamic attempts combined regex match for dynamic routes
-     * @param string $normalizedUrl
-     * @return bool
-     */
-    protected function matchDynamic($normalizedUrl)
-    {
-        if ($this->dynamicRegex === null) {
-            return false;
-        }
-
-        if (!preg_match($this->dynamicRegex, $normalizedUrl, $matches)) {
-            return false;
-        }
-
-        // Extract matched route and parameters
-        $result = RouteCompiler::extractMatchedRoute($matches, $this->dynamicRouteMap);
-        if ($result === null) {
-            return false;
-        }
-
-        [$routeIndex, $parameters] = $result;
-        $ruleName = $this->dynamicRouteMap[$routeIndex]['ruleName'];
-
-        if (!isset($this->routeMap[$ruleName])) {
-            return false;
-        }
-
-        $routeRule = $this->routeMap[$ruleName];
-
-        // Check condition callback
-        $callback = $routeRule->condition();
-        if ($callback !== null) {
-            $callbackResult = call_user_func($callback, $parameters, $normalizedUrl);
-            if ($callbackResult === false) {
-                return false;
-            }
-        }
-
-        $this->matchedRouteRule = $routeRule;
-
-        // Run afterMatch callback
-        $matchCallback = $routeRule->afterMatch();
-        if ($matchCallback !== null) {
-            $parameters = call_user_func($matchCallback, $parameters, $normalizedUrl);
-        }
-
-        $this->parameters = $parameters;
-        return true;
-    }
-
-    /**
-     * matchWildcard attempts sequential wildcard route matching
+     * matchFromPosition matches sequentially starting from a position in the
+     * sorted route map, used when compiled matching rejects a candidate
+     * @param array $segments
      * @param string $url
+     * @param int $position
      * @return bool
      */
-    protected function matchWildcard($url)
+    protected function matchFromPosition($segments, $url, $position)
     {
-        $segments = Helper::segmentizeUrl($url, false);
-        $normalizedUrl = Helper::normalizeUrl($url);
+        $rules = $position > 0
+            ? array_slice($this->routeMap, $position)
+            : $this->routeMap;
 
-        foreach ($this->wildcardRules as $ruleName) {
-            if (!isset($this->routeMap[$ruleName])) {
-                continue;
-            }
-
-            $routeRule = $this->routeMap[$ruleName];
+        foreach ($rules as $routeRule) {
             $parameters = [];
-
-            if ($routeRule->resolveUrlSegments($segments, $parameters)) {
-                // Check condition callback
-                $callback = $routeRule->condition();
-                if ($callback !== null) {
-                    $callbackResult = call_user_func($callback, $parameters, $normalizedUrl);
-                    if ($callbackResult === false) {
-                        continue;
-                    }
-                }
-
-                $this->matchedRouteRule = $routeRule;
-
-                // Run afterMatch callback
-                $matchCallback = $routeRule->afterMatch();
-                if ($matchCallback !== null) {
-                    $parameters = call_user_func($matchCallback, $parameters, $url);
-                }
-
-                $this->parameters = $parameters;
+            if (
+                $routeRule->resolveUrlSegments($segments, $parameters) &&
+                $this->acceptRuleMatch($routeRule, $parameters, $url)
+            ) {
                 return true;
             }
         }
@@ -236,33 +198,90 @@ class Router
     }
 
     /**
-     * compile builds optimized lookup structures for all registered routes
-     * @return $this
+     * acceptRuleMatch runs the rule condition, stores the matched rule and
+     * processed parameters. Returns false when the condition rejects the match.
+     * @param Rule $routeRule
+     * @param array $parameters
+     * @param string $url
+     * @return bool
      */
-    public function compile()
+    protected function acceptRuleMatch($routeRule, $parameters, $url)
     {
-        $compiled = RouteCompiler::compile($this->routeMap);
+        // If this route has a condition, run it
+        $callback = $routeRule->condition();
+        if ($callback !== null) {
+            $callbackResult = call_user_func($callback, $parameters, Helper::normalizeUrl($url));
 
-        $this->staticRoutes = $compiled['staticRoutes'];
-        $this->dynamicRegex = $compiled['dynamicRegex'];
-        $this->dynamicRouteMap = $compiled['dynamicRouteMap'];
-        $this->wildcardRules = $compiled['wildcardRules'];
-        $this->isCompiled = true;
+            // Callback responded to abort
+            if ($callbackResult === false) {
+                return false;
+            }
+        }
 
-        return $this;
+        $this->matchedRouteRule = $routeRule;
+
+        // If this route has a match callback, run it
+        $matchCallback = $routeRule->afterMatch();
+        if ($matchCallback !== null) {
+            $parameters = call_user_func($matchCallback, $parameters, $url);
+        }
+
+        $this->parameters = $parameters;
+
+        return true;
     }
 
     /**
-     * invalidate clears compiled state when routes change
-     * @return void
+     * extractDynamicCandidate builds the matched route candidate from a
+     * combined regex match, validating custom segment expressions with the
+     * same logic as Rule::resolveUrlSegments
+     * @param array $matches
+     * @return array|null ['name', 'position', 'parameters', 'valid']
      */
-    protected function invalidate()
+    protected function extractDynamicCandidate($matches)
     {
-        $this->isCompiled = false;
-        $this->staticRoutes = [];
-        $this->dynamicRegex = null;
-        $this->dynamicRouteMap = [];
-        $this->wildcardRules = [];
+        if (!isset($matches['MARK'])) {
+            return null;
+        }
+
+        $routeInfo = $this->dynamicRouteMap[(int) $matches['MARK']] ?? null;
+        if ($routeInfo === null) {
+            return null;
+        }
+
+        $parameters = [];
+        $valid = true;
+
+        foreach ($routeInfo['params'] as $index => $param) {
+            $value = $matches[$index + 1] ?? '';
+
+            // Unmatched optional segment, use the default value
+            if ($value === '') {
+                $parameters[$param['name']] = $param['default'];
+                continue;
+            }
+
+            // Validate the value with the custom regular expression
+            if ($param['regex'] !== null) {
+                try {
+                    if (!preg_match($param['regex'], $value)) {
+                        $valid = false;
+                        break;
+                    }
+                }
+                catch (Exception $ex) {
+                }
+            }
+
+            $parameters[$param['name']] = $value;
+        }
+
+        return [
+            'name' => $routeInfo['name'],
+            'position' => $routeInfo['position'],
+            'parameters' => $parameters,
+            'valid' => $valid,
+        ];
     }
 
     /**
@@ -369,7 +388,7 @@ class Router
     }
 
     /**
-     * hasRoute checks if a named route exists (like Laravel's hasNamedRoute)
+     * hasRoute checks if a named route exists
      * @param string $name
      * @return bool
      */
@@ -379,22 +398,13 @@ class Router
     }
 
     /**
-     * getRoute returns a route rule by name (like Laravel's getByName)
+     * getRoute returns a route rule by name
      * @param string $name
      * @return Rule|null
      */
     public function getRoute($name)
     {
         return $this->routeMap[$name] ?? null;
-    }
-
-    /**
-     * isCompiled returns whether routes have been compiled
-     * @return bool
-     */
-    public function isCompiled()
-    {
-        return $this->isCompiled;
     }
 
     /**
@@ -429,7 +439,7 @@ class Router
     public function reset()
     {
         $this->routeMap = [];
-        $this->invalidate();
+        $this->invalidateCompiled();
         return $this;
     }
 
@@ -482,73 +492,72 @@ class Router
     }
 
     /**
-     * fromArray loads routes from an array.
-     * @deprecated Use setCompiledRoutes() for better performance
+     * compileRules sorts the route map and builds the compiled lookup
+     * structures used for optimized matching
+     * @return $this
      */
-    public function fromArray($data)
-    {
-        // Support both old format (array of rules) and new format (with compiled state)
-        $rules = isset($data['rules']) ? $data['rules'] : $data;
-
-        foreach ($rules as $route) {
-            $this->routeMap[$route['ruleName']] = new Rule($route);
-        }
-
-        // Load compiled state if present and version matches
-        if (isset($data['compiled']) && $data['compiled']['version'] === RouteCompiler::COMPILED_VERSION) {
-            $this->setCompiledRoutes($data['compiled']);
-        }
-    }
-
-    /**
-     * toArray converts the rules to an array including compiled state.
-     * @return array
-     */
-    public function toArray()
+    public function compileRules()
     {
         $this->sortRules();
 
-        $rules = [];
-        foreach ($this->routeMap as $rule) {
-            $rules[] = $rule->toArray();
-        }
+        $this->setCompiledRoutes(RouteCompiler::compile($this->routeMap));
 
-        return [
-            'rules' => $rules,
-            'compiled' => $this->getCompiledRoutes(),
-        ];
+        return $this;
     }
 
     /**
-     * setCompiledRoutes sets the compiled route data directly (like Laravel)
-     * This bypasses compilation and uses pre-compiled data for maximum performance.
-     * @param array $compiled The compiled route data
+     * isCompiled returns whether routes have been compiled
+     * @return bool
+     */
+    public function isCompiled()
+    {
+        return $this->isCompiled;
+    }
+
+    /**
+     * invalidateCompiled clears compiled state when routes change
+     * @return void
+     */
+    protected function invalidateCompiled()
+    {
+        $this->isCompiled = false;
+        $this->staticRoutes = [];
+        $this->dynamicRegex = null;
+        $this->dynamicRouteMap = [];
+        $this->fallbackRules = [];
+    }
+
+    /**
+     * setCompiledRoutes restores compiled route data, positions in the data
+     * must correspond to the current route map order. Data with a version
+     * mismatch is ignored and routes are recompiled on the next match.
+     * @param array $compiled
      * @return $this
      */
     public function setCompiledRoutes(array $compiled)
     {
-        if (!isset($compiled['version']) || $compiled['version'] !== RouteCompiler::COMPILED_VERSION) {
-            // Version mismatch, need to recompile
+        if (($compiled['version'] ?? null) !== RouteCompiler::COMPILED_VERSION) {
             return $this;
         }
 
         $this->staticRoutes = $compiled['staticRoutes'] ?? [];
         $this->dynamicRegex = $compiled['dynamicRegex'] ?? null;
         $this->dynamicRouteMap = $compiled['dynamicRouteMap'] ?? [];
-        $this->wildcardRules = $compiled['wildcardRules'] ?? [];
+        $this->fallbackRules = $compiled['fallbackRules'] ?? [];
         $this->isCompiled = true;
 
         return $this;
     }
 
     /**
-     * getCompiledRoutes returns the compiled route data
+     * getCompiledRoutes returns the compiled route data, compiling first
+     * if necessary
      * @return array
      */
     public function getCompiledRoutes()
     {
         if (!$this->isCompiled) {
-            $this->compile();
+            $this->compileRules();
         }
 
         return [
@@ -556,40 +565,67 @@ class Router
             'staticRoutes' => $this->staticRoutes,
             'dynamicRegex' => $this->dynamicRegex,
             'dynamicRouteMap' => $this->dynamicRouteMap,
-            'wildcardRules' => $this->wildcardRules,
+            'fallbackRules' => $this->fallbackRules,
         ];
     }
 
     /**
-     * saveCompiledRoutes saves compiled routes to a PHP file (like Laravel's route:cache)
-     * The file can be loaded later with loadCompiledRoutes() for instant route matching.
-     * @param string $path File path to save to
-     * @return bool
+     * fromArray loads routes from an array, including compiled state when
+     * present. Supports the legacy format (a plain list of rules).
      */
-    public function saveCompiledRoutes($path)
+    public function fromArray($data)
     {
-        $this->sortRules();
+        $rules = isset($data['rules']) && is_array($data['rules'])
+            ? $data['rules']
+            : $data;
+
+        foreach ($rules as $route) {
+            $this->routeMap[$route['ruleName']] = new Rule($route);
+        }
+
+        if (isset($data['compiled']) && is_array($data['compiled'])) {
+            $this->setCompiledRoutes($data['compiled']);
+        }
+    }
+
+    /**
+     * toArray converts the rules to an array, including the compiled state
+     * for cache storage.
+     * @return array
+     */
+    public function toArray()
+    {
+        $compiled = $this->getCompiledRoutes();
 
         $rules = [];
         foreach ($this->routeMap as $rule) {
             $rules[] = $rule->toArray();
         }
 
-        $data = [
+        return [
             'rules' => $rules,
-            'compiled' => $this->getCompiledRoutes(),
+            'compiled' => $compiled,
         ];
+    }
 
-        $content = '<?php return ' . var_export($data, true) . ';' . PHP_EOL;
+    /**
+     * saveCompiledRoutes saves the routes with their compiled state to a PHP
+     * file, similar to Laravel's route:cache. Load it later with
+     * loadCompiledRoutes for instant route matching.
+     * @param string $path File path to save to
+     * @return bool
+     */
+    public function saveCompiledRoutes($path)
+    {
+        $content = '<?php return ' . var_export($this->toArray(), true) . ';' . PHP_EOL;
 
         return file_put_contents($path, $content) !== false;
     }
 
     /**
      * loadCompiledRoutes loads compiled routes from a PHP file
-     * This is the fastest way to initialize routes - just include the cached file.
      * @param string $path File path to load from
-     * @return static|null Returns router instance or null if file doesn't exist
+     * @return static|null Returns a router instance or null if the file doesn't exist
      */
     public static function loadCompiledRoutes($path)
     {

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -22,7 +22,9 @@ class Router
     public static $defaultValue = 'default';
 
     /**
-     * @var array routeMap is a list of specified routes
+     * @var array routeMap is a list of specified routes. Rules restored from
+     * cached data are stored as raw config arrays and hydrated to Rule
+     * objects on demand.
      */
     protected $routeMap = [];
 
@@ -93,7 +95,7 @@ class Router
         // Static route lookup
         $static = $this->staticRoutes[mb_strtolower($plainUrl)] ?? null;
         if ($static !== null) {
-            $routeRule = $this->routeMap[$static['name']] ?? null;
+            $routeRule = $this->ruleObject($static['name']);
             if ($routeRule && $this->acceptRuleMatch($routeRule, [], $url)) {
                 return true;
             }
@@ -139,7 +141,7 @@ class Router
                     }
                 }
 
-                $routeRule = $this->routeMap[$fallback['name']] ?? null;
+                $routeRule = $this->ruleObject($fallback['name']);
                 if (!$routeRule) {
                     continue;
                 }
@@ -156,7 +158,7 @@ class Router
 
         if ($candidate !== null) {
             if ($candidate['valid']) {
-                $routeRule = $this->routeMap[$candidate['name']] ?? null;
+                $routeRule = $this->ruleObject($candidate['name']);
                 if ($routeRule && $this->acceptRuleMatch($routeRule, $candidate['parameters'], $url)) {
                     return true;
                 }
@@ -181,10 +183,14 @@ class Router
     protected function matchFromPosition($segments, $url, $position)
     {
         $rules = $position > 0
-            ? array_slice($this->routeMap, $position)
+            ? array_slice($this->routeMap, $position, null, true)
             : $this->routeMap;
 
-        foreach ($rules as $routeRule) {
+        foreach ($rules as $name => $routeRule) {
+            if (is_array($routeRule)) {
+                $routeRule = $this->ruleObject($name);
+            }
+
             $parameters = [];
             if (
                 $routeRule->resolveUrlSegments($segments, $parameters) &&
@@ -293,11 +299,10 @@ class Router
      */
     public function url($name, $parameters = [])
     {
-        if (!isset($this->routeMap[$name])) {
+        $routeRule = $this->ruleObject($name);
+        if (!$routeRule) {
             return null;
         }
-
-        $routeRule = $this->routeMap[$name];
 
         $pattern = $routeRule->pattern();
 
@@ -384,6 +389,8 @@ class Router
      */
     public function getRouteMap()
     {
+        $this->hydrateRules();
+
         return $this->routeMap;
     }
 
@@ -404,7 +411,7 @@ class Router
      */
     public function getRoute($name)
     {
-        return $this->routeMap[$name] ?? null;
+        return $this->ruleObject($name);
     }
 
     /**
@@ -450,6 +457,8 @@ class Router
      */
     public function sortRules()
     {
+        $this->hydrateRules();
+
         uasort($this->routeMap, function ($a, $b) {
             // When comparing static, longer tails go to the start
             $lengthA = $a->staticSegmentCount;
@@ -503,6 +512,36 @@ class Router
         $this->setCompiledRoutes(RouteCompiler::compile($this->routeMap));
 
         return $this;
+    }
+
+    /**
+     * ruleObject returns a rule by name, hydrating it from raw config
+     * if needed
+     * @param string $name
+     * @return Rule|null
+     */
+    protected function ruleObject($name)
+    {
+        $rule = $this->routeMap[$name] ?? null;
+
+        if (is_array($rule)) {
+            $rule = $this->routeMap[$name] = new Rule($rule);
+        }
+
+        return $rule;
+    }
+
+    /**
+     * hydrateRules converts any raw rule configs to Rule objects
+     * @return void
+     */
+    protected function hydrateRules()
+    {
+        foreach ($this->routeMap as $name => $rule) {
+            if (is_array($rule)) {
+                $this->routeMap[$name] = new Rule($rule);
+            }
+        }
     }
 
     /**
@@ -580,7 +619,8 @@ class Router
             : $data;
 
         foreach ($rules as $route) {
-            $this->routeMap[$route['ruleName']] = new Rule($route);
+            // Store the raw config, rules are hydrated to objects on demand
+            $this->routeMap[$route['ruleName']] = $route;
         }
 
         if (isset($data['compiled']) && is_array($data['compiled'])) {
@@ -599,7 +639,7 @@ class Router
 
         $rules = [];
         foreach ($this->routeMap as $rule) {
-            $rules[] = $rule->toArray();
+            $rules[] = is_array($rule) ? $rule : $rule->toArray();
         }
 
         return [

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -29,15 +29,41 @@ class Router
     protected $parameters = [];
 
     /**
+     * @var bool isCompiled indicates if routes have been compiled for optimized matching
+     */
+    protected $isCompiled = false;
+
+    /**
+     * @var array staticRoutes hash map for O(1) static route lookup
+     */
+    protected $staticRoutes = [];
+
+    /**
+     * @var string|null dynamicRegex combined regex for dynamic routes
+     */
+    protected $dynamicRegex = null;
+
+    /**
+     * @var array dynamicRouteMap maps regex group index to route info
+     */
+    protected $dynamicRouteMap = [];
+
+    /**
+     * @var array wildcardRules ordered list of wildcard route rule names
+     */
+    protected $wildcardRules = [];
+
+    /**
      * route registers a new route rule
      */
     public function route($name, $route)
     {
+        $this->invalidate();
         return $this->routeMap[$name] = Rule::fromPattern($name, $route);
     }
 
     /**
-     * match given URL string
+     * match given URL string using compiled route matching for performance
      * @param string $url Request URL to match for
      * @return bool
      */
@@ -45,43 +71,198 @@ class Router
     {
         // Reset any previous matches
         $this->matchedRouteRule = null;
+        $this->parameters = [];
 
-        $segments = Helper::segmentizeUrl($url, false);
+        // Compile routes on first match if not already compiled
+        if (!$this->isCompiled) {
+            $this->compile();
+        }
 
+        $normalizedUrl = Helper::normalizeUrl($url);
+
+        // Tier 1: Try static route lookup (O(1))
+        if ($this->matchStatic($normalizedUrl)) {
+            return true;
+        }
+
+        // Tier 2: Try combined regex for dynamic routes (O(1))
+        if ($this->matchDynamic($normalizedUrl)) {
+            return true;
+        }
+
+        // Tier 3: Try wildcard routes sequentially (O(w))
+        if ($this->matchWildcard($url)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * matchStatic attempts O(1) static route lookup
+     * @param string $normalizedUrl
+     * @return bool
+     */
+    protected function matchStatic($normalizedUrl)
+    {
+        $urlLower = mb_strtolower($normalizedUrl);
+
+        if (!isset($this->staticRoutes[$urlLower])) {
+            return false;
+        }
+
+        $ruleName = $this->staticRoutes[$urlLower];
+        if (!isset($this->routeMap[$ruleName])) {
+            return false;
+        }
+
+        $routeRule = $this->routeMap[$ruleName];
         $parameters = [];
-        foreach ($this->routeMap as $routeRule) {
-            if ($routeRule->resolveUrlSegments($segments, $parameters)) {
-                $this->matchedRouteRule = $routeRule;
 
-                // If this route has a condition, run it
+        // Check condition callback
+        $callback = $routeRule->condition();
+        if ($callback !== null) {
+            $callbackResult = call_user_func($callback, $parameters, $normalizedUrl);
+            if ($callbackResult === false) {
+                return false;
+            }
+        }
+
+        $this->matchedRouteRule = $routeRule;
+
+        // Run afterMatch callback
+        $matchCallback = $routeRule->afterMatch();
+        if ($matchCallback !== null) {
+            $parameters = call_user_func($matchCallback, $parameters, $normalizedUrl);
+        }
+
+        $this->parameters = $parameters;
+        return true;
+    }
+
+    /**
+     * matchDynamic attempts combined regex match for dynamic routes
+     * @param string $normalizedUrl
+     * @return bool
+     */
+    protected function matchDynamic($normalizedUrl)
+    {
+        if ($this->dynamicRegex === null) {
+            return false;
+        }
+
+        if (!preg_match($this->dynamicRegex, $normalizedUrl, $matches)) {
+            return false;
+        }
+
+        // Extract matched route and parameters
+        $result = RouteCompiler::extractMatchedRoute($matches, $this->dynamicRouteMap);
+        if ($result === null) {
+            return false;
+        }
+
+        [$routeIndex, $parameters] = $result;
+        $ruleName = $this->dynamicRouteMap[$routeIndex]['ruleName'];
+
+        if (!isset($this->routeMap[$ruleName])) {
+            return false;
+        }
+
+        $routeRule = $this->routeMap[$ruleName];
+
+        // Check condition callback
+        $callback = $routeRule->condition();
+        if ($callback !== null) {
+            $callbackResult = call_user_func($callback, $parameters, $normalizedUrl);
+            if ($callbackResult === false) {
+                return false;
+            }
+        }
+
+        $this->matchedRouteRule = $routeRule;
+
+        // Run afterMatch callback
+        $matchCallback = $routeRule->afterMatch();
+        if ($matchCallback !== null) {
+            $parameters = call_user_func($matchCallback, $parameters, $normalizedUrl);
+        }
+
+        $this->parameters = $parameters;
+        return true;
+    }
+
+    /**
+     * matchWildcard attempts sequential wildcard route matching
+     * @param string $url
+     * @return bool
+     */
+    protected function matchWildcard($url)
+    {
+        $segments = Helper::segmentizeUrl($url, false);
+        $normalizedUrl = Helper::normalizeUrl($url);
+
+        foreach ($this->wildcardRules as $ruleName) {
+            if (!isset($this->routeMap[$ruleName])) {
+                continue;
+            }
+
+            $routeRule = $this->routeMap[$ruleName];
+            $parameters = [];
+
+            if ($routeRule->resolveUrlSegments($segments, $parameters)) {
+                // Check condition callback
                 $callback = $routeRule->condition();
                 if ($callback !== null) {
-                    $callbackResult = call_user_func($callback, $parameters, Helper::normalizeUrl($url));
-
-                    // Callback responded to abort
+                    $callbackResult = call_user_func($callback, $parameters, $normalizedUrl);
                     if ($callbackResult === false) {
-                        $parameters = [];
-                        $this->matchedRouteRule = null;
                         continue;
                     }
                 }
 
-                break;
+                $this->matchedRouteRule = $routeRule;
+
+                // Run afterMatch callback
+                $matchCallback = $routeRule->afterMatch();
+                if ($matchCallback !== null) {
+                    $parameters = call_user_func($matchCallback, $parameters, $url);
+                }
+
+                $this->parameters = $parameters;
+                return true;
             }
         }
 
-        // Success
-        if ($this->matchedRouteRule) {
-            // If this route has a match callback, run it
-            $matchCallback = $routeRule->afterMatch();
-            if ($matchCallback !== null) {
-                $parameters = call_user_func($matchCallback, $parameters, $url);
-            }
-        }
+        return false;
+    }
 
-        $this->parameters = $parameters;
+    /**
+     * compile builds optimized lookup structures for all registered routes
+     * @return $this
+     */
+    public function compile()
+    {
+        $compiled = RouteCompiler::compile($this->routeMap);
 
-        return $this->matchedRouteRule ? true : false;
+        $this->staticRoutes = $compiled['staticRoutes'];
+        $this->dynamicRegex = $compiled['dynamicRegex'];
+        $this->dynamicRouteMap = $compiled['dynamicRouteMap'];
+        $this->wildcardRules = $compiled['wildcardRules'];
+        $this->isCompiled = true;
+
+        return $this;
+    }
+
+    /**
+     * invalidate clears compiled state when routes change
+     * @return void
+     */
+    protected function invalidate()
+    {
+        $this->isCompiled = false;
+        $this->staticRoutes = [];
+        $this->dynamicRegex = null;
+        $this->dynamicRouteMap = [];
+        $this->wildcardRules = [];
     }
 
     /**
@@ -188,6 +369,35 @@ class Router
     }
 
     /**
+     * hasRoute checks if a named route exists (like Laravel's hasNamedRoute)
+     * @param string $name
+     * @return bool
+     */
+    public function hasRoute($name)
+    {
+        return isset($this->routeMap[$name]);
+    }
+
+    /**
+     * getRoute returns a route rule by name (like Laravel's getByName)
+     * @param string $name
+     * @return Rule|null
+     */
+    public function getRoute($name)
+    {
+        return $this->routeMap[$name] ?? null;
+    }
+
+    /**
+     * isCompiled returns whether routes have been compiled
+     * @return bool
+     */
+    public function isCompiled()
+    {
+        return $this->isCompiled;
+    }
+
+    /**
      * getParameters returns a list of parameters specified in the requested page URL.
      * For example, if the URL pattern was /blog/post/:id and the actual URL
      * was /blog/post/10, the $parameters['id'] element would be 10.
@@ -219,6 +429,7 @@ class Router
     public function reset()
     {
         $this->routeMap = [];
+        $this->invalidate();
         return $this;
     }
 
@@ -272,16 +483,25 @@ class Router
 
     /**
      * fromArray loads routes from an array.
+     * @deprecated Use setCompiledRoutes() for better performance
      */
-    public function fromArray($routes)
+    public function fromArray($data)
     {
-        foreach ($routes as $route) {
+        // Support both old format (array of rules) and new format (with compiled state)
+        $rules = isset($data['rules']) ? $data['rules'] : $data;
+
+        foreach ($rules as $route) {
             $this->routeMap[$route['ruleName']] = new Rule($route);
+        }
+
+        // Load compiled state if present and version matches
+        if (isset($data['compiled']) && $data['compiled']['version'] === RouteCompiler::COMPILED_VERSION) {
+            $this->setCompiledRoutes($data['compiled']);
         }
     }
 
     /**
-     * toArray converts the rules to an array.
+     * toArray converts the rules to an array including compiled state.
      * @return array
      */
     public function toArray()
@@ -289,11 +509,103 @@ class Router
         $this->sortRules();
 
         $rules = [];
-
         foreach ($this->routeMap as $rule) {
             $rules[] = $rule->toArray();
         }
 
-        return $rules;
+        return [
+            'rules' => $rules,
+            'compiled' => $this->getCompiledRoutes(),
+        ];
+    }
+
+    /**
+     * setCompiledRoutes sets the compiled route data directly (like Laravel)
+     * This bypasses compilation and uses pre-compiled data for maximum performance.
+     * @param array $compiled The compiled route data
+     * @return $this
+     */
+    public function setCompiledRoutes(array $compiled)
+    {
+        if (!isset($compiled['version']) || $compiled['version'] !== RouteCompiler::COMPILED_VERSION) {
+            // Version mismatch, need to recompile
+            return $this;
+        }
+
+        $this->staticRoutes = $compiled['staticRoutes'] ?? [];
+        $this->dynamicRegex = $compiled['dynamicRegex'] ?? null;
+        $this->dynamicRouteMap = $compiled['dynamicRouteMap'] ?? [];
+        $this->wildcardRules = $compiled['wildcardRules'] ?? [];
+        $this->isCompiled = true;
+
+        return $this;
+    }
+
+    /**
+     * getCompiledRoutes returns the compiled route data
+     * @return array
+     */
+    public function getCompiledRoutes()
+    {
+        if (!$this->isCompiled) {
+            $this->compile();
+        }
+
+        return [
+            'version' => RouteCompiler::COMPILED_VERSION,
+            'staticRoutes' => $this->staticRoutes,
+            'dynamicRegex' => $this->dynamicRegex,
+            'dynamicRouteMap' => $this->dynamicRouteMap,
+            'wildcardRules' => $this->wildcardRules,
+        ];
+    }
+
+    /**
+     * saveCompiledRoutes saves compiled routes to a PHP file (like Laravel's route:cache)
+     * The file can be loaded later with loadCompiledRoutes() for instant route matching.
+     * @param string $path File path to save to
+     * @return bool
+     */
+    public function saveCompiledRoutes($path)
+    {
+        $this->sortRules();
+
+        $rules = [];
+        foreach ($this->routeMap as $rule) {
+            $rules[] = $rule->toArray();
+        }
+
+        $data = [
+            'rules' => $rules,
+            'compiled' => $this->getCompiledRoutes(),
+        ];
+
+        $content = '<?php return ' . var_export($data, true) . ';' . PHP_EOL;
+
+        return file_put_contents($path, $content) !== false;
+    }
+
+    /**
+     * loadCompiledRoutes loads compiled routes from a PHP file
+     * This is the fastest way to initialize routes - just include the cached file.
+     * @param string $path File path to load from
+     * @return static|null Returns router instance or null if file doesn't exist
+     */
+    public static function loadCompiledRoutes($path)
+    {
+        if (!file_exists($path)) {
+            return null;
+        }
+
+        $data = include $path;
+
+        if (!is_array($data)) {
+            return null;
+        }
+
+        $router = new static;
+        $router->fromArray($data);
+
+        return $router;
     }
 }

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -49,9 +49,10 @@ class Router
     protected $staticRoutes = [];
 
     /**
-     * @var string|null dynamicRegex combined regex for dynamic routes
+     * @var array dynamicRegexes combined regexes for dynamic routes, keyed
+     * by the first static URL segment
      */
-    protected $dynamicRegex = null;
+    protected $dynamicRegexes = [];
 
     /**
      * @var array dynamicRouteMap maps a combined regex mark to route info
@@ -105,20 +106,33 @@ class Router
             return $this->matchFromPosition($segments, $url, $static['position'] + 1);
         }
 
-        // Dynamic route lookup, a single combined regex identifies the
-        // matched route using the (*MARK) verb
+        // Dynamic route lookup, a combined regex identifies the matched
+        // route using the (*MARK) verb. Routes bucketed by the URL's first
+        // segment and routes starting with a dynamic segment ('' bucket)
+        // are both checked, the earliest sorted match wins.
         $candidate = null;
-        if ($this->dynamicRegex !== null) {
-            $result = @preg_match($this->dynamicRegex, $plainUrl, $matches);
+        if ($this->dynamicRegexes) {
+            $buckets = isset($segments[0]) ? [mb_strtolower($segments[0]), ''] : [''];
 
-            // Regex engine failure (e.g. backtrack limit), fall back to
-            // sequential matching
-            if ($result === false) {
-                return $this->matchFromPosition($segments, $url, 0);
-            }
+            foreach ($buckets as $bucket) {
+                if (!isset($this->dynamicRegexes[$bucket])) {
+                    continue;
+                }
 
-            if ($result === 1) {
-                $candidate = $this->extractDynamicCandidate($matches);
+                $result = @preg_match($this->dynamicRegexes[$bucket], $plainUrl, $matches);
+
+                // Regex engine failure (e.g. backtrack limit), fall back to
+                // sequential matching
+                if ($result === false) {
+                    return $this->matchFromPosition($segments, $url, 0);
+                }
+
+                if ($result === 1) {
+                    $found = $this->extractDynamicCandidate($matches);
+                    if ($found !== null && ($candidate === null || $found['position'] < $candidate['position'])) {
+                        $candidate = $found;
+                    }
+                }
             }
         }
 
@@ -561,7 +575,7 @@ class Router
     {
         $this->isCompiled = false;
         $this->staticRoutes = [];
-        $this->dynamicRegex = null;
+        $this->dynamicRegexes = [];
         $this->dynamicRouteMap = [];
         $this->fallbackRules = [];
     }
@@ -580,7 +594,7 @@ class Router
         }
 
         $this->staticRoutes = $compiled['staticRoutes'] ?? [];
-        $this->dynamicRegex = $compiled['dynamicRegex'] ?? null;
+        $this->dynamicRegexes = $compiled['dynamicRegexes'] ?? [];
         $this->dynamicRouteMap = $compiled['dynamicRouteMap'] ?? [];
         $this->fallbackRules = $compiled['fallbackRules'] ?? [];
         $this->isCompiled = true;
@@ -602,7 +616,7 @@ class Router
         return [
             'version' => RouteCompiler::COMPILED_VERSION,
             'staticRoutes' => $this->staticRoutes,
-            'dynamicRegex' => $this->dynamicRegex,
+            'dynamicRegexes' => $this->dynamicRegexes,
             'dynamicRouteMap' => $this->dynamicRouteMap,
             'fallbackRules' => $this->fallbackRules,
         ];

--- a/tests/Benchmark/Router/RouterBench.php
+++ b/tests/Benchmark/Router/RouterBench.php
@@ -111,4 +111,16 @@ class RouterBench
 
         $router->match('authors/test/details');
     }
+
+    /**
+     * @Subject
+     */
+    public function benchRouteCachedMiss()
+    {
+        $router = new Router;
+
+        $router->fromArray($this->routesCached);
+
+        $router->match('/this/url/matches/nothing/at/all');
+    }
 }

--- a/tests/Router/RouteCompilerTest.php
+++ b/tests/Router/RouteCompilerTest.php
@@ -396,6 +396,57 @@ class RouteCompilerTest extends TestCase
         $this->assertFalse($router->match("/\xFF\xFE/nothing/here"));
     }
 
+    public function testSharedCachePayloadAcrossInstances()
+    {
+        // Multiple server instances restore the same cached payload, each
+        // router must work independently with no shared mutable state
+        $source = new Router;
+        $source->route('blogPost', '/blog/post/:post_id');
+        $source->route('blogIndex', '/blog');
+        $payload = unserialize(serialize($source->toArray()));
+
+        $instanceA = new Router;
+        $instanceA->fromArray($payload);
+        $instanceB = new Router;
+        $instanceB->fromArray($payload);
+
+        $this->assertTrue($instanceA->match('/blog/post/10'));
+
+        // Instance A registers an extra route locally, instance B must be
+        // unaffected and keep serving from its compiled state
+        $instanceA->route('extraPage', '/extra');
+        $this->assertFalse($instanceA->isCompiled());
+        $this->assertTrue($instanceB->isCompiled());
+
+        $this->assertTrue($instanceA->match('/extra'));
+        $this->assertFalse($instanceB->match('/extra'));
+        $this->assertTrue($instanceB->match('/blog/post/10'));
+        $this->assertEquals(['post_id' => '10'], $instanceB->getParameters());
+    }
+
+    public function testCorruptedCompiledStateRecompiles()
+    {
+        // A torn or corrupted cache write from another instance must never
+        // break matching, invalid compiled data is ignored and rebuilt
+        $source = new Router;
+        $source->route('blogPost', '/blog/post/:post_id');
+        $data = $source->toArray();
+
+        foreach ([
+            'not-an-array',
+            [],
+            ['version' => RouteCompiler::COMPILED_VERSION],
+            ['version' => RouteCompiler::COMPILED_VERSION, 'staticRoutes' => 'garbage', 'dynamicRegexes' => ['' => '#broken('], 'dynamicRouteMap' => [], 'fallbackRules' => []],
+        ] as $corrupted) {
+            $restored = new Router;
+            $restored->fromArray(['rules' => $data['rules'], 'compiled' => is_array($corrupted) ? $corrupted : []]);
+
+            $this->assertTrue($restored->match('/blog/post/10'), 'Failed for corrupted payload: ' . json_encode($corrupted));
+            $this->assertEquals('blogPost', $restored->matchedRoute());
+            $this->assertEquals(['post_id' => '10'], $restored->getParameters());
+        }
+    }
+
     public function testParityWithSequentialMatching()
     {
         // The full fixture set from the benchmark suite, every URL must

--- a/tests/Router/RouteCompilerTest.php
+++ b/tests/Router/RouteCompilerTest.php
@@ -1,0 +1,415 @@
+<?php
+
+use October\Rain\Router\Router;
+use October\Rain\Router\RouteCompiler;
+
+class RouteCompilerTest extends TestCase
+{
+    public function testStaticRouteMatching()
+    {
+        $router = new Router;
+        $router->route('home', '/');
+        $router->route('blogPost', 'blog/post');
+
+        $this->assertTrue($router->match('/'));
+        $this->assertEquals('home', $router->matchedRoute());
+
+        $this->assertTrue($router->match('/blog/post'));
+        $this->assertEquals('blogPost', $router->matchedRoute());
+        $this->assertEquals([], $router->getParameters());
+
+        // Case-insensitive, same as sequential matching
+        $this->assertTrue($router->match('/Blog/POST'));
+        $this->assertEquals('blogPost', $router->matchedRoute());
+
+        // Trailing and duplicate slashes are normalized
+        $this->assertTrue($router->match('blog/post/'));
+        $this->assertTrue($router->match('/blog//post'));
+
+        $this->assertFalse($router->match('/blog'));
+        $this->assertFalse($router->match('/blog/post/extra'));
+    }
+
+    public function testStaticRouteFirstRuleWins()
+    {
+        $router = new Router;
+        $router->route('first', '/blog/post');
+        $router->route('second', '/blog/post');
+
+        $this->assertTrue($router->match('/blog/post'));
+        $this->assertEquals('first', $router->matchedRoute());
+
+        // When the first rule's condition rejects, the second rule matches,
+        // same as sequential matching
+        $router = new Router;
+        $router->route('first', '/blog/post')->condition(function () {
+            return false;
+        });
+        $router->route('second', '/blog/post');
+
+        $this->assertTrue($router->match('/blog/post'));
+        $this->assertEquals('second', $router->matchedRoute());
+    }
+
+    public function testDynamicRouteMatching()
+    {
+        $router = new Router;
+        $router->route('blogPost', '/blog/post/:post_id');
+        $router->route('authorDetails', '/authors/:author_id?/:details?');
+
+        $this->assertTrue($router->match('/blog/post/10'));
+        $this->assertEquals('blogPost', $router->matchedRoute());
+        $this->assertEquals(['post_id' => '10'], $router->getParameters());
+
+        // Static segments match case-insensitively
+        $this->assertTrue($router->match('/BLOG/Post/10'));
+        $this->assertEquals(['post_id' => '10'], $router->getParameters());
+
+        $this->assertTrue($router->match('/authors'));
+        $this->assertEquals(['author_id' => false, 'details' => false], $router->getParameters());
+
+        $this->assertTrue($router->match('/authors/shaq'));
+        $this->assertEquals(['author_id' => 'shaq', 'details' => false], $router->getParameters());
+
+        $this->assertTrue($router->match('/authors/shaq/history'));
+        $this->assertEquals(['author_id' => 'shaq', 'details' => 'history'], $router->getParameters());
+
+        $this->assertFalse($router->match('/authors/shaq/history/more'));
+    }
+
+    public function testOptionalSegmentDefaults()
+    {
+        $router = new Router;
+        $router->route('page', '/p/:id?42');
+
+        $this->assertTrue($router->match('/p'));
+        $this->assertEquals(['id' => '42'], $router->getParameters());
+
+        $this->assertTrue($router->match('/p/7'));
+        $this->assertEquals(['id' => '7'], $router->getParameters());
+    }
+
+    public function testAllOptionalSegmentsMatchRoot()
+    {
+        $router = new Router;
+        $router->route('page', '/:page?');
+
+        $this->assertTrue($router->match('/'));
+        $this->assertEquals(['page' => false], $router->getParameters());
+
+        $this->assertTrue($router->match('/about'));
+        $this->assertEquals(['page' => 'about'], $router->getParameters());
+    }
+
+    public function testCustomRegexKeepsCaseSensitivity()
+    {
+        $router = new Router;
+        $router->route('post', '/x/:id|^[a-z]+$');
+
+        $this->assertTrue($router->match('/x/abc'));
+
+        // The custom expression is case-sensitive, even though static
+        // segments match case-insensitively
+        $this->assertFalse($router->match('/x/ABC'));
+    }
+
+    public function testCustomRegexKeepsSearchSemantics()
+    {
+        // An unanchored expression matches a substring of the segment and the
+        // whole segment becomes the parameter value
+        $router = new Router;
+        $router->route('post', '/x/:id|[0-9]+');
+
+        $this->assertTrue($router->match('/x/abc123'));
+        $this->assertEquals(['id' => 'abc123'], $router->getParameters());
+
+        $this->assertFalse($router->match('/x/abcdef'));
+    }
+
+    public function testCustomRegexRejectionContinuesToNextRule()
+    {
+        $router = new Router;
+        $router->route('postById', '/blog/:id|^[0-9]+$');
+        $router->route('postBySlug', '/blog/:slug');
+
+        $this->assertTrue($router->match('/blog/10'));
+        $this->assertEquals('postById', $router->matchedRoute());
+        $this->assertEquals(['id' => '10'], $router->getParameters());
+
+        $this->assertTrue($router->match('/blog/hello-world'));
+        $this->assertEquals('postBySlug', $router->matchedRoute());
+        $this->assertEquals(['slug' => 'hello-world'], $router->getParameters());
+    }
+
+    public function testConditionRejectionContinuesToNextRule()
+    {
+        $router = new Router;
+        $router->route('draft', '/blog/:slug')->condition(function () {
+            return false;
+        });
+        $router->route('published', '/blog/:slug');
+
+        $this->assertTrue($router->match('/blog/hello'));
+        $this->assertEquals('published', $router->matchedRoute());
+        $this->assertEquals(['slug' => 'hello'], $router->getParameters());
+    }
+
+    public function testAfterMatchReceivesRawUrl()
+    {
+        $passedUrl = null;
+
+        $router = new Router;
+        $router->route('post', '/blog/:slug')->afterMatch(function ($params, $url) use (&$passedUrl) {
+            $passedUrl = $url;
+            $params['extra'] = true;
+            return $params;
+        });
+
+        $this->assertTrue($router->match('blog/hello'));
+        $this->assertEquals('blog/hello', $passedUrl);
+        $this->assertEquals(['slug' => 'hello', 'extra' => true], $router->getParameters());
+    }
+
+    public function testWildcardOutranksLessSpecificDynamicRule()
+    {
+        $router = new Router;
+        $router->route('cmsPage', '/:page/:sub?');
+        $router->route('blogWild', '/blog/:slug*');
+
+        // The wildcard rule has more static segments so it sorts first,
+        // same as sequential matching after sortRules
+        $this->assertTrue($router->match('/blog/foo'));
+        $this->assertEquals('blogWild', $router->matchedRoute());
+        $this->assertEquals(['slug' => 'foo'], $router->getParameters());
+
+        $this->assertTrue($router->match('/blog/foo/bar/baz'));
+        $this->assertEquals('blogWild', $router->matchedRoute());
+        $this->assertEquals(['slug' => 'foo/bar/baz'], $router->getParameters());
+
+        $this->assertTrue($router->match('/about/team'));
+        $this->assertEquals('cmsPage', $router->matchedRoute());
+        $this->assertEquals(['page' => 'about', 'sub' => 'team'], $router->getParameters());
+    }
+
+    public function testDynamicRuleOutranksLessSpecificWildcard()
+    {
+        $router = new Router;
+        $router->route('vehiclesWild', '/vehicles/:query?*');
+        $router->route('vehiclesDynamic', '/vehicles/:make/:model/:id');
+
+        $this->assertTrue($router->match('vehicles/audi/a3/123'));
+        $this->assertEquals('vehiclesDynamic', $router->matchedRoute());
+
+        $this->assertTrue($router->match('vehicles/audi/a3/123/456'));
+        $this->assertEquals('vehiclesWild', $router->matchedRoute());
+    }
+
+    public function testCompiledStateRoundTrip()
+    {
+        $router = new Router;
+        $router->route('blogPost', '/blog/post/:post_id');
+        $router->route('blogIndex', '/blog');
+        $router->route('docsWild', '/docs/:path*');
+
+        $data = $router->toArray();
+
+        $this->assertArrayHasKey('rules', $data);
+        $this->assertArrayHasKey('compiled', $data);
+        $this->assertEquals(RouteCompiler::COMPILED_VERSION, $data['compiled']['version']);
+
+        // Simulate a serialized cache round trip
+        $data = unserialize(serialize($data));
+
+        $restored = new Router;
+        $restored->fromArray($data);
+
+        // Compiled state restored, no recompilation needed
+        $this->assertTrue($restored->isCompiled());
+
+        $this->assertTrue($restored->match('/blog/post/10'));
+        $this->assertEquals('blogPost', $restored->matchedRoute());
+        $this->assertEquals(['post_id' => '10'], $restored->getParameters());
+
+        $this->assertTrue($restored->match('/blog'));
+        $this->assertEquals('blogIndex', $restored->matchedRoute());
+
+        $this->assertTrue($restored->match('/docs/a/b/c'));
+        $this->assertEquals('docsWild', $restored->matchedRoute());
+        $this->assertEquals(['path' => 'a/b/c'], $restored->getParameters());
+    }
+
+    public function testFromArrayLegacyFormat()
+    {
+        $router = new Router;
+        $router->route('blogPost', '/blog/post/:post_id');
+        $router->route('blogIndex', '/blog');
+
+        // Legacy format is a plain list of rules
+        $legacy = $router->toArray()['rules'];
+
+        $restored = new Router;
+        $restored->fromArray($legacy);
+
+        $this->assertFalse($restored->isCompiled());
+
+        $this->assertTrue($restored->match('/blog/post/10'));
+        $this->assertEquals('blogPost', $restored->matchedRoute());
+        $this->assertTrue($restored->isCompiled());
+    }
+
+    public function testVersionMismatchRecompiles()
+    {
+        $router = new Router;
+        $router->route('blogPost', '/blog/post/:post_id');
+
+        $data = $router->toArray();
+        $data['compiled']['version'] = -1;
+
+        $restored = new Router;
+        $restored->fromArray($data);
+
+        // Stale compiled data is ignored, routes recompile on first match
+        $this->assertFalse($restored->isCompiled());
+        $this->assertTrue($restored->match('/blog/post/10'));
+        $this->assertEquals(['post_id' => '10'], $restored->getParameters());
+    }
+
+    public function testInvalidationOnRouteChange()
+    {
+        $router = new Router;
+        $router->route('blogIndex', '/blog');
+
+        $this->assertTrue($router->match('/blog'));
+        $this->assertTrue($router->isCompiled());
+
+        $router->route('aboutPage', '/about');
+        $this->assertFalse($router->isCompiled());
+
+        $this->assertTrue($router->match('/about'));
+        $this->assertEquals('aboutPage', $router->matchedRoute());
+
+        $router->reset();
+        $this->assertFalse($router->isCompiled());
+        $this->assertFalse($router->match('/blog'));
+    }
+
+    public function testSaveAndLoadCompiledRoutes()
+    {
+        $path = tempnam(sys_get_temp_dir(), 'october-routes');
+
+        try {
+            $router = new Router;
+            $router->route('blogPost', '/blog/post/:post_id');
+            $router->route('blogIndex', '/blog');
+
+            $this->assertTrue($router->saveCompiledRoutes($path));
+
+            $restored = Router::loadCompiledRoutes($path);
+
+            $this->assertNotNull($restored);
+            $this->assertTrue($restored->isCompiled());
+
+            $this->assertTrue($restored->match('/blog/post/10'));
+            $this->assertEquals('blogPost', $restored->matchedRoute());
+            $this->assertEquals(['post_id' => '10'], $restored->getParameters());
+        }
+        finally {
+            @unlink($path);
+        }
+
+        $this->assertNull(Router::loadCompiledRoutes('/nonexistent/path/routes.php'));
+    }
+
+    public function testHasRouteAndGetRoute()
+    {
+        $router = new Router;
+        $rule = $router->route('blogIndex', '/blog');
+
+        $this->assertTrue($router->hasRoute('blogIndex'));
+        $this->assertFalse($router->hasRoute('missing'));
+
+        $this->assertSame($rule, $router->getRoute('blogIndex'));
+        $this->assertNull($router->getRoute('missing'));
+    }
+
+    public function testParityWithSequentialMatching()
+    {
+        // The full fixture set from the benchmark suite, every URL must
+        // produce the same result as Rule::resolveUrlSegments does
+        $routes = [
+            'home' => '/',
+            'blogIndex' => '/blog',
+            'blogPost' => '/blog/post/:post_id',
+            'blogPostOptional' => '/blog/post/:post_id?',
+            'blogPostSlug' => '/blog/post/:post_id/:post_slug|^my-slug-.*',
+            'blogArchive' => '/blog/:year|^\d{4}$/:month|^\d{2}$/:day|^\d{2}$/:slug',
+            'jobRequest' => '/job/:type?request/:id',
+            'userProfile' => '/profile/:username',
+            'productPage' => '/product/:category?/:id',
+            'portfolioPage' => '/portfolio/:year?noYear/:category?noCategory/:budget?noBudget',
+            'authorDetails' => '/authors/:author_id|^[a-z\-]+$/details/:record_type?|^[0-9]+$',
+            'largeCode' => '/color/:color/largecode/:largecode*/edit',
+        ];
+
+        $urls = [
+            '/',
+            '/blog',
+            '/blog/post/10',
+            '/blog/post',
+            '/blog/post/4/my-slug-test',
+            '/blog/post/4/no-slug-test',
+            '/blog/2021/03/31/hello-world',
+            '/blog/21/03/31/hello-world',
+            '/job/test/4',
+            '/job/test',
+            '/profile/shaq',
+            '/product/7',
+            '/product/helmets/7',
+            '/portfolio',
+            '/portfolio/2020',
+            '/authors/my-author/details',
+            '/authors/my-author/details/441',
+            '/authors/MY-AUTHOR/details',
+            '/color/brown/largecode/code/with/slashes/edit',
+            '/does/not/exist',
+            'XXXXXXXXGARBAGE',
+        ];
+
+        // Compiled matching
+        $compiled = new Router;
+        foreach ($routes as $name => $pattern) {
+            $compiled->route($name, $pattern);
+        }
+
+        // Sequential matching over the same sorted rules
+        $sequential = new Router;
+        foreach ($routes as $name => $pattern) {
+            $sequential->route($name, $pattern);
+        }
+        $sequential->sortRules();
+
+        foreach ($urls as $url) {
+            $expectedRule = false;
+            $expectedParams = [];
+            $segments = October\Rain\Router\Helper::segmentizeUrl($url, false);
+
+            foreach ($sequential->getRouteMap() as $rule) {
+                $parameters = [];
+                if ($rule->resolveUrlSegments($segments, $parameters)) {
+                    $expectedRule = $rule->name();
+                    $expectedParams = $parameters;
+                    break;
+                }
+            }
+
+            $matched = $compiled->match($url);
+
+            $this->assertEquals($expectedRule !== false, $matched, "Match result differs for URL: {$url}");
+            $this->assertEquals($expectedRule, $compiled->matchedRoute() ?: false, "Matched rule differs for URL: {$url}");
+
+            if ($matched) {
+                $this->assertEquals($expectedParams, $compiled->getParameters(), "Parameters differ for URL: {$url}");
+            }
+        }
+    }
+}

--- a/tests/Router/RouteCompilerTest.php
+++ b/tests/Router/RouteCompilerTest.php
@@ -204,6 +204,25 @@ class RouteCompilerTest extends TestCase
         $this->assertEquals('vehiclesWild', $router->matchedRoute());
     }
 
+    public function testBucketOrderingAcrossFirstSegments()
+    {
+        // Routes land in different regex buckets ('blog' and the catch-all),
+        // the more specific rule must still win by sort order
+        $router = new Router;
+        $router->route('cmsPage', '/:page');
+        $router->route('blogPost', '/blog/:slug?');
+
+        $this->assertTrue($router->match('/blog/hello'));
+        $this->assertEquals('blogPost', $router->matchedRoute());
+
+        $this->assertTrue($router->match('/blog'));
+        $this->assertEquals('blogPost', $router->matchedRoute());
+
+        $this->assertTrue($router->match('/about'));
+        $this->assertEquals('cmsPage', $router->matchedRoute());
+        $this->assertEquals(['page' => 'about'], $router->getParameters());
+    }
+
     public function testCompiledStateRoundTrip()
     {
         $router = new Router;

--- a/tests/Router/RouteCompilerTest.php
+++ b/tests/Router/RouteCompilerTest.php
@@ -236,6 +236,12 @@ class RouteCompilerTest extends TestCase
         $this->assertTrue($restored->match('/docs/a/b/c'));
         $this->assertEquals('docsWild', $restored->matchedRoute());
         $this->assertEquals(['path' => 'a/b/c'], $restored->getParameters());
+
+        // Rules restored from cache hydrate lazily, the public API always
+        // exposes Rule objects
+        $this->assertContainsOnlyInstancesOf(October\Rain\Router\Rule::class, $restored->getRouteMap());
+        $this->assertInstanceOf(October\Rain\Router\Rule::class, $restored->getRoute('blogIndex'));
+        $this->assertEquals('/blog/post/10', $restored->url('blogPost', ['post_id' => '10']));
     }
 
     public function testFromArrayLegacyFormat()

--- a/tests/Router/RouteCompilerTest.php
+++ b/tests/Router/RouteCompilerTest.php
@@ -357,6 +357,45 @@ class RouteCompilerTest extends TestCase
         $this->assertNull($router->getRoute('missing'));
     }
 
+    public function testTranslatedUnicodeRoutes()
+    {
+        $router = new Router;
+        $router->route('categoryIndex', '/kategória');
+        $router->route('categoryPage', '/kategória/:slug');
+        $router->route('collectionWild', '/kolekcia/:path*');
+
+        // Static routes fold case with full unicode support
+        $this->assertTrue($router->match('/KATEGÓRIA'));
+        $this->assertEquals('categoryIndex', $router->matchedRoute());
+
+        // Multibyte static segments inside dynamic routes fold too
+        $this->assertTrue($router->match('/kategória/kožené-tašky'));
+        $this->assertEquals('categoryPage', $router->matchedRoute());
+        $this->assertEquals(['slug' => 'kožené-tašky'], $router->getParameters());
+
+        $this->assertTrue($router->match('/KATEGÓRIA/tašky'));
+        $this->assertEquals('categoryPage', $router->matchedRoute());
+        $this->assertEquals(['slug' => 'tašky'], $router->getParameters());
+
+        // Multibyte parameter values pass through wildcards unchanged
+        $this->assertTrue($router->match('/kolekcia/jar/kožená-kabelka'));
+        $this->assertEquals(['path' => 'jar/kožená-kabelka'], $router->getParameters());
+    }
+
+    public function testInvalidUtf8UrlFallsBackToSequential()
+    {
+        $router = new Router;
+        $router->route('blogPost', '/blog/:slug');
+
+        // Invalid UTF-8 fails the combined regex, sequential matching
+        // still resolves the route without errors
+        $this->assertTrue($router->match("/blog/\xC3\x28"));
+        $this->assertEquals('blogPost', $router->matchedRoute());
+        $this->assertEquals(['slug' => "\xC3\x28"], $router->getParameters());
+
+        $this->assertFalse($router->match("/\xFF\xFE/nothing/here"));
+    }
+
     public function testParityWithSequentialMatching()
     {
         // The full fixture set from the benchmark suite, every URL must
@@ -374,6 +413,12 @@ class RouteCompilerTest extends TestCase
             'portfolioPage' => '/portfolio/:year?noYear/:category?noCategory/:budget?noBudget',
             'authorDetails' => '/authors/:author_id|^[a-z\-]+$/details/:record_type?|^[0-9]+$',
             'largeCode' => '/color/:color/largecode/:largecode*/edit',
+            'middleOptional' => '/m/:a?/end',
+            'optionalWildcard' => '/files/:path?*',
+            'wildcardRegex' => '/code/:code*|^[a-z]+\/[a-z]+$',
+            'defaultRegex' => '/pf/:year?2020|^[0-9]+$/:tag?',
+            'unicodeCategory' => '/kategória/:slug?všetko',
+            'catchAll' => '/:page?',
         ];
 
         $urls = [
@@ -396,6 +441,21 @@ class RouteCompilerTest extends TestCase
             '/authors/my-author/details/441',
             '/authors/MY-AUTHOR/details',
             '/color/brown/largecode/code/with/slashes/edit',
+            '/m/end',
+            '/m/x/end',
+            '/m/end/x',
+            '/files',
+            '/files/a/b/c',
+            '/code/ab/cd',
+            '/code/ab/99',
+            '/code/ab/cd/ef',
+            '/pf',
+            '/pf/1999',
+            '/pf/xx',
+            '/pf/1999/sale',
+            '/kategória',
+            '/KATEGÓRIA/tašky',
+            '/lonely',
             '/does/not/exist',
             'XXXXXXXXGARBAGE',
         ];


### PR DESCRIPTION
Reworked follow-up to #658. Routes compile into optimized lookup structures on first match: static routes in a hash map, dynamic routes in combined `(*MARK)` regexes bucketed by first segment, wildcard routes sequential. The compiled state travels through `toArray()`/`fromArray()`, so the CMS route cache carries it with no changes on the CMS side. Rules restored from cache hydrate lazily, only the matched rule becomes an object.

Matching behavior is identical to the sequential matcher, verified by a parity test and by 500 sampled URLs from a production site's traffic shape (52.8k visited URLs over ~25 pages, query strings included). Custom segment expressions are validated post-match with the original code path (case sensitivity, substring search and error tolerance preserved), condition rejections continue to later rules, wildcards keep their sorted priority.

Benchmarks at 120 routes (`RouterBench`, Apple Silicon, PHP 8.4):

| | before | after |
|---|---|---|
| static URL match | 10.7 µs | 0.4 µs |
| dynamic URL match | 13-21 µs | 1.5-1.7 µs |
| no match | 14.9 µs | 1.1 µs |
| cached boot + match | 21.1 µs | 4.4 µs |

Matching stays ~1 µs up to 1000 routes (bucketed regexes), where sequential grows to ~35 µs.

`fromArray()` accepts both the new format and the legacy rules list, existing caches survive. `toArray()` now returns `['rules' => ..., 'compiled' => ...]`, the serialized payload grows ~45% (25 routes: 10.6 KB to 15.3 KB). New API: `hasRoute()`, `getRoute()`, `isCompiled()`, `compileRules()`, `getCompiledRoutes()`/`setCompiledRoutes()`, `saveCompiledRoutes()`/`loadCompiledRoutes()`.

With this in place the CMS side no longer needs the per-URL `cms-url-list` cache (unbounded blob, deserialized fully per request), removed separately in octobercms/october-private#791.
