### PR TITLE
Limit combined attachment eager loading to requested fields

### DIFF
--- a/src/Database/Builder.php
+++ b/src/Database/Builder.php
@@ -17,6 +17,19 @@ class Builder extends BuilderModel
     use \October\Rain\Database\Concerns\HasEagerLoadAttachRelation;
 
     /**
+     * eagerLoadRelations eagerly load the relationships for the models, combining
+     * attachments freshly for each set of models.
+     * @param  array  $models
+     * @return array
+     */
+    public function eagerLoadRelations(array $models)
+    {
+        $this->eagerLoadAttachResultCache = [];
+
+        return parent::eagerLoadRelations($models);
+    }
+
+    /**
      * eagerLoadRelation eagerly load the relationship on a set of models, with support
      * for attach relations.
      * @param  array  $models

--- a/src/Database/Concerns/HasEagerLoadAttachRelation.php
+++ b/src/Database/Concerns/HasEagerLoadAttachRelation.php
@@ -15,8 +15,12 @@ trait HasEagerLoadAttachRelation
     protected $eagerLoadAttachResultCache = [];
 
     /**
+     * @var array eagerLoadAttachRelationCache reuses relations inspected for grouping.
+     */
+    protected $eagerLoadAttachRelationCache = [];
+
+    /**
      * eagerLoadAttachRelation eagerly loads an attachment relationship on a set of models.
-     * @param  string  $relatedModel
      * @param  array  $models
      * @param  string  $name
      * @param  \Closure  $constraints
@@ -24,30 +28,36 @@ trait HasEagerLoadAttachRelation
      */
     protected function eagerLoadAttachRelation(array $models, $name, Closure $constraints)
     {
-        // Look up relation type
-        $relationType = $this->getModel()->getRelationType($name);
-        if (!$relationType || !in_array($relationType, ['attachOne', 'attachMany'])) {
+        if (!$this->canCombineEagerLoadAttachRelation($name)) {
             return null;
         }
 
-        // Only vanilla attachments are supported, pass complex lookups back to Laravel
-        $definition = $this->getModel()->getRelationDefinition($name);
-        if (isset($definition['conditions']) || isset($definition['scope'])) {
-            return null;
+        $names = array_values(array_filter(array_keys($this->getEagerLoads()), function ($name) {
+            return !str_contains($name, '.') && $this->canCombineEagerLoadAttachRelation($name);
+        }));
+
+        // A builder can be reused with different models or eager loads. Start a fresh
+        // combined cache at the first eligible attachment in each eager-load pass.
+        if ($name === ($names[0] ?? null)) {
+            $this->eagerLoadAttachResultCache = [];
+            $this->eagerLoadAttachRelationCache = [];
         }
 
-        // Opt-out of the combined eager loading logic
-        if (isset($definition['combineEager']) && $definition['combineEager'] === false) {
-            return null;
-        }
-
-        $relation = $this->getRelation($name);
+        $relation = $this->eagerLoadAttachRelationCache[$name] ??= $this->getRelation($name);
         $relatedModel = get_class($relation->getRelated());
 
-        // Perform a global look up attachment without the 'field' constraint
-        // to produce a combined subset of all possible attachment relations.
+        // Combine only requested attachment fields that use the same related model.
         if (!isset($this->eagerLoadAttachResultCache[$relatedModel])) {
+            $fields = [];
+            foreach ($names as $field) {
+                $fieldRelation = $this->eagerLoadAttachRelationCache[$field] ??= $this->getRelation($field);
+                if (get_class($fieldRelation->getRelated()) === $relatedModel) {
+                    $fields[] = $field;
+                }
+            }
+
             $relation->addCommonEagerConstraints($models);
+            $relation->whereIn('field', $fields);
 
             // Note this takes first constraint only. If it becomes a problem one solution
             // could be to compare the md5 of toSql() to ensure uniqueness. The workaround
@@ -64,5 +74,22 @@ trait HasEagerLoadAttachRelation
             $results->where('field', $name)->values(),
             $name
         );
+    }
+
+    /**
+     * canCombineEagerLoadAttachRelation checks whether an attachment can share a query.
+     * Complex lookups and explicit opt-outs use Laravel's normal eager loading path.
+     */
+    protected function canCombineEagerLoadAttachRelation(string $name): bool
+    {
+        if (!in_array($this->getModel()->getRelationType($name), ['attachOne', 'attachMany'])) {
+            return false;
+        }
+
+        $definition = $this->getModel()->getRelationDefinition($name);
+
+        return !isset($definition['conditions'])
+            && !isset($definition['scope'])
+            && ($definition['combineEager'] ?? true) !== false;
     }
 }

--- a/src/Database/Concerns/HasEagerLoadAttachRelation.php
+++ b/src/Database/Concerns/HasEagerLoadAttachRelation.php
@@ -15,11 +15,6 @@ trait HasEagerLoadAttachRelation
     protected $eagerLoadAttachResultCache = [];
 
     /**
-     * @var array eagerLoadAttachRelationCache reuses relations inspected for grouping.
-     */
-    protected $eagerLoadAttachRelationCache = [];
-
-    /**
      * eagerLoadAttachRelation eagerly loads an attachment relationship on a set of models.
      * @param  array  $models
      * @param  string  $name
@@ -32,32 +27,20 @@ trait HasEagerLoadAttachRelation
             return null;
         }
 
-        $names = array_values(array_filter(array_keys($this->getEagerLoads()), function ($name) {
-            return !str_contains($name, '.') && $this->canCombineEagerLoadAttachRelation($name);
-        }));
+        $relation = $this->getRelation($name);
+        $relatedModel = $this->getAttachRelatedClass($name);
 
-        // A builder can be reused with different models or eager loads. Start a fresh
-        // combined cache at the first eligible attachment in each eager-load pass.
-        if ($name === ($names[0] ?? null)) {
-            $this->eagerLoadAttachResultCache = [];
-            $this->eagerLoadAttachRelationCache = [];
-        }
-
-        $relation = $this->eagerLoadAttachRelationCache[$name] ??= $this->getRelation($name);
-        $relatedModel = get_class($relation->getRelated());
-
-        // Combine only requested attachment fields that use the same related model.
+        // Combine the requested attachments that share this related model in one query,
+        // constrained to their field names so unrequested attachments are not hydrated.
         if (!isset($this->eagerLoadAttachResultCache[$relatedModel])) {
-            $fields = [];
-            foreach ($names as $field) {
-                $fieldRelation = $this->eagerLoadAttachRelationCache[$field] ??= $this->getRelation($field);
-                if (get_class($fieldRelation->getRelated()) === $relatedModel) {
-                    $fields[] = $field;
-                }
-            }
+            $fields = array_filter(array_keys($this->getEagerLoads()), function ($field) use ($relatedModel) {
+                return !str_contains($field, '.')
+                    && $this->canCombineEagerLoadAttachRelation($field)
+                    && $this->getAttachRelatedClass($field) === $relatedModel;
+            });
 
             $relation->addCommonEagerConstraints($models);
-            $relation->whereIn('field', $fields);
+            $relation->whereIn('field', array_values($fields));
 
             // Note this takes first constraint only. If it becomes a problem one solution
             // could be to compare the md5 of toSql() to ensure uniqueness. The workaround
@@ -91,5 +74,13 @@ trait HasEagerLoadAttachRelation
         return !isset($definition['conditions'])
             && !isset($definition['scope'])
             && ($definition['combineEager'] ?? true) !== false;
+    }
+
+    /**
+     * getAttachRelatedClass returns the related model class from an attachment definition.
+     */
+    protected function getAttachRelatedClass(string $name): string
+    {
+        return $this->getModel()->getRelationDefinition($name)[0];
     }
 }

--- a/tests/Database/AttachmentEagerLoadingTest.php
+++ b/tests/Database/AttachmentEagerLoadingTest.php
@@ -1,0 +1,301 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+use October\Rain\Database\Attach\File;
+use October\Rain\Database\Model;
+
+class AttachmentEagerLoadingTest extends TestCase
+{
+    protected $connection;
+
+    protected $savedResolver;
+
+    protected $savedDispatcher;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->savedResolver = EloquentModel::getConnectionResolver();
+        $this->savedDispatcher = EloquentModel::getEventDispatcher();
+
+        $capsule = new Capsule;
+        $capsule->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+        $capsule->bootEloquent();
+        EloquentModel::unsetEventDispatcher();
+        $this->connection = $capsule->getConnection();
+
+        $schema = $this->connection->getSchemaBuilder();
+        $schema->create('attachment_owners', function ($table) {
+            $table->increments('id');
+        });
+        $schema->create('attachment_files', function ($table) {
+            $table->increments('id');
+            $table->unsignedInteger('attachment_id');
+            $table->string('attachment_type');
+            $table->string('field');
+            $table->integer('sort_order')->default(0);
+            $table->boolean('is_public')->default(true);
+        });
+        $this->connection->enableQueryLog();
+        AttachmentEagerLoadingFile::$hydrated = [];
+        AttachmentEagerLoadingOwner::$relationsCreated = [];
+    }
+
+    public function tearDown(): void
+    {
+        if ($this->savedResolver) {
+            EloquentModel::setConnectionResolver($this->savedResolver);
+        }
+        else {
+            EloquentModel::unsetConnectionResolver();
+        }
+
+        if ($this->savedDispatcher) {
+            EloquentModel::setEventDispatcher($this->savedDispatcher);
+        }
+        else {
+            EloquentModel::unsetEventDispatcher();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testCoverDoesNotHydrateUnrequestedGallery()
+    {
+        $this->seedOwner(1, 100);
+        $this->connection->flushQueryLog();
+
+        $owner = AttachmentEagerLoadingOwner::with('cover')->first();
+
+        $this->assertSame('cover', $owner->cover->field);
+        $this->assertFalse($owner->relationLoaded('gallery'));
+        $this->assertCount(1, $this->attachmentQueries());
+        $this->assertSame(['cover'], AttachmentEagerLoadingFile::$hydrated);
+    }
+
+    public function testCompatibleFieldsShareOneQueryAndMatchMultipleOwners()
+    {
+        $this->seedOwner(1, 2);
+        $this->seedOwner(2, 3);
+        $this->connection->table('attachment_owners')->insert(['id' => 3]);
+        $this->connection->flushQueryLog();
+
+        $owners = AttachmentEagerLoadingOwner::with(['cover', 'gallery'])->orderBy('id')->get();
+
+        $this->assertCount(1, $this->attachmentQueries());
+        $this->assertCount(7, AttachmentEagerLoadingFile::$hydrated);
+        foreach ([0 => 2, 1 => 3] as $index => $count) {
+            $this->assertSame($owners[$index]->id, $owners[$index]->cover->attachment_id);
+            $this->assertCount($count, $owners[$index]->gallery);
+            $this->assertSame([$owners[$index]->id], $owners[$index]->gallery->pluck('attachment_id')->unique()->values()->all());
+        }
+        $this->assertNull($owners[2]->cover);
+        $this->assertCount(0, $owners[2]->gallery);
+    }
+
+    public function testDifferentFileClassesUseSeparateQueriesAndFieldSets()
+    {
+        $this->seedOwner(1, 2);
+        $this->seedFile(1, 'document');
+        $this->connection->flushQueryLog();
+
+        $owner = AttachmentEagerLoadingOwner::with(['cover', 'document'])->first();
+
+        $this->assertInstanceOf(AttachmentEagerLoadingFile::class, $owner->cover);
+        $this->assertInstanceOf(AttachmentEagerLoadingDocument::class, $owner->document);
+        $this->assertCount(2, $this->attachmentQueries());
+        $this->assertSame(['cover', 'document'], AttachmentEagerLoadingFile::$hydrated);
+    }
+
+    public function testGroupingConstructsEachRequestedRelationOnlyOnce()
+    {
+        $this->seedOwner(1, 2);
+        $this->seedFile(1, 'document');
+
+        AttachmentEagerLoadingOwner::with(['cover', 'gallery', 'document'])->first();
+
+        $this->assertSame(['cover', 'gallery', 'document'], AttachmentEagerLoadingOwner::$relationsCreated);
+    }
+
+    public function testScopedAndOptedOutFieldsUseTheirOwnQueries()
+    {
+        $this->seedOwner(1, 2);
+        foreach (['scoped', 'conditional', 'separate'] as $field) {
+            $this->seedFile(1, $field, true);
+            $this->seedFile(1, $field, false);
+        }
+        $this->connection->flushQueryLog();
+
+        $owner = AttachmentEagerLoadingOwner::with(['cover', 'scoped', 'conditional', 'separate'])->first();
+
+        $this->assertCount(4, $this->attachmentQueries());
+        $this->assertCount(1, $owner->scoped);
+        $this->assertCount(1, $owner->conditional);
+        $this->assertCount(2, $owner->separate);
+        $this->assertSame(['cover', 'scoped', 'conditional', 'separate', 'separate'], AttachmentEagerLoadingFile::$hydrated);
+    }
+
+    public function testNestedEagerLoadsStillLoadTheRelatedOwner()
+    {
+        $this->seedOwner(1, 100);
+        $this->connection->flushQueryLog();
+
+        $owner = AttachmentEagerLoadingOwner::with('cover.attachment')->first();
+
+        $this->assertTrue($owner->cover->relationLoaded('attachment'));
+        $this->assertSame($owner->id, $owner->cover->attachment->id);
+        $this->assertCount(1, $this->attachmentQueries());
+        $this->assertSame(['cover'], AttachmentEagerLoadingFile::$hydrated);
+    }
+
+    public function testNoAttachmentsAreQueriedWithoutEagerLoads()
+    {
+        $this->seedOwner(1, 2);
+        $this->connection->flushQueryLog();
+
+        $owner = AttachmentEagerLoadingOwner::first();
+
+        $this->assertFalse($owner->relationLoaded('cover'));
+        $this->assertCount(0, $this->attachmentQueries());
+        $this->assertSame([], AttachmentEagerLoadingFile::$hydrated);
+    }
+
+    public function testReusedBuilderCanRequestAnotherAttachmentField()
+    {
+        $this->seedOwner(1, 2);
+        $query = AttachmentEagerLoadingOwner::with('cover');
+        $query->get();
+        AttachmentEagerLoadingFile::$hydrated = [];
+        $this->connection->flushQueryLog();
+
+        $owner = $query->with('gallery')->first();
+
+        $this->assertCount(2, $owner->gallery);
+        $this->assertCount(1, $this->attachmentQueries());
+        $this->assertSame(['cover', 'gallery', 'gallery'], AttachmentEagerLoadingFile::$hydrated);
+    }
+
+    public function testReusedBuilderRefreshesAttachmentsForNewOwners()
+    {
+        $this->seedOwner(1, 1);
+        $this->seedOwner(2, 2);
+        $query = AttachmentEagerLoadingOwner::with(['cover', 'gallery'])->orderBy('id')->limit(1);
+        $query->get();
+        AttachmentEagerLoadingFile::$hydrated = [];
+        $this->connection->flushQueryLog();
+
+        $owner = $query->offset(1)->first();
+
+        $this->assertSame(2, $owner->id);
+        $this->assertNotNull($owner->cover);
+        $this->assertSame(2, $owner->cover->attachment_id);
+        $this->assertCount(2, $owner->gallery);
+        $this->assertCount(1, $this->attachmentQueries());
+        $this->assertCount(3, AttachmentEagerLoadingFile::$hydrated);
+    }
+
+    public function testCombinedQueryPreservesTheFirstCustomConstraint()
+    {
+        $this->seedOwner(1, 1);
+        $this->seedFile(1, 'gallery', false);
+        $this->connection->flushQueryLog();
+
+        $owner = AttachmentEagerLoadingOwner::with([
+            'cover' => function ($relation) {
+                $relation->where('is_public', true);
+            },
+            'gallery' => function ($relation) {
+                $relation->where('is_public', false);
+            },
+        ])->first();
+
+        $this->assertNotNull($owner->cover);
+        $this->assertCount(1, $owner->gallery);
+        $this->assertSame(1, $owner->gallery->first()->is_public);
+        $this->assertCount(1, $this->attachmentQueries());
+    }
+
+    protected function seedOwner(int $id, int $galleryCount): void
+    {
+        $this->connection->table('attachment_owners')->insert(['id' => $id]);
+        $this->seedFile($id, 'cover');
+        for ($index = 0; $index < $galleryCount; $index++) {
+            $this->seedFile($id, 'gallery');
+        }
+    }
+
+    protected function seedFile(int $ownerId, string $field, bool $isPublic = true): void
+    {
+        $this->connection->table('attachment_files')->insert([
+            'attachment_id' => $ownerId,
+            'attachment_type' => AttachmentEagerLoadingOwner::class,
+            'field' => $field,
+            'is_public' => $isPublic,
+        ]);
+    }
+
+    protected function attachmentQueries(): array
+    {
+        return array_values(array_filter($this->connection->getQueryLog(), function ($query) {
+            return strpos($query['query'], 'from "attachment_files"') !== false;
+        }));
+    }
+}
+
+class AttachmentEagerLoadingOwner extends Model
+{
+    protected $table = 'attachment_owners';
+
+    public $timestamps = false;
+
+    public static $relationsCreated = [];
+
+    public $attachOne = [
+        'cover' => AttachmentEagerLoadingFile::class,
+        'document' => AttachmentEagerLoadingDocument::class,
+    ];
+
+    public $attachMany = [
+        'gallery' => AttachmentEagerLoadingFile::class,
+        'scoped' => [AttachmentEagerLoadingFile::class, 'scope' => 'visible'],
+        'conditional' => [AttachmentEagerLoadingFile::class, 'conditions' => 'is_public = 1'],
+        'separate' => [AttachmentEagerLoadingFile::class, 'combineEager' => false],
+    ];
+
+    protected function beforeRelation($name, $relation)
+    {
+        static::$relationsCreated[] = $name;
+    }
+}
+
+class AttachmentEagerLoadingFile extends File
+{
+    protected $table = 'attachment_files';
+
+    public $timestamps = false;
+
+    public static $hydrated = [];
+
+    public function newFromBuilder($attributes = [], $connection = null)
+    {
+        $model = parent::newFromBuilder($attributes, $connection);
+        static::$hydrated[] = $model->field;
+
+        return $model;
+    }
+
+    public function scopeVisible($query)
+    {
+        return $query->where('is_public', true);
+    }
+}
+
+class AttachmentEagerLoadingDocument extends AttachmentEagerLoadingFile
+{
+}


### PR DESCRIPTION
Eager-loading one attachment field currently fetches every attachment for the selected owners, then filters the hydrated models by field. An entry with one cover and 100 gallery files therefore hydrates 101 file records for `with('cover')`.

Restrict the combined attachment query to the requested fields that share the same related model, while keeping one query for multiple fields. The combined result cache is reset at the start of each eager-load pass so a reused builder loads the correct owners and fields. Scoped/conditional relations, `combineEager => false`, and first-constraint behavior are preserved.

10 regression tests cover cover-only hydration (101 → 1 file, one attachment query), multiple owners and fields, distinct related classes, opt-outs, nested loads, custom constraints, relation hooks, and reused builders. Full suite on PHP 8.4: 240 tests, 1493 assertions.

Rechecked on 2026-09-18 with PHP 8.4 / SQLite. Seven samples of ten warm cover-only loads (fixture setup excluded): with 100 unrelated gallery files, hydrated files drop from 101 to 1 and median time from 0.618 ms to 0.100 ms; with 1000 gallery files, from 1001 to 1 and 5.740 ms to 0.130 ms. Both versions issue two total queries (owner plus attachments). These are local illustrative timings; work-count tests are the regression gate. Full suite remains 240 tests / 1493 assertions.
