### PR TITLE
Resolve a unique slug with one query

### DIFF
--- a/src/Database/Traits/Sluggable.php
+++ b/src/Database/Traits/Sluggable.php
@@ -94,16 +94,54 @@ trait Sluggable
      */
     protected function getSluggableUniqueAttributeValue($name, $value)
     {
-        $counter = 1;
         $separator = $this->getSluggableSeparator();
-        $_value = $value;
+        $prefix = $value . $separator;
 
-        while ($this->newSluggableQuery()->where($name, $_value)->count() > 0) {
-            $counter++;
-            $_value = $value . $separator . $counter;
+        // One query for the value and every suffixed variant in use, the lowest
+        // free slot is then picked here rather than asking once per attempt
+        $existing = $this->newSluggableQuery()
+            ->where(function ($query) use ($name, $value, $prefix) {
+                $query->where($name, $value)->orWhere($name, 'like', $prefix . '%');
+            })
+            ->pluck($name)
+            ->all();
+
+        // Compared case insensitively so a case insensitive collation never
+        // produces a value the database considers a duplicate
+        $valueLower = mb_strtolower($value);
+        $prefixLower = mb_strtolower($prefix);
+        $prefixLength = mb_strlen($prefixLower);
+        $baseTaken = false;
+        $countersTaken = [];
+
+        foreach ($existing as $slug) {
+            $slug = mb_strtolower((string) $slug);
+
+            if ($slug === $valueLower) {
+                $baseTaken = true;
+                continue;
+            }
+
+            if (mb_substr($slug, 0, $prefixLength) !== $prefixLower) {
+                continue;
+            }
+
+            $suffix = mb_substr($slug, $prefixLength);
+            if ($suffix !== '' && ctype_digit($suffix)) {
+                $countersTaken[(int) $suffix] = true;
+            }
         }
 
-        return $_value;
+        if (!$baseTaken) {
+            return $value;
+        }
+
+        $counter = 2;
+        while (isset($countersTaken[$counter])) {
+            $counter++;
+        }
+
+        return $prefix . $counter;
     }
 
     /**

--- a/tests/Database/Traits/SluggableTest.php
+++ b/tests/Database/Traits/SluggableTest.php
@@ -48,6 +48,51 @@ class SluggableTest extends TestCase
         $testModel3 = TestModelSluggable::create(['name' => 'test']);
         $this->assertEquals($testModel3->slug, 'test-3');
     }
+    /**
+     * testSlugGenerationFillsTheLowestFreeCounter
+     */
+    public function testSlugGenerationFillsTheLowestFreeCounter()
+    {
+        TestModelSluggable::create(['name' => 'test']);
+        TestModelSluggable::create(['name' => 'test']);
+
+        // Rows written outside the trait, a gap at 3, a non numeric suffix and
+        // an unrelated slug that shares the prefix
+        TestModelSluggable::insert([
+            ['name' => 'test', 'slug' => 'test-4'],
+            ['name' => 'test', 'slug' => 'test-foo'],
+            ['name' => 'test', 'slug' => 'test-10'],
+            ['name' => 'testing', 'slug' => 'testing'],
+        ]);
+
+        $this->assertEquals('test-3', TestModelSluggable::create(['name' => 'test'])->slug);
+        $this->assertEquals('test-5', TestModelSluggable::create(['name' => 'test'])->slug);
+        $this->assertEquals('testing-2', TestModelSluggable::create(['name' => 'testing'])->slug);
+    }
+
+    /**
+     * testSlugGenerationUsesOneQueryRegardlessOfExistingCount
+     */
+    public function testSlugGenerationUsesOneQueryRegardlessOfExistingCount()
+    {
+        $rows = [['name' => 'test', 'slug' => 'test']];
+        for ($i = 2; $i <= 200; $i++) {
+            $rows[] = ['name' => 'test', 'slug' => 'test-' . $i];
+        }
+        TestModelSluggable::insert($rows);
+
+        $connection = TestModelSluggable::resolveConnection();
+        $connection->enableQueryLog();
+
+        $model = TestModelSluggable::create(['name' => 'test']);
+
+        $selects = array_filter($connection->getQueryLog(), function ($query) {
+            return stripos($query['query'], 'select') === 0;
+        });
+
+        $this->assertEquals('test-201', $model->slug);
+        $this->assertCount(1, $selects);
+    }
 }
 
 /**


### PR DESCRIPTION
Fixes octobercms/october-private#776

**Problem.** `Sluggable::getSluggableUniqueAttributeValue()` (`src/Database/Traits/Sluggable.php:95`) looped `while (query->where($name, $candidate)->count() > 0)`, starting from the base value every time. With N existing records on the same base slug each new record issued N+1 `COUNT` queries; the test below measures 201 queries for 200 existing rows on `develop`.

**Change.** One query fetches every existing value equal to the base slug or `LIKE base<separator>%`, via the same `newSluggableQuery()` (so the key exclusion, `withTrashed` and multisite scoping are unchanged). The lowest free counter is then chosen in PHP:
- the base value is returned if no row equals it
- otherwise the first `n >= 2` whose `base-n` is not present, so existing gaps are filled exactly as the loop did
- suffixes that are not purely numeric (`test-foo`) and longer slugs that merely share the prefix (`testing`) are ignored, which also makes any `_`/`%` in the base value harmless since `LIKE` can only over-match

Comparison is case insensitive so a case insensitive collation (MySQL default) cannot end up with a value the database treats as a duplicate.

Portable: only `=`, `LIKE` and `pluck()`, no engine specific functions, which was the blocker raised in the issue.

**Tests** (`tests/Database/Traits/SluggableTest.php`)
- `testSlugGenerationFillsTheLowestFreeCounter`: existing `test`, `test-2`, `test-4`, `test-foo`, `test-10`, `testing` → new records get `test-3`, then `test-5`; `testing` → `testing-2`.
- `testSlugGenerationUsesOneQueryRegardlessOfExistingCount`: 200 existing rows, query log shows exactly 1 select and the result is `test-201`. On `develop` this test fails with 201 selects.