### PR TITLE
Fix element booting, holder writes, db path names and invalid route expressions

### DIFF
--- a/src/Element/ElementBase.php
+++ b/src/Element/ElementBase.php
@@ -24,6 +24,8 @@ abstract class ElementBase extends Extendable implements Arrayable, ArrayAccess,
      */
     public function __construct($config = [])
     {
+        parent::__construct();
+
         $this->initDefaultValues();
 
         $this->useConfig($config);

--- a/src/Element/ElementHolder.php
+++ b/src/Element/ElementHolder.php
@@ -34,15 +34,22 @@ class ElementHolder extends ElementBase implements IteratorAggregate
      */
     public function get($key, $default = null)
     {
-        if (isset($this->touchedElements[$key])) {
-            return $this->touchedElements[$key];
-        }
-
         if (isset($this->config[$key])) {
             return $this->touchedElements[$key] = $this->config[$key];
         }
 
         return parent::get($key, $default);
+    }
+
+    /**
+     * offsetUnset removes the value and forgets that it was touched
+     * @param  string  $offset
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->touchedElements[$offset]);
+
+        parent::offsetUnset($offset);
     }
 
     /**

--- a/src/Halcyon/Datasource/DbDatasource.php
+++ b/src/Halcyon/Datasource/DbDatasource.php
@@ -448,7 +448,13 @@ class DbDatasource extends Datasource implements DatasourceInterface
      */
     protected function pathToFileName(string $dirName, string $path): string
     {
-        return ltrim(str_replace($dirName, '', $path), '/');
+        $prefix = $dirName . '/';
+
+        if (str_starts_with($path, $prefix)) {
+            $path = substr($path, strlen($prefix));
+        }
+
+        return ltrim($path, '/');
     }
 
     /**

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -286,6 +286,9 @@ class Router
                     }
                 }
                 catch (Exception $ex) {
+                    // An expression that cannot run cannot have matched
+                    $valid = false;
+                    break;
                 }
             }
 

--- a/src/Router/Rule.php
+++ b/src/Router/Rule.php
@@ -219,6 +219,8 @@ class Rule
                         }
                     }
                     catch (Exception $ex) {
+                        // An expression that cannot run cannot have matched
+                        return false;
                     }
                 }
 

--- a/tests/Element/ElementBaseTest.php
+++ b/tests/Element/ElementBaseTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use October\Rain\Element\ElementBase;
+use October\Rain\Element\ElementHolder;
+use October\Rain\Extension\ExtensionBase;
+
+class ElementBaseTestElement extends ElementBase
+{
+}
+
+class ElementBaseTestBehavior extends ExtensionBase
+{
+    public $behaviorMarker = 'applied';
+}
+
+class ElementBaseTestElementWithBehavior extends ElementBase
+{
+    public $implement = [ElementBaseTestBehavior::class];
+}
+
+class ElementBaseTest extends TestCase
+{
+    public function testExtendCallbackIsAppliedOnConstruction()
+    {
+        $seen = null;
+        ElementBaseTestElement::extend(function ($element) use (&$seen) {
+            $seen = $element;
+        });
+
+        $element = new ElementBaseTestElement(['label' => 'Name']);
+
+        $this->assertSame($element, $seen);
+        $this->assertSame('Name', $element->label);
+    }
+
+    public function testImplementedBehaviorIsApplied()
+    {
+        $element = new ElementBaseTestElementWithBehavior;
+
+        $this->assertTrue($element->isClassExtendedWith(ElementBaseTestBehavior::class));
+        $this->assertSame('applied', $element->asExtension(ElementBaseTestBehavior::class)->behaviorMarker);
+    }
+
+    public function testHolderReturnsWrittenValueAfterRead()
+    {
+        $holder = new ElementHolder(['name' => 'old']);
+
+        $this->assertSame('old', $holder->get('name'));
+
+        $holder['name'] = 'new';
+        $this->assertSame('new', $holder->get('name'));
+        $this->assertSame(['name' => 'new'], $holder->getTouchedElements());
+
+        unset($holder['name']);
+        $this->assertNull($holder->get('name'));
+        $this->assertSame([], $holder->getTouchedElements());
+    }
+}

--- a/tests/Halcyon/Datasource/DbDatasourceTest.php
+++ b/tests/Halcyon/Datasource/DbDatasourceTest.php
@@ -117,4 +117,11 @@ class DbDatasourceTest extends TestCase
             $this->assertStringStartsNotWith('-', $item['fileName']);
         }
     }
+
+    public function testPathToFileNameStripsOnlyTheDirectoryPrefix()
+    {
+        $this->assertSame('about.htm', self::callProtectedMethod($this->dbDatasource, 'pathToFileName', ['pages', 'pages/about.htm']));
+        $this->assertSame('pages/about.htm', self::callProtectedMethod($this->dbDatasource, 'pathToFileName', ['pages', 'pages/pages/about.htm']));
+        $this->assertSame('blog/pages.htm', self::callProtectedMethod($this->dbDatasource, 'pathToFileName', ['pages', 'pages/blog/pages.htm']));
+    }
 }

--- a/tests/Router/RouteTest.php
+++ b/tests/Router/RouteTest.php
@@ -379,4 +379,43 @@ class RouteTest extends TestCase
         $result = $router->url('portfolioPage', ['year' => 'default', 'category' => 'noCategory', 'budget' => '200-500']);
         $this->assertEquals('/portfolio/default/noCategory/200-500', $result);
     }
+
+    public function testInvalidParameterExpressionFailsClosed()
+    {
+        $router = new Router;
+        $router->route('bad', '/blog/:id|[unclosed');
+
+        // Laravel converts the preg_match warning into an exception
+        set_error_handler(function ($no, $str, $file, $line) {
+            throw new ErrorException($str, 0, $no, $file, $line);
+        });
+
+        try {
+            $matched = $router->match('/blog/abc');
+        }
+        finally {
+            restore_error_handler();
+        }
+
+        $this->assertFalse($matched);
+    }
+
+    public function testInvalidParameterExpressionFailsClosedOnRule()
+    {
+        $params = [];
+        $rule = (new Router)->reset()->route('bad', '/blog/:id|[unclosed');
+
+        set_error_handler(function ($no, $str, $file, $line) {
+            throw new ErrorException($str, 0, $no, $file, $line);
+        });
+
+        try {
+            $result = $rule->resolveUrl('/blog/abc', $params);
+        }
+        finally {
+            restore_error_handler();
+        }
+
+        $this->assertFalse($result);
+    }
 }


### PR DESCRIPTION
Four unrelated correctness bugs, one commit. Each has a test that fails on `develop`.

**`src/Element/ElementBase.php`** — `__construct()` never called `parent::__construct()`, so `Extendable::extendableConstruct()` did not run: `SomeElement::extend(fn)` callbacks and `$implement` behaviors were ignored for constructed elements, but applied by `__wakeup()` for unserialized ones. Added the parent call. Test: `tests/Element/ElementBaseTest.php` (`testExtendCallbackIsAppliedOnConstruction`, `testImplementedBehaviorIsApplied`).

**`src/Element/ElementHolder.php`** — `get()` returned `$touchedElements[$key]` if present, so a value read once was returned forever even after `$holder['key'] = 'new'` wrote to `$config`. `get()` now reads `$config` and records the touch; added `offsetUnset()` that also clears the touch. Test: `testHolderReturnsWrittenValueAfterRead`.

**`src/Halcyon/Datasource/DbDatasource.php`** — `pathToFileName()` used `str_replace($dirName, '', $path)`, removing every occurrence: `pages/pages/about.htm` → `about.htm`. Now strips only a leading `$dirName/`. Test: `tests/Halcyon/Datasource/DbDatasourceTest.php::testPathToFileNameStripsOnlyTheDirectoryPrefix`.

**`src/Router/Router.php`, `src/Router/Rule.php`** — the `preg_match` on a `:param|regex` segment sat in `try { } catch (Exception) { }` with an empty catch. When the expression is invalid, PHP emits a warning; under Laravel's error handler that is an `ErrorException`, which was swallowed, leaving `$valid = true` (Router) or falling through to `return true` (Rule). A malformed route expression therefore matched any value. Both now treat the exception as a non-match. Tests: `tests/Router/RouteTest.php` (`testInvalidParameterExpressionFailsClosed`, `...OnRule`) install a throwing error handler and assert the URL does not match.