### PR TITLE
Drop the doctrine/dbal requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "composer/composer": "^2.0.0",
         "composer/installers": "^1 || ^2",
         "larajax/larajax": "^2.0",
-        "doctrine/dbal": "^2.13.3|^3.1.4",
         "intervention/image": "^3.10",
         "jaybizzle/crawler-detect": "^1.3",
         "linkorb/jsmin-php": "~1.0",


### PR DESCRIPTION
Removes `"doctrine/dbal": "^2.13.3|^3.1.4"` from `composer.json`.

It was added in 461271a4 for the Dongle. Laravel 11 dropped its own DBAL dependency and does column changes natively. Today nothing references it: `grep -ri "doctrine\|dbal"` over `src/`, `init/`, and every CMS module, config and plugin returns nothing, and `composer why doctrine/dbal` lists only two `conflicts` entries (carbon-doctrine-types, symfony/http-foundation), no dependents. The `^2|^3` constraint also blocks DBAL 4 for projects that need it themselves.

Verified by running `composer update doctrine/dbal` (removes dbal, deprecations and event-manager from vendor) and then the full library suite (230 tests) and the CMS suite against this library (618 tests). Both pass.