### PR TITLE
Remove Laravel 10 compatibility shims

### DIFF
--- a/src/Database/Dongle.php
+++ b/src/Database/Dongle.php
@@ -39,16 +39,10 @@ class Dongle
 
     /**
      * rawValue converts a raw expression to a string
-     *
-     * @todo Can be refactored if Laravel >= 10
      */
     public function rawValue($sql): string
     {
-        if (interface_exists(\Illuminate\Contracts\Database\Query\Expression::class)) {
-            return $this->db->raw($sql)->getValue($this->db->connection()->getQueryGrammar());
-        }
-
-        return (string) $this->db->raw($sql);
+        return $this->db->raw($sql)->getValue($this->db->connection()->getQueryGrammar());
     }
 
     /**

--- a/src/Events/EventServiceProvider.php
+++ b/src/Events/EventServiceProvider.php
@@ -18,30 +18,13 @@ class EventServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('events', function ($app) {
-            // return (new Dispatcher($app))->setQueueResolver(function () use ($app) {
-            //     return $app->make(QueueFactoryContract::class);
-            // })->setTransactionManagerResolver(function () use ($app) {
-            //     return $app->bound('db.transactions')
-            //         ? $app->make('db.transactions')
-            //         : null;
-            // });
-
-            // The following adds support for Laravel 10.30 when a transaction manager resolver
-            // was included as part of the dispatcher. Detect its presence and set it as needed
-            // @deprecated remove reflection and use code above in v4 (Laravel 11)
-            $dispatcher = (new Dispatcher($app))->setQueueResolver(function () use ($app) {
+            return (new Dispatcher($app))->setQueueResolver(function () use ($app) {
                 return $app->make(QueueFactoryContract::class);
+            })->setTransactionManagerResolver(function () use ($app) {
+                return $app->bound('db.transactions')
+                    ? $app->make('db.transactions')
+                    : null;
             });
-
-            if (method_exists($dispatcher, 'setTransactionManagerResolver')) {
-                $dispatcher->setTransactionManagerResolver(function () use ($app) {
-                    return $app->bound('db.transactions')
-                        ? $app->make('db.transactions')
-                        : null;
-                });
-            }
-
-            return $dispatcher;
         });
 
         $this->app->singleton('events.priority', function ($app) {

--- a/src/Translation/FileLoader.php
+++ b/src/Translation/FileLoader.php
@@ -11,20 +11,6 @@ use Illuminate\Translation\FileLoader as FileLoaderBase;
 class FileLoader extends FileLoaderBase
 {
     /**
-     * @var string path is a single path for the loader.
-     *
-     * @todo Can be removed if Laravel >= 10
-     */
-    protected $path;
-
-    /**
-     * @var array paths are used by default for the loader.
-     *
-     * @todo Can be removed if Laravel >= 10
-     */
-    protected $paths;
-
-    /**
      * @var array jsonLines maps a locale to programmatically-registered JSON
      * translation lines
      */
@@ -35,9 +21,7 @@ class FileLoader extends FileLoaderBase
      */
     protected function loadNamespaceOverrides(array $lines, $locale, $group, $namespace)
     {
-        $paths = (array) $this->path ?: $this->paths;
-
-        return collect($paths)
+        return collect($this->paths)
             ->reduce(function ($output, $path) use ($lines, $locale, $group, $namespace) {
                 $namespace = str_replace('.', '/', $namespace);
                 $file = "{$path}/{$namespace}/{$locale}/{$group}.php";


### PR DESCRIPTION
`composer.json` requires `laravel/framework ^12`. These three guards were written for 9/10 and are always true on 12; verified against `vendor/laravel/framework`.

- `src/Events/EventServiceProvider.php`: removed `method_exists($dispatcher, 'setTransactionManagerResolver')` (added in Laravel 10.30, present in `Illuminate\Events\Dispatcher` on 12). The singleton now uses the chained call that was sitting above it as a comment.
- `src/Translation/FileLoader.php`: removed the redeclared `$path` and `$paths` properties and the `(array) $this->path ?: $this->paths` expression. `Illuminate\Translation\FileLoader` on 12 has only `$paths`, so `$this->path` was always null and the right side always won. `loadNamespaceOverrides()` now iterates `$this->paths` directly.
- `src/Database/Dongle.php`: removed `interface_exists(\Illuminate\Contracts\Database\Query\Expression::class)` from `rawValue()`. The contract ships with 12; the `(string) $this->db->raw($sql)` fallback was unreachable.

No behavior change. Library suite and CMS suite pass unchanged.