### PR TITLE
Require PHP 8.2 to match Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "composer/composer": "^2.0.0",
         "composer/installers": "^1 || ^2",
         "larajax/larajax": "^2.0",


### PR DESCRIPTION
`composer.json`: `"php": "^8.1"` → `"php": "^8.2"`.

`laravel/framework ^12` requires PHP 8.2, so 8.1 could never resolve. The CMS already declares `^8.2` and CI runs 8.2 to 8.5. This only makes the stated floor match the effective one.