### PR TITLE
Read a template once when resolving through AutoDatasource

### DIFF
--- a/src/Halcyon/Datasource/AutoDatasource.php
+++ b/src/Halcyon/Datasource/AutoDatasource.php
@@ -61,12 +61,13 @@ class AutoDatasource extends Datasource implements DatasourceInterface
             return null;
         }
 
+        // Each datasource answers with the template or null, so the
+        // existence check and the read are a single operation
         foreach ($this->datasources as $source) {
-            if (!$source->hasTemplate($dirName, $fileName, $extension)) {
-                continue;
+            $result = $source->selectOne($dirName, $fileName, $extension);
+            if ($result !== null) {
+                return $result;
             }
-
-            return $source->selectOne($dirName, $fileName, $extension);
         }
 
         return null;
@@ -171,11 +172,10 @@ class AutoDatasource extends Datasource implements DatasourceInterface
         }
 
         foreach ($this->datasources as $source) {
-            if (!$source->hasTemplate($dirName, $fileName, $extension)) {
-                continue;
+            $mtime = $source->lastModified($dirName, $fileName, $extension);
+            if ($mtime !== null) {
+                return $mtime;
             }
-
-            return $source->lastModified($dirName, $fileName, $extension);
         }
 
         return null;

--- a/src/Halcyon/Datasource/FileDatasource.php
+++ b/src/Halcyon/Datasource/FileDatasource.php
@@ -45,7 +45,12 @@ class FileDatasource extends Datasource implements DatasourceInterface
      */
     public function hasTemplate(string $dirName, string $fileName, string $extension): bool
     {
-        return (bool) $this->selectOne($dirName, $fileName, $extension);
+        try {
+            return $this->files->isFile($this->makeFilePath($dirName, $fileName, $extension));
+        }
+        catch (Exception $ex) {
+            return false;
+        }
     }
 
     /**

--- a/tests/Halcyon/Datasource/AutoDatasourceTest.php
+++ b/tests/Halcyon/Datasource/AutoDatasourceTest.php
@@ -7,6 +7,18 @@ use October\Rain\Filesystem\Filesystem;
 use October\Rain\Halcyon\Datasource\AutoDatasource;
 use October\Rain\Halcyon\Datasource\FileDatasource;
 
+class CountingFilesystem extends Filesystem
+{
+    public array $reads = [];
+
+    public function get($path, $lock = false)
+    {
+        $this->reads[] = $path;
+
+        return parent::get($path, $lock);
+    }
+}
+
 class AutoDatasourceTest extends TestCase
 {
     use SetsUpHalcyonDb;
@@ -115,5 +127,48 @@ class AutoDatasourceTest extends TestCase
 
         $content = $this->autoDatasource->selectOne($this->dirName, $this->fileName, $this->extension);
         $this->assertStringContainsString('Restored content', $content['content']);
+    }
+
+    public function testSelectOneReadsTemplateContentOnce()
+    {
+        $files = new CountingFilesystem;
+        $auto = new AutoDatasource([new FileDatasource($this->themePath, $files)]);
+
+        $result = $auto->selectOne($this->dirName, $this->fileName, $this->extension);
+
+        $this->assertNotNull($result);
+        $this->assertCount(1, $files->reads);
+    }
+
+    public function testSelectOneSkipsDatasourcesWithoutTheTemplate()
+    {
+        $files = new CountingFilesystem;
+        $auto = new AutoDatasource([$this->dbDatasource, new FileDatasource($this->themePath, $files)]);
+
+        $result = $auto->selectOne($this->dirName, $this->fileName, $this->extension);
+
+        $this->assertNotNull($result);
+        $this->assertCount(1, $files->reads);
+        $this->assertNull($auto->selectOne($this->dirName, 'missing', $this->extension));
+    }
+
+    public function testLastModifiedDoesNotReadTemplateContent()
+    {
+        $files = new CountingFilesystem;
+        $auto = new AutoDatasource([new FileDatasource($this->themePath, $files)]);
+
+        $this->assertIsInt($auto->lastModified($this->dirName, $this->fileName, $this->extension));
+        $this->assertNull($auto->lastModified($this->dirName, 'missing', $this->extension));
+        $this->assertCount(0, $files->reads);
+    }
+
+    public function testHasTemplateDoesNotReadTemplateContent()
+    {
+        $files = new CountingFilesystem;
+        $fileDatasource = new FileDatasource($this->themePath, $files);
+
+        $this->assertTrue($fileDatasource->hasTemplate($this->dirName, $this->fileName, $this->extension));
+        $this->assertFalse($fileDatasource->hasTemplate($this->dirName, 'missing', $this->extension));
+        $this->assertCount(0, $files->reads);
     }
 }


### PR DESCRIPTION
**Problem.** `FileDatasource::hasTemplate()` was implemented as `(bool) $this->selectOne()`, so checking whether a template exists read the whole file. `AutoDatasource::selectOne()` and `lastModified()` both called `hasTemplate()` on each datasource before doing their own work. Net effect per template: two full file reads on a cold load, one full file read on every warm load (via `Builder::isCacheBusted()` → `lastModified()`).

**Changes**
- `src/Halcyon/Datasource/FileDatasource.php`: `hasTemplate()` now returns `Filesystem::isFile()` on the resolved path.
- `src/Halcyon/Datasource/AutoDatasource.php`: `selectOne()` returns the first non-null result from the chain; `lastModified()` returns the first non-null mtime. The `hasTemplate()` pre-check in both is gone. Trashed-template check before the chain is unchanged.

**Tests** (`tests/Halcyon/Datasource/AutoDatasourceTest.php`), using a `Filesystem` subclass that records `get()` calls:
- `testSelectOneReadsTemplateContentOnce`: 1 read (develop: 2)
- `testSelectOneSkipsDatasourcesWithoutTheTemplate`: db datasource first, file second, still 1 read
- `testLastModifiedDoesNotReadTemplateContent`: 0 reads (develop: 1)
- `testHasTemplateDoesNotReadTemplateContent`: 0 reads